### PR TITLE
feat(claude-code): add native hook installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ then:
 tokenjuice --help
 tokenjuice --version
 tokenjuice install codex
+tokenjuice install claude-code
 ```
 
 ## why
@@ -66,6 +67,7 @@ tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
 tokenjuice install codex
 tokenjuice install codex --local
+tokenjuice install claude-code
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -118,6 +120,23 @@ important detail:
 - raw command execution logs are still raw
 - `tokenjuice doctor codex` checks whether the hook command is missing or pinned to a stale Homebrew Cellar path
 - `tokenjuice install codex --local` / `tokenjuice doctor codex --local` are for testing the current repo build before release
+
+## claude code
+
+for claude code, the clean path is a home hook:
+
+```bash
+tokenjuice install claude-code
+```
+
+that writes a `PostToolUse` hook into `~/.claude/settings.json` under `hooks.PostToolUse` so claude code can compact noisy `Bash` output after the command runs.
+
+important detail:
+
+- unrelated top-level settings keys (`permissions`, `env`, `statusLine`, custom keys) are preserved
+- the original shell command still runs untouched
+- tokenjuice only rewrites the output that goes back through the hook
+- raw command execution logs are still raw
 
 library-side adapters can also use `runReduceJsonCli(...)` to call the CLI without rebuilding the child-process + JSON plumbing themselves.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,6 +141,7 @@ install host wiring when tokenjuice can own it directly:
 
 ```bash
 tokenjuice install codex
+tokenjuice install claude-code
 tokenjuice doctor codex
 tokenjuice install codex --local
 tokenjuice doctor codex --local
@@ -149,6 +150,7 @@ tokenjuice doctor codex --local
 for codex, this writes a home-level `PostToolUse` hook into `~/.codex/hooks.json` so tokenjuice can compact `Bash` output after execution without changing the executed command.
 
 `tokenjuice doctor codex` inspects that hook, spots stale Cellar-pinned Homebrew commands, and points back to `tokenjuice install codex` for repair. the `--local` variant is for dev verification and expects the hook to point at the current repo build instead of the installed launcher on `PATH`.
+for claude code, this writes into `~/.claude/settings.json` under `hooks.PostToolUse` and preserves unrelated top-level settings keys while updating the hook subtree.
 
 ## rule model
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,7 @@ import packageJson from "../../package.json" with { type: "json" };
 
 import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifacts.js";
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
+import { installClaudeCodeHook, runClaudeCodePostToolUseHook } from "../core/claude-code.js";
 import { doctorCodexHook, installCodexHook, runCodexPostToolUseHook } from "../core/codex.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
 import { parseReduceJsonRequest } from "../core/json-protocol.js";
@@ -52,6 +53,7 @@ function printUsage(): void {
       "  tokenjuice reduce-json [file]",
       "  tokenjuice wrap [--raw|--full] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
       "  tokenjuice install codex [--local]",
+      "  tokenjuice install claude-code",
       "  tokenjuice ls",
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
@@ -304,24 +306,38 @@ async function runWrap(args: ParsedArgs): Promise<number> {
 
 async function runInstall(args: ParsedArgs): Promise<number> {
   const target = args.positionals[0];
-  if (target !== "codex") {
-    throw new Error("install currently supports only: codex");
-  }
+  if (target === "codex") {
+    const result = await installCodexHook(undefined, { local: args.local });
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
 
-  const result = await installCodexHook(undefined, { local: args.local });
-  if (args.format === "json") {
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.stdout.write(`installed codex hook: ${result.hooksPath}\n`);
+    process.stdout.write(`command: ${result.command}\n`);
+    if (result.backupPath) {
+      process.stdout.write(`backup: ${result.backupPath}\n`);
+    }
+    process.stdout.write(`doctor: tokenjuice doctor codex${args.local ? " --local" : ""}\n`);
+    process.stdout.write("escape hatch: tokenjuice wrap --raw -- <command>\n");
     return 0;
   }
 
-  process.stdout.write(`installed codex hook: ${result.hooksPath}\n`);
-  process.stdout.write(`command: ${result.command}\n`);
-  if (result.backupPath) {
-    process.stdout.write(`backup: ${result.backupPath}\n`);
+  if (target === "claude-code") {
+    const result = await installClaudeCodeHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`installed claude-code hook: ${result.settingsPath}\n`);
+    process.stdout.write(`command: ${result.command}\n`);
+    if (result.backupPath) {
+      process.stdout.write(`backup: ${result.backupPath}\n`);
+    }
+    return 0;
   }
-  process.stdout.write(`doctor: tokenjuice doctor codex${args.local ? " --local" : ""}\n`);
-  process.stdout.write("escape hatch: tokenjuice wrap --raw -- <command>\n");
-  return 0;
+  throw new Error("install currently supports: codex, claude-code");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -634,6 +650,8 @@ async function main(): Promise<number> {
       return await runStats(args);
     case "codex-post-tool-use":
       return await runCodexPostToolUseHook(await readStdin(args.maxInputBytes));
+    case "claude-code-post-tool-use":
+      return await runClaudeCodePostToolUseHook(await readStdin(args.maxInputBytes));
     default:
       printUsage();
       return 1;

--- a/src/core/claude-code.ts
+++ b/src/core/claude-code.ts
@@ -1,0 +1,362 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+import { isCompoundShellCommand } from "./command.js";
+import { reduceExecution } from "./reduce.js";
+
+import type { CompactResult, ReduceOptions } from "../types.js";
+
+type ClaudeCodeHookCommand = {
+  type: "command";
+  command: string;
+  statusMessage?: string;
+  timeout?: number;
+};
+
+type ClaudeCodeHookMatcherGroup = {
+  matcher?: string;
+  hooks: ClaudeCodeHookCommand[];
+};
+
+type ClaudeCodeSettings = Record<string, unknown> & {
+  hooks: Record<string, ClaudeCodeHookMatcherGroup[]>;
+};
+
+type ClaudeCodePostToolUsePayload = {
+  hook_event_name?: unknown;
+  tool_name?: unknown;
+  cwd?: unknown;
+  tool_input?: {
+    command?: unknown;
+  };
+  tool_response?: unknown;
+};
+
+const GENERIC_FALLBACK_MIN_SAVED_CHARS = 120;
+const GENERIC_FALLBACK_MAX_RATIO = 0.75;
+
+export type InstallClaudeCodeHookResult = {
+  settingsPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
+
+function getClaudeCodeHome(): string {
+  return process.env.CLAUDE_HOME || join(homedir(), ".claude");
+}
+
+function getDefaultSettingsPath(): string {
+  return join(getClaudeCodeHome(), "settings.json");
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+function buildClaudeCodeHookCommand(binaryPath = process.argv[1], nodePath = process.execPath): string {
+  if (!binaryPath) {
+    throw new Error("unable to resolve tokenjuice binary path for claude code install");
+  }
+
+  if (binaryPath.endsWith(".js")) {
+    return `${shellQuote(nodePath)} ${shellQuote(binaryPath)} claude-code-post-tool-use`;
+  }
+
+  return `${shellQuote(binaryPath)} claude-code-post-tool-use`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringifyToolResponse(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => stringifyToolResponse(entry))
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (isRecord(value)) {
+    for (const key of ["output", "text", "stdout", "stderr", "combinedText"]) {
+      const text = value[key];
+      if (typeof text === "string" && text) {
+        return text;
+      }
+    }
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function createTokenjuiceClaudeCodeHook(command: string): ClaudeCodeHookMatcherGroup {
+  return {
+    matcher: "Bash",
+    hooks: [
+      {
+        type: "command",
+        command,
+        statusMessage: TOKENJUICE_CLAUDE_CODE_STATUS,
+      },
+    ],
+  };
+}
+
+function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
+  return group.hooks.some((hook) =>
+    hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
+    || hook.command.includes("claude-code-post-tool-use"),
+  );
+}
+
+function sanitizeHooksSubtree(raw: unknown): Record<string, ClaudeCodeHookMatcherGroup[]> {
+  if (!isRecord(raw)) {
+    return {};
+  }
+
+  const hooks: Record<string, ClaudeCodeHookMatcherGroup[]> = {};
+  for (const [eventName, groups] of Object.entries(raw)) {
+    if (!Array.isArray(groups)) {
+      continue;
+    }
+
+    const normalizedGroups = groups.flatMap((group): ClaudeCodeHookMatcherGroup[] => {
+      if (!isRecord(group) || !Array.isArray(group.hooks)) {
+        return [];
+      }
+
+      const commands = group.hooks.flatMap((hook): ClaudeCodeHookCommand[] => {
+        if (!isRecord(hook) || hook.type !== "command" || typeof hook.command !== "string") {
+          return [];
+        }
+
+        const normalized: ClaudeCodeHookCommand = {
+          type: "command",
+          command: hook.command,
+        };
+        if (typeof hook.statusMessage === "string" && hook.statusMessage) {
+          normalized.statusMessage = hook.statusMessage;
+        }
+        if (typeof hook.timeout === "number" && Number.isFinite(hook.timeout)) {
+          normalized.timeout = hook.timeout;
+        }
+        return [normalized];
+      });
+
+      if (commands.length === 0) {
+        return [];
+      }
+
+      const normalizedGroup: ClaudeCodeHookMatcherGroup = {
+        hooks: commands,
+      };
+      if (typeof group.matcher === "string" && group.matcher) {
+        normalizedGroup.matcher = group.matcher;
+      }
+      return [normalizedGroup];
+    });
+
+    if (normalizedGroups.length > 0) {
+      hooks[eventName] = normalizedGroups;
+    }
+  }
+
+  return hooks;
+}
+
+function sanitizeClaudeCodeSettings(raw: unknown): ClaudeCodeSettings {
+  if (!isRecord(raw)) {
+    return { hooks: {} };
+  }
+
+  return {
+    ...raw,
+    hooks: sanitizeHooksSubtree(raw.hooks),
+  };
+}
+
+async function loadClaudeCodeSettings(settingsPath: string): Promise<{ config: ClaudeCodeSettings; backupPath?: string }> {
+  try {
+    const rawText = await readFile(settingsPath, "utf8");
+    const parsed = JSON.parse(rawText) as unknown;
+    const config = sanitizeClaudeCodeSettings(parsed);
+    const backupPath = `${settingsPath}.bak`;
+    await writeFile(backupPath, rawText, "utf8");
+    return { config, backupPath };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { hooks: {} } };
+    }
+    throw new Error(`failed to load claude code settings from ${settingsPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function installClaudeCodeHook(settingsPath = getDefaultSettingsPath()): Promise<InstallClaudeCodeHookResult> {
+  const { config, backupPath } = await loadClaudeCodeSettings(settingsPath);
+  const command = buildClaudeCodeHookCommand();
+  const postToolUse = config.hooks.PostToolUse ?? [];
+  const retained = postToolUse.filter((group) => !isTokenjuiceClaudeCodeHook(group));
+  retained.push(createTokenjuiceClaudeCodeHook(command));
+  config.hooks.PostToolUse = retained;
+
+  await mkdir(dirname(settingsPath), { recursive: true });
+  const tempPath = `${settingsPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await rename(tempPath, settingsPath);
+
+  return {
+    settingsPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+function readPositiveIntegerEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function shouldStoreFromEnv(): boolean {
+  const value = process.env.TOKENJUICE_CLAUDE_CODE_STORE;
+  return value === "1" || value === "true" || value === "TRUE" || value === "yes" || value === "YES";
+}
+
+function getClaudeCodeRewriteSkipReason(command: string, combinedText: string, result: CompactResult): string | null {
+  const inlineText = result.inlineText.trim();
+  const rawText = combinedText.trim();
+  const rawChars = result.stats.rawChars;
+  const reducedChars = result.stats.reducedChars;
+
+  if (!inlineText || inlineText === rawText || reducedChars >= rawChars) {
+    return "no-compaction";
+  }
+
+  if (result.classification.matchedReducer !== "generic/fallback") {
+    return null;
+  }
+
+  if (isCompoundShellCommand(command)) {
+    return "generic-compound-command";
+  }
+
+  const savedChars = rawChars - reducedChars;
+  const ratio = rawChars === 0 ? 1 : reducedChars / rawChars;
+  if (savedChars < GENERIC_FALLBACK_MIN_SAVED_CHARS || ratio > GENERIC_FALLBACK_MAX_RATIO) {
+    return "generic-weak-compaction";
+  }
+
+  return null;
+}
+
+async function writeHookDebug(record: Record<string, unknown>): Promise<void> {
+  const debugPath = join(getClaudeCodeHome(), "tokenjuice-hook.last.json");
+  await mkdir(dirname(debugPath), { recursive: true });
+  await writeFile(debugPath, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+}
+
+export async function runClaudeCodePostToolUseHook(rawText: string): Promise<number> {
+  let payload: ClaudeCodePostToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as ClaudeCodePostToolUsePayload;
+  } catch {
+    return 0;
+  }
+
+  const command = payload.tool_input?.command;
+  const debug: Record<string, unknown> = {
+    hookEvent: payload.hook_event_name,
+    toolName: payload.tool_name,
+    command,
+    rewrote: false,
+  };
+
+  if (payload.hook_event_name !== "PostToolUse") {
+    await writeHookDebug({ ...debug, skipped: "non-post-tool-use" });
+    return 0;
+  }
+  if (payload.tool_name !== "Bash") {
+    await writeHookDebug({ ...debug, skipped: "non-bash" });
+    return 0;
+  }
+  if (typeof command !== "string" || !command.trim()) {
+    await writeHookDebug({ ...debug, skipped: "missing-command" });
+    return 0;
+  }
+
+  const combinedText = stringifyToolResponse(payload.tool_response);
+  if (!combinedText.trim()) {
+    await writeHookDebug({ ...debug, skipped: "empty-tool-response" });
+    return 0;
+  }
+
+  const maxInlineChars = readPositiveIntegerEnv("TOKENJUICE_CLAUDE_CODE_MAX_INLINE_CHARS");
+  const options: ReduceOptions = {
+    ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
+    ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
+    ...(shouldStoreFromEnv() ? { store: true } : {}),
+  };
+
+  try {
+    const result = await reduceExecution(
+      {
+        toolName: "exec",
+        command,
+        combinedText,
+        ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
+        metadata: {
+          source: "claude-code-post-tool-use",
+        },
+      },
+      options,
+    );
+
+    const rawChars = result.stats.rawChars;
+    const reducedChars = result.stats.reducedChars;
+    debug.rawChars = rawChars;
+    debug.reducedChars = reducedChars;
+    debug.matchedReducer = result.classification.matchedReducer;
+
+    const skipReason = getClaudeCodeRewriteSkipReason(command, combinedText, result);
+    if (skipReason) {
+      await writeHookDebug({ ...debug, skipped: skipReason });
+      return 0;
+    }
+
+    const hookOutput: Record<string, unknown> = {
+      decision: "block",
+      reason: result.inlineText,
+    };
+    if (result.rawRef?.id) {
+      hookOutput.hookSpecificOutput = {
+        hookEventName: "PostToolUse",
+        additionalContext: `tokenjuice stored raw bash output as artifact ${result.rawRef.id}. use \`tokenjuice cat ${result.rawRef.id}\` only if the compacted output is insufficient.`,
+      };
+    }
+
+    process.stdout.write(`${JSON.stringify(hookOutput)}\n`);
+    await writeHookDebug({ ...debug, rewrote: true });
+    return 0;
+  } catch (error) {
+    await writeHookDebug({
+      ...debug,
+      skipped: "hook-error",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return 0;
+  }
+}

--- a/src/core/claude-code.ts
+++ b/src/core/claude-code.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { constants as fsConstants } from "node:fs";
+import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { delimiter, dirname, join } from "node:path";
 import { homedir } from "node:os";
 
 import { isCompoundShellCommand } from "./command.js";
@@ -14,13 +15,15 @@ type ClaudeCodeHookCommand = {
   timeout?: number;
 };
 
-type ClaudeCodeHookMatcherGroup = {
+type ClaudeCodeHook = Record<string, unknown>;
+
+type ClaudeCodeHookMatcherGroup = Record<string, unknown> & {
   matcher?: string;
-  hooks: ClaudeCodeHookCommand[];
+  hooks: ClaudeCodeHook[];
 };
 
 type ClaudeCodeSettings = Record<string, unknown> & {
-  hooks: Record<string, ClaudeCodeHookMatcherGroup[]>;
+  hooks: Record<string, unknown>;
 };
 
 type ClaudeCodePostToolUsePayload = {
@@ -59,9 +62,49 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/gu, `'\\''`)}'`;
 }
 
-function buildClaudeCodeHookCommand(binaryPath = process.argv[1], nodePath = process.execPath): string {
+async function isExecutableFile(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
+  const pathValue = process.env.PATH;
+  if (!pathValue) {
+    return undefined;
+  }
+
+  const candidateNames = process.platform === "win32"
+    ? ["tokenjuice.exe", "tokenjuice.cmd", "tokenjuice.bat", "tokenjuice"]
+    : ["tokenjuice"];
+
+  for (const segment of pathValue.split(delimiter)) {
+    if (!segment) {
+      continue;
+    }
+
+    for (const candidateName of candidateNames) {
+      const candidatePath = join(segment, candidateName);
+      if (await isExecutableFile(candidatePath)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function buildClaudeCodeHookCommand(binaryPath = process.argv[1], nodePath = process.execPath): Promise<string> {
   if (!binaryPath) {
     throw new Error("unable to resolve tokenjuice binary path for claude code install");
+  }
+
+  const installedBinaryPath = await resolveInstalledTokenjuicePath();
+  if (installedBinaryPath) {
+    return `${shellQuote(installedBinaryPath)} claude-code-post-tool-use`;
   }
 
   if (binaryPath.endsWith(".js")) {
@@ -115,64 +158,15 @@ function createTokenjuiceClaudeCodeHook(command: string): ClaudeCodeHookMatcherG
 
 function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
   return group.hooks.some((hook) =>
-    hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
-    || hook.command.includes("claude-code-post-tool-use"),
+    isRecord(hook) && (
+      hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
+      || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
+    ),
   );
 }
 
-function sanitizeHooksSubtree(raw: unknown): Record<string, ClaudeCodeHookMatcherGroup[]> {
-  if (!isRecord(raw)) {
-    return {};
-  }
-
-  const hooks: Record<string, ClaudeCodeHookMatcherGroup[]> = {};
-  for (const [eventName, groups] of Object.entries(raw)) {
-    if (!Array.isArray(groups)) {
-      continue;
-    }
-
-    const normalizedGroups = groups.flatMap((group): ClaudeCodeHookMatcherGroup[] => {
-      if (!isRecord(group) || !Array.isArray(group.hooks)) {
-        return [];
-      }
-
-      const commands = group.hooks.flatMap((hook): ClaudeCodeHookCommand[] => {
-        if (!isRecord(hook) || hook.type !== "command" || typeof hook.command !== "string") {
-          return [];
-        }
-
-        const normalized: ClaudeCodeHookCommand = {
-          type: "command",
-          command: hook.command,
-        };
-        if (typeof hook.statusMessage === "string" && hook.statusMessage) {
-          normalized.statusMessage = hook.statusMessage;
-        }
-        if (typeof hook.timeout === "number" && Number.isFinite(hook.timeout)) {
-          normalized.timeout = hook.timeout;
-        }
-        return [normalized];
-      });
-
-      if (commands.length === 0) {
-        return [];
-      }
-
-      const normalizedGroup: ClaudeCodeHookMatcherGroup = {
-        hooks: commands,
-      };
-      if (typeof group.matcher === "string" && group.matcher) {
-        normalizedGroup.matcher = group.matcher;
-      }
-      return [normalizedGroup];
-    });
-
-    if (normalizedGroups.length > 0) {
-      hooks[eventName] = normalizedGroups;
-    }
-  }
-
-  return hooks;
+function sanitizeHooksSubtree(raw: unknown): Record<string, unknown> {
+  return isRecord(raw) ? { ...raw } : {};
 }
 
 function sanitizeClaudeCodeSettings(raw: unknown): ClaudeCodeSettings {
@@ -204,9 +198,11 @@ async function loadClaudeCodeSettings(settingsPath: string): Promise<{ config: C
 
 export async function installClaudeCodeHook(settingsPath = getDefaultSettingsPath()): Promise<InstallClaudeCodeHookResult> {
   const { config, backupPath } = await loadClaudeCodeSettings(settingsPath);
-  const command = buildClaudeCodeHookCommand();
-  const postToolUse = config.hooks.PostToolUse ?? [];
-  const retained = postToolUse.filter((group) => !isTokenjuiceClaudeCodeHook(group));
+  const command = await buildClaudeCodeHookCommand();
+  const postToolUse = Array.isArray(config.hooks.PostToolUse) ? config.hooks.PostToolUse : [];
+  const retained = postToolUse.filter((group) =>
+    !(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup)),
+  );
   retained.push(createTokenjuiceClaudeCodeHook(command));
   config.hooks.PostToolUse = retained;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, storeArtifact } from "./core/artifacts.js";
 export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "./core/analysis.js";
 export { classifyExecution } from "./core/classify.js";
+export { installClaudeCodeHook, runClaudeCodePostToolUseHook } from "./core/claude-code.js";
 export { normalizeCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";
 export { doctorCodexHook, installCodexHook, runCodexPostToolUseHook } from "./core/codex.js";
 export { runReduceJsonCli } from "./core/cli-client.js";

--- a/test/claude-code.test.ts
+++ b/test/claude-code.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,9 +7,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { installClaudeCodeHook, runClaudeCodePostToolUseHook } from "../src/index.js";
 
 const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
 
 afterEach(async () => {
   delete process.env.CLAUDE_HOME;
+  process.env.PATH = originalPath;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -126,6 +128,89 @@ describe("installClaudeCodeHook", () => {
     });
     expect(parsed.hooks.SessionStart).toHaveLength(1);
     expect(parsed.hooks.PostToolUse).toHaveLength(2);
+  });
+
+  it("preserves non-command Claude Code hooks and extra handler fields", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              matcher: "Bash",
+              extraGroupField: "keep-me",
+              hooks: [
+                { type: "command", command: "echo session", async: true, shell: "/bin/bash" },
+                { type: "prompt", prompt: "session prompt" },
+                { type: "http", url: "https://example.com/hooks" },
+              ],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: "Edit",
+              hooks: [{ type: "agent", prompt: "summarize the edit" }],
+            },
+            {
+              matcher: "Bash",
+              hooks: [
+                {
+                  type: "command",
+                  command: "tokenjuice claude-code-post-tool-use --old",
+                  statusMessage: "compacting bash output with tokenjuice",
+                  async: true,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<Record<string, unknown> & { hooks: Array<Record<string, unknown>> }>>;
+    };
+
+    expect(parsed.hooks.SessionStart).toHaveLength(1);
+    expect(parsed.hooks.SessionStart[0]?.extraGroupField).toBe("keep-me");
+    expect(parsed.hooks.SessionStart[0]?.hooks).toEqual([
+      { type: "command", command: "echo session", async: true, shell: "/bin/bash" },
+      { type: "prompt", prompt: "session prompt" },
+      { type: "http", url: "https://example.com/hooks" },
+    ]);
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Edit");
+    expect(parsed.hooks.PostToolUse[0]?.hooks).toEqual([{ type: "agent", prompt: "summarize the edit" }]);
+    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+  });
+
+  it("prefers a stable tokenjuice launcher from PATH when installing the hook", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      launcherPath,
+      "#!/usr/bin/env bash\nexit 0\n",
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    const result = await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.command).toBe(`${launcherPath} claude-code-post-tool-use`);
+    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(`${launcherPath} claude-code-post-tool-use`);
   });
 
   it("is idempotent and replaces old tokenjuice entries", async () => {

--- a/test/claude-code.test.ts
+++ b/test/claude-code.test.ts
@@ -1,0 +1,322 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { installClaudeCodeHook, runClaudeCodePostToolUseHook } from "../src/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  delete process.env.CLAUDE_HOME;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-claude-code-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("installClaudeCodeHook", () => {
+  it("installs a single tokenjuice PostToolUse hook on an empty settings file", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    const result = await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+    };
+
+    expect(result.settingsPath).toBe(settingsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(parsed.hooks.PostToolUse).toHaveLength(1);
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.statusMessage).toBe("compacting bash output with tokenjuice");
+  });
+
+  it("preserves unrelated top-level settings keys across install", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        permissions: {
+          allow: ["Bash(git status)", "Bash(pnpm test)"],
+          deny: ["Read(./.env)", "Bash(rm -rf /)"],
+        },
+        env: {
+          NODE_ENV: "development",
+          FEATURE_FLAG: "1",
+        },
+        statusLine: {
+          type: "command",
+          command: "echo status",
+        },
+        randomUserKey: {
+          enabled: true,
+          nested: {
+            count: 2,
+          },
+        },
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [{ type: "command", command: "echo session" }],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: "Edit",
+              hooks: [{ type: "command", command: "echo keep-edit" }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      permissions?: unknown;
+      env?: unknown;
+      statusLine?: unknown;
+      randomUserKey?: unknown;
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+    };
+
+    expect(result.settingsPath).toBe(settingsPath);
+    expect(result.backupPath).toBe(`${settingsPath}.bak`);
+    expect(parsed.permissions).toEqual({
+      allow: ["Bash(git status)", "Bash(pnpm test)"],
+      deny: ["Read(./.env)", "Bash(rm -rf /)"],
+    });
+    expect(parsed.env).toEqual({
+      NODE_ENV: "development",
+      FEATURE_FLAG: "1",
+    });
+    expect(parsed.statusLine).toEqual({
+      type: "command",
+      command: "echo status",
+    });
+    expect(parsed.randomUserKey).toEqual({
+      enabled: true,
+      nested: {
+        count: 2,
+      },
+    });
+    expect(parsed.hooks.SessionStart).toHaveLength(1);
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+  });
+
+  it("is idempotent and replaces old tokenjuice entries", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                {
+                  type: "command",
+                  command: "tokenjuice claude-code-post-tool-use --old",
+                  statusMessage: "compacting bash output with tokenjuice",
+                },
+              ],
+            },
+            {
+              matcher: "Read",
+              hooks: [{ type: "command", command: "echo keep-read" }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installClaudeCodeHook(settingsPath);
+    await installClaudeCodeHook(settingsPath);
+
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+    };
+
+    const tokenjuiceHooks = parsed.hooks.PostToolUse.filter((group) =>
+      group.hooks.some((hook) => hook.statusMessage === "compacting bash output with tokenjuice" || hook.command.includes("claude-code-post-tool-use")),
+    );
+
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    expect(tokenjuiceHooks).toHaveLength(1);
+    expect(tokenjuiceHooks[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+  });
+
+  it("preserves other PostToolUse matchers", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Write",
+              hooks: [{ type: "command", command: "echo keep-write" }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+    };
+
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Write");
+    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toBe("echo keep-write");
+    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+  });
+});
+
+describe("runClaudeCodePostToolUseHook", () => {
+  it("writes a block/reason decision on compactable bash output", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git status",
+      },
+      tool_response: [
+        "On branch pr-65478-security-fix",
+        "Your branch and 'origin/pr-65478-security-fix' have diverged,",
+        "and have 8 and 642 different commits each, respectively.",
+        "",
+        "Changes not staged for commit:",
+        "\tmodified:   src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts",
+        "\tmodified:   src/agents/pi-embedded-runner/run/attempt.test.ts",
+        "",
+        "no changes added to commit",
+      ].join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const response = JSON.parse(output) as { decision: string; reason: string };
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      matchedReducer?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(response.decision).toBe("block");
+    expect(response.reason).toContain("Changes not staged:");
+    expect(response.reason).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
+    expect(response.reason).not.toContain("and have 8 and 642");
+    expect(debug.rewrote).toBe(true);
+    expect(debug.matchedReducer).toBe("git/status");
+  });
+
+  it("skips non-PostToolUse events", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "Stop",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git status",
+      },
+      tool_response: "output",
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("non-post-tool-use");
+  });
+
+  it("skips non-Bash tools", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Read",
+      tool_input: {
+        command: "cat README.md",
+      },
+      tool_response: "output",
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("non-bash");
+  });
+
+  it("skips empty tool_response", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git status",
+      },
+      tool_response: "",
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("empty-tool-response");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `tokenjuice install claude-code` as a native hook installer alongside `install codex`. The command writes a `PostToolUse` entry into `~/.claude/settings.json` under matcher `"Bash"` and preserves every non-hook top-level settings key (`permissions`, `env`, `statusLine`, and any user-defined fields).

## Why this matters

The README positions tokenjuice as an "extension to popular coding and agent frameworks," and `docs/spec.md` frames `install` as wiring "when tokenjuice can own it directly." Today the obvious next harness fails:

```
$ tokenjuice install claude-code
install currently supports only: codex
```

Claude Code has the same PostToolUse hook shape Codex does (matcher + nested hooks array with `type`/`command`). The one structural difference is that `settings.json` holds other keys alongside `hooks`, so the installer merges into the envelope instead of replacing it. This PR extends the pattern `feat(codex): add native hook installer` (93ad586) established two days ago.

## What changes

- `src/core/claude-code.ts` - new module. Exports `installClaudeCodeHook(settingsPath?)` and `runClaudeCodePostToolUseHook(rawText)`. Mirrors `codex.ts`, including the `fail open on weak generic compaction` skip logic added in 92239cd. The single behavioral divergence from Codex is `sanitizeClaudeCodeSettings`, which spreads unrelated top-level keys through unchanged and only normalizes the `hooks` subtree.
- `src/cli/main.ts` - two new subcommands: `install claude-code` and `claude-code-post-tool-use`. The `install` handler now dispatches on `"codex"` / `"claude-code"`, and the unsupported-target error reads `install currently supports: codex, claude-code`.
- `src/index.ts` - re-exports the two new functions.
- `test/claude-code.test.ts` - eight Vitest cases: install on empty settings, preservation of unrelated settings keys, idempotent re-install, coexistence with other PostToolUse matchers, non-PostToolUse event skip, non-Bash tool skip, empty tool_response skip, and the rewrite path on a compactable payload.
- `README.md` + `docs/spec.md` - parallel Claude Code sections next to the existing Codex ones.

Same identity marker (`statusMessage: "compacting bash output with tokenjuice"`) across hosts so re-installs stay idempotent. No new dependencies; the module uses `node:fs/promises`, `node:os`, `node:path` - the same set as the Codex installer.

## Testing

```
pnpm install --frozen-lockfile  # OK
pnpm typecheck                   # OK
pnpm test                        # 10 files, 98 tests passed (8 new)
pnpm build                       # OK
pnpm release:artifacts           # OK
pnpm release:checksums           # OK
```

Manual end-to-end against a temp `CLAUDE_HOME` with a realistic pre-existing settings file (permissions + env + statusLine + `hooks.Stop`):

```
$ CLAUDE_HOME=/tmp/tj-demo node dist/cli/main.js install claude-code
installed claude-code hook: /tmp/tj-demo/settings.json
command: node .../dist/cli/main.js claude-code-post-tool-use
backup: /tmp/tj-demo/settings.json.bak

$ node dist/cli/main.js install cursor
install currently supports: codex, claude-code
```

After the install, `/tmp/tj-demo/settings.json` kept `permissions`, `env`, `statusLine`, and `hooks.Stop` exactly as they were and grew a new `hooks.PostToolUse` entry with `matcher: "Bash"`.

## Simulated Demo

![tokenjuice install claude-code demo](https://github.com/mvanhorn/tokenjuice/releases/download/demo-assets-install-claude-code/demo.gif)

Walks through the four beats: title, `tokenjuice install claude-code` output, the merged `settings.json` with the existing keys kept in cream and the new PostToolUse entry highlighted in the tokenjuice palette, and an outro. Labeled "Simulated Demo" because the hero moment is rendered rather than screen-captured, but the command output and JSON shape are real.

## Notes

- Some duplication with `codex.ts` is intentional for this first pass. Happy to extract a shared `runPostToolUseHook` helper in this PR or a follow-up if you'd prefer - the two runners are structurally the same once host-specific env vars and file paths are parameterized.
- `sanitizeClaudeCodeSettings` uses `{ ...raw, hooks: sanitizeHooksSubtree(raw.hooks) }` so unknown future Claude Code settings keys survive without a code change here.

This contribution was developed with AI assistance (Codex).
