### PR TITLE
fix(ci): finalize v0.3.3 release automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,8 @@
-name-template: "tokenjuice $NEXT_TAG"
-tag-template: "$NEXT_TAG"
+name-template: "tokenjuice v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
+no-changes-template: "- No merged pull requests in this release."
 
 categories:
   - title: "Features"
@@ -115,7 +116,7 @@ autolabeler:
       - '/.*/'
 
 template: |
-  ## tokenjuice $NEXT_TAG
+  ## tokenjuice v$RESOLVED_VERSION
 
   lean output compaction for terminal-heavy agent workflows.
 

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,9 +1,6 @@
 name: Update Homebrew Tap
 
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       tag_name:
@@ -17,7 +14,7 @@ permissions:
 jobs:
   update-tap:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name || inputs.tag_name, 'v')
+    if: startsWith(inputs.tag_name, 'v')
 
     steps:
       - name: Validate tap configuration
@@ -31,12 +28,12 @@ jobs:
       - name: Checkout tap repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ vars.HOMEBREW_TAP_REPO || 'vincentkoc/tap' }}
+          repository: vincentkoc/tap
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Update formula
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
+          TAG: ${{ inputs.tag_name }}
           SOURCE_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -95,7 +92,7 @@ jobs:
 
       - name: Commit and push formula update
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
+          TAG: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
           git add Formula/tokenjuice.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
   id-token: write
 
@@ -169,6 +170,25 @@ jobs:
             release/sha256sums.txt \
             release/Formula/tokenjuice.rb \
             --clobber
+
+      - name: Sync Homebrew tap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/homebrew-tap.yml/dispatches" \
+            -d @- <<EOF
+          {
+            "ref": "main",
+            "inputs": {
+              "tag_name": "${RELEASE_TAG}"
+            }
+          }
+          EOF
 
       - name: Publish npm package
         if: startsWith(github.ref, 'refs/tags/v')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjuice",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Lean output compaction for terminal-heavy agent workflows.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary
- dispatch the Homebrew tap sync directly from the release workflow
- hardcode the tap target to vincentkoc/tap so no repo variable is required
- fix release-drafter templates and bump package.json to v0.3.3

## Testing
- pnpm test
- pnpm build
- pnpm release:local