### PR TITLE
fix(claude-code): honor tokenjuice wrap --raw/--full bypass in PostToolUse hook

### DIFF
--- a/src/core/claude-code.ts
+++ b/src/core/claude-code.ts
@@ -424,6 +424,36 @@ function shouldStoreFromEnv(): boolean {
   return value === "1" || value === "true" || value === "TRUE" || value === "yes" || value === "YES";
 }
 
+function commandRequestsTokenjuiceRawBypass(command: string): boolean {
+  const argv = parseShellWords(command);
+  if (argv.length < 3) {
+    return false;
+  }
+
+  const first = argv[0];
+  const second = argv[1];
+  let wrapIndex = -1;
+  if (first === "tokenjuice") {
+    wrapIndex = 1;
+  } else if (
+    typeof first === "string"
+    && first.endsWith("/node")
+    && typeof second === "string"
+    && second.endsWith(".js")
+    && argv.slice(1).some((part) => part.includes("tokenjuice"))
+  ) {
+    wrapIndex = 2;
+  }
+
+  if (wrapIndex === -1 || argv[wrapIndex] !== "wrap") {
+    return false;
+  }
+
+  const optionEndIndex = argv.indexOf("--", wrapIndex + 1);
+  const optionArgs = argv.slice(wrapIndex + 1, optionEndIndex === -1 ? undefined : optionEndIndex);
+  return optionArgs.includes("--raw") || optionArgs.includes("--full");
+}
+
 function buildClaudeCodeHint(rawRefId?: string): string {
   const hints = [
     "if this compaction looks wrong, rerun with `tokenjuice wrap --raw -- <command>` or `tokenjuice wrap --full -- <command>`.",
@@ -472,6 +502,11 @@ export async function runClaudeCodePostToolUseHook(rawText: string): Promise<num
   const combinedText = stringifyToolResponse(payload.tool_response);
   if (!combinedText.trim()) {
     await writeHookDebug({ ...debug, skipped: "empty-tool-response" });
+    return 0;
+  }
+
+  if (commandRequestsTokenjuiceRawBypass(command)) {
+    await writeHookDebug({ ...debug, skipped: "explicit-raw-bypass" });
     return 0;
   }
 

--- a/test/claude-code.test.ts
+++ b/test/claude-code.test.ts
@@ -502,6 +502,62 @@ describe("runClaudeCodePostToolUseHook", () => {
     expect(debug.skipped).toBe("non-bash");
   });
 
+  it("honors tokenjuice raw bypass commands without re-compacting them", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "tokenjuice wrap --raw -- bash -lc 'git show HEAD --stat'",
+      },
+      tool_response: [
+        "commit abcdef",
+        "Author: Example",
+        "",
+        " README.md | 10 +++++-----",
+        " src/core/claude-code.ts | 12 +++++++-----",
+      ].join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("explicit-raw-bypass");
+  });
+
+  it("honors tokenjuice full bypass commands without re-compacting them", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "tokenjuice wrap --full -- git log --oneline -50",
+      },
+      tool_response: Array.from({ length: 50 }, (_, i) => `${String(i).padStart(7, "0")} commit ${i}`).join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("explicit-raw-bypass");
+  });
+
   it("skips empty tool_response", async () => {
     const home = await createTempDir();
     process.env.CLAUDE_HOME = home;


### PR DESCRIPTION
## Summary

- Port `commandRequestsTokenjuiceRawBypass()` from the Codex hook to the Claude Code hook so that `tokenjuice wrap --raw -- <command>` and `tokenjuice wrap --full -- <command>` skip compaction instead of being re-compacted by the PostToolUse hook
- Add tests for both `--raw` and `--full` bypass paths

The `additionalContext` hint already tells agents to rerun with `tokenjuice wrap --raw`, but the Claude Code hook didn't detect this and compacted the output anyway — making the suggestion circular.

Closes #5

## Test plan

- [x] `pnpm build && pnpm test` — all 191 tests pass (including 2 new)
- [x] Manual verification: temporarily pointed Claude Code hook at local build, confirmed `git log --oneline -50` gets compacted (`rewrote: true`) and `tokenjuice wrap --raw -- git log --oneline -50` bypasses compaction (`skipped: "explicit-raw-bypass"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) under the supervision of Bill Murdock.