### PR TITLE
feat(rules): add git diff and xcodebuild reducers

### DIFF
--- a/src/core/builtin-rules.generated.ts
+++ b/src/core/builtin-rules.generated.ts
@@ -9,95 +9,97 @@ import rule4 from "../rules/build/tsc.json" with { type: "json" };
 import rule5 from "../rules/build/tsdown.json" with { type: "json" };
 import rule6 from "../rules/build/vite.json" with { type: "json" };
 import rule7 from "../rules/build/webpack.json" with { type: "json" };
-import rule8 from "../rules/cloud/aws.json" with { type: "json" };
-import rule9 from "../rules/cloud/az.json" with { type: "json" };
-import rule10 from "../rules/cloud/flyctl.json" with { type: "json" };
-import rule11 from "../rules/cloud/gcloud.json" with { type: "json" };
-import rule12 from "../rules/cloud/gh.json" with { type: "json" };
-import rule13 from "../rules/cloud/vercel.json" with { type: "json" };
-import rule14 from "../rules/database/mongosh.json" with { type: "json" };
-import rule15 from "../rules/database/mysql.json" with { type: "json" };
-import rule16 from "../rules/database/psql.json" with { type: "json" };
-import rule17 from "../rules/database/redis-cli.json" with { type: "json" };
-import rule18 from "../rules/database/sqlite3.json" with { type: "json" };
-import rule19 from "../rules/devops/docker-build.json" with { type: "json" };
-import rule20 from "../rules/devops/docker-compose.json" with { type: "json" };
-import rule21 from "../rules/devops/docker-images.json" with { type: "json" };
-import rule22 from "../rules/devops/docker-logs.json" with { type: "json" };
-import rule23 from "../rules/devops/docker-ps.json" with { type: "json" };
-import rule24 from "../rules/devops/kubectl-describe.json" with { type: "json" };
-import rule25 from "../rules/devops/kubectl-get.json" with { type: "json" };
-import rule26 from "../rules/devops/kubectl-logs.json" with { type: "json" };
-import rule27 from "../rules/filesystem/find.json" with { type: "json" };
-import rule28 from "../rules/filesystem/ls.json" with { type: "json" };
-import rule29 from "../rules/generic/fallback.json" with { type: "json" };
-import rule30 from "../rules/generic/help.json" with { type: "json" };
-import rule31 from "../rules/git/branch.json" with { type: "json" };
-import rule32 from "../rules/git/diff-name-only.json" with { type: "json" };
-import rule33 from "../rules/git/diff-stat.json" with { type: "json" };
-import rule34 from "../rules/git/log-oneline.json" with { type: "json" };
-import rule35 from "../rules/git/remote-v.json" with { type: "json" };
-import rule36 from "../rules/git/show.json" with { type: "json" };
-import rule37 from "../rules/git/stash-list.json" with { type: "json" };
-import rule38 from "../rules/git/status.json" with { type: "json" };
-import rule39 from "../rules/install/bun-install.json" with { type: "json" };
-import rule40 from "../rules/install/npm-install.json" with { type: "json" };
-import rule41 from "../rules/install/pnpm-install.json" with { type: "json" };
-import rule42 from "../rules/install/yarn-install.json" with { type: "json" };
-import rule43 from "../rules/lint/biome.json" with { type: "json" };
-import rule44 from "../rules/lint/eslint.json" with { type: "json" };
-import rule45 from "../rules/lint/oxlint.json" with { type: "json" };
-import rule46 from "../rules/lint/prettier-check.json" with { type: "json" };
-import rule47 from "../rules/media/ffmpeg.json" with { type: "json" };
-import rule48 from "../rules/media/mediainfo.json" with { type: "json" };
-import rule49 from "../rules/network/curl.json" with { type: "json" };
-import rule50 from "../rules/network/dig.json" with { type: "json" };
-import rule51 from "../rules/network/nslookup.json" with { type: "json" };
-import rule52 from "../rules/network/ping.json" with { type: "json" };
-import rule53 from "../rules/network/ssh.json" with { type: "json" };
-import rule54 from "../rules/network/traceroute.json" with { type: "json" };
-import rule55 from "../rules/network/wget.json" with { type: "json" };
-import rule56 from "../rules/observability/free.json" with { type: "json" };
-import rule57 from "../rules/observability/htop.json" with { type: "json" };
-import rule58 from "../rules/observability/iostat.json" with { type: "json" };
-import rule59 from "../rules/observability/top.json" with { type: "json" };
-import rule60 from "../rules/observability/vmstat.json" with { type: "json" };
-import rule61 from "../rules/openclaw/sessions-history.json" with { type: "json" };
-import rule62 from "../rules/package/apt-install.json" with { type: "json" };
-import rule63 from "../rules/package/apt-upgrade.json" with { type: "json" };
-import rule64 from "../rules/package/brew-install.json" with { type: "json" };
-import rule65 from "../rules/package/brew-upgrade.json" with { type: "json" };
-import rule66 from "../rules/package/dnf-install.json" with { type: "json" };
-import rule67 from "../rules/package/yum-install.json" with { type: "json" };
-import rule68 from "../rules/search/git-grep.json" with { type: "json" };
-import rule69 from "../rules/search/grep.json" with { type: "json" };
-import rule70 from "../rules/search/rg.json" with { type: "json" };
-import rule71 from "../rules/service/journalctl.json" with { type: "json" };
-import rule72 from "../rules/service/launchctl.json" with { type: "json" };
-import rule73 from "../rules/service/lsof.json" with { type: "json" };
-import rule74 from "../rules/service/netstat.json" with { type: "json" };
-import rule75 from "../rules/service/service.json" with { type: "json" };
-import rule76 from "../rules/service/ss.json" with { type: "json" };
-import rule77 from "../rules/service/systemctl-status.json" with { type: "json" };
-import rule78 from "../rules/system/df.json" with { type: "json" };
-import rule79 from "../rules/system/du.json" with { type: "json" };
-import rule80 from "../rules/system/file.json" with { type: "json" };
-import rule81 from "../rules/system/ps.json" with { type: "json" };
-import rule82 from "../rules/task/just.json" with { type: "json" };
-import rule83 from "../rules/task/make.json" with { type: "json" };
-import rule84 from "../rules/tests/bun-test.json" with { type: "json" };
-import rule85 from "../rules/tests/cargo-test.json" with { type: "json" };
-import rule86 from "../rules/tests/go-test.json" with { type: "json" };
-import rule87 from "../rules/tests/jest.json" with { type: "json" };
-import rule88 from "../rules/tests/mocha.json" with { type: "json" };
-import rule89 from "../rules/tests/npm-test.json" with { type: "json" };
-import rule90 from "../rules/tests/playwright.json" with { type: "json" };
-import rule91 from "../rules/tests/pnpm-test.json" with { type: "json" };
-import rule92 from "../rules/tests/pytest.json" with { type: "json" };
-import rule93 from "../rules/tests/vitest.json" with { type: "json" };
-import rule94 from "../rules/tests/yarn-test.json" with { type: "json" };
-import rule95 from "../rules/transfer/rsync.json" with { type: "json" };
-import rule96 from "../rules/transfer/scp.json" with { type: "json" };
+import rule8 from "../rules/build/xcodebuild.json" with { type: "json" };
+import rule9 from "../rules/cloud/aws.json" with { type: "json" };
+import rule10 from "../rules/cloud/az.json" with { type: "json" };
+import rule11 from "../rules/cloud/flyctl.json" with { type: "json" };
+import rule12 from "../rules/cloud/gcloud.json" with { type: "json" };
+import rule13 from "../rules/cloud/gh.json" with { type: "json" };
+import rule14 from "../rules/cloud/vercel.json" with { type: "json" };
+import rule15 from "../rules/database/mongosh.json" with { type: "json" };
+import rule16 from "../rules/database/mysql.json" with { type: "json" };
+import rule17 from "../rules/database/psql.json" with { type: "json" };
+import rule18 from "../rules/database/redis-cli.json" with { type: "json" };
+import rule19 from "../rules/database/sqlite3.json" with { type: "json" };
+import rule20 from "../rules/devops/docker-build.json" with { type: "json" };
+import rule21 from "../rules/devops/docker-compose.json" with { type: "json" };
+import rule22 from "../rules/devops/docker-images.json" with { type: "json" };
+import rule23 from "../rules/devops/docker-logs.json" with { type: "json" };
+import rule24 from "../rules/devops/docker-ps.json" with { type: "json" };
+import rule25 from "../rules/devops/kubectl-describe.json" with { type: "json" };
+import rule26 from "../rules/devops/kubectl-get.json" with { type: "json" };
+import rule27 from "../rules/devops/kubectl-logs.json" with { type: "json" };
+import rule28 from "../rules/filesystem/find.json" with { type: "json" };
+import rule29 from "../rules/filesystem/ls.json" with { type: "json" };
+import rule30 from "../rules/generic/fallback.json" with { type: "json" };
+import rule31 from "../rules/generic/help.json" with { type: "json" };
+import rule32 from "../rules/git/branch.json" with { type: "json" };
+import rule33 from "../rules/git/diff-name-only.json" with { type: "json" };
+import rule34 from "../rules/git/diff-stat.json" with { type: "json" };
+import rule35 from "../rules/git/diff.json" with { type: "json" };
+import rule36 from "../rules/git/log-oneline.json" with { type: "json" };
+import rule37 from "../rules/git/remote-v.json" with { type: "json" };
+import rule38 from "../rules/git/show.json" with { type: "json" };
+import rule39 from "../rules/git/stash-list.json" with { type: "json" };
+import rule40 from "../rules/git/status.json" with { type: "json" };
+import rule41 from "../rules/install/bun-install.json" with { type: "json" };
+import rule42 from "../rules/install/npm-install.json" with { type: "json" };
+import rule43 from "../rules/install/pnpm-install.json" with { type: "json" };
+import rule44 from "../rules/install/yarn-install.json" with { type: "json" };
+import rule45 from "../rules/lint/biome.json" with { type: "json" };
+import rule46 from "../rules/lint/eslint.json" with { type: "json" };
+import rule47 from "../rules/lint/oxlint.json" with { type: "json" };
+import rule48 from "../rules/lint/prettier-check.json" with { type: "json" };
+import rule49 from "../rules/media/ffmpeg.json" with { type: "json" };
+import rule50 from "../rules/media/mediainfo.json" with { type: "json" };
+import rule51 from "../rules/network/curl.json" with { type: "json" };
+import rule52 from "../rules/network/dig.json" with { type: "json" };
+import rule53 from "../rules/network/nslookup.json" with { type: "json" };
+import rule54 from "../rules/network/ping.json" with { type: "json" };
+import rule55 from "../rules/network/ssh.json" with { type: "json" };
+import rule56 from "../rules/network/traceroute.json" with { type: "json" };
+import rule57 from "../rules/network/wget.json" with { type: "json" };
+import rule58 from "../rules/observability/free.json" with { type: "json" };
+import rule59 from "../rules/observability/htop.json" with { type: "json" };
+import rule60 from "../rules/observability/iostat.json" with { type: "json" };
+import rule61 from "../rules/observability/top.json" with { type: "json" };
+import rule62 from "../rules/observability/vmstat.json" with { type: "json" };
+import rule63 from "../rules/openclaw/sessions-history.json" with { type: "json" };
+import rule64 from "../rules/package/apt-install.json" with { type: "json" };
+import rule65 from "../rules/package/apt-upgrade.json" with { type: "json" };
+import rule66 from "../rules/package/brew-install.json" with { type: "json" };
+import rule67 from "../rules/package/brew-upgrade.json" with { type: "json" };
+import rule68 from "../rules/package/dnf-install.json" with { type: "json" };
+import rule69 from "../rules/package/yum-install.json" with { type: "json" };
+import rule70 from "../rules/search/git-grep.json" with { type: "json" };
+import rule71 from "../rules/search/grep.json" with { type: "json" };
+import rule72 from "../rules/search/rg.json" with { type: "json" };
+import rule73 from "../rules/service/journalctl.json" with { type: "json" };
+import rule74 from "../rules/service/launchctl.json" with { type: "json" };
+import rule75 from "../rules/service/lsof.json" with { type: "json" };
+import rule76 from "../rules/service/netstat.json" with { type: "json" };
+import rule77 from "../rules/service/service.json" with { type: "json" };
+import rule78 from "../rules/service/ss.json" with { type: "json" };
+import rule79 from "../rules/service/systemctl-status.json" with { type: "json" };
+import rule80 from "../rules/system/df.json" with { type: "json" };
+import rule81 from "../rules/system/du.json" with { type: "json" };
+import rule82 from "../rules/system/file.json" with { type: "json" };
+import rule83 from "../rules/system/ps.json" with { type: "json" };
+import rule84 from "../rules/task/just.json" with { type: "json" };
+import rule85 from "../rules/task/make.json" with { type: "json" };
+import rule86 from "../rules/tests/bun-test.json" with { type: "json" };
+import rule87 from "../rules/tests/cargo-test.json" with { type: "json" };
+import rule88 from "../rules/tests/go-test.json" with { type: "json" };
+import rule89 from "../rules/tests/jest.json" with { type: "json" };
+import rule90 from "../rules/tests/mocha.json" with { type: "json" };
+import rule91 from "../rules/tests/npm-test.json" with { type: "json" };
+import rule92 from "../rules/tests/playwright.json" with { type: "json" };
+import rule93 from "../rules/tests/pnpm-test.json" with { type: "json" };
+import rule94 from "../rules/tests/pytest.json" with { type: "json" };
+import rule95 from "../rules/tests/vitest.json" with { type: "json" };
+import rule96 from "../rules/tests/yarn-test.json" with { type: "json" };
+import rule97 from "../rules/transfer/rsync.json" with { type: "json" };
+import rule98 from "../rules/transfer/scp.json" with { type: "json" };
 
 export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule0 as JsonRule, // rules/archive/tar.json
@@ -108,93 +110,95 @@ export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule5 as JsonRule, // rules/build/tsdown.json
   rule6 as JsonRule, // rules/build/vite.json
   rule7 as JsonRule, // rules/build/webpack.json
-  rule8 as JsonRule, // rules/cloud/aws.json
-  rule9 as JsonRule, // rules/cloud/az.json
-  rule10 as JsonRule, // rules/cloud/flyctl.json
-  rule11 as JsonRule, // rules/cloud/gcloud.json
-  rule12 as JsonRule, // rules/cloud/gh.json
-  rule13 as JsonRule, // rules/cloud/vercel.json
-  rule14 as JsonRule, // rules/database/mongosh.json
-  rule15 as JsonRule, // rules/database/mysql.json
-  rule16 as JsonRule, // rules/database/psql.json
-  rule17 as JsonRule, // rules/database/redis-cli.json
-  rule18 as JsonRule, // rules/database/sqlite3.json
-  rule19 as JsonRule, // rules/devops/docker-build.json
-  rule20 as JsonRule, // rules/devops/docker-compose.json
-  rule21 as JsonRule, // rules/devops/docker-images.json
-  rule22 as JsonRule, // rules/devops/docker-logs.json
-  rule23 as JsonRule, // rules/devops/docker-ps.json
-  rule24 as JsonRule, // rules/devops/kubectl-describe.json
-  rule25 as JsonRule, // rules/devops/kubectl-get.json
-  rule26 as JsonRule, // rules/devops/kubectl-logs.json
-  rule27 as JsonRule, // rules/filesystem/find.json
-  rule28 as JsonRule, // rules/filesystem/ls.json
-  rule29 as JsonRule, // rules/generic/fallback.json
-  rule30 as JsonRule, // rules/generic/help.json
-  rule31 as JsonRule, // rules/git/branch.json
-  rule32 as JsonRule, // rules/git/diff-name-only.json
-  rule33 as JsonRule, // rules/git/diff-stat.json
-  rule34 as JsonRule, // rules/git/log-oneline.json
-  rule35 as JsonRule, // rules/git/remote-v.json
-  rule36 as JsonRule, // rules/git/show.json
-  rule37 as JsonRule, // rules/git/stash-list.json
-  rule38 as JsonRule, // rules/git/status.json
-  rule39 as JsonRule, // rules/install/bun-install.json
-  rule40 as JsonRule, // rules/install/npm-install.json
-  rule41 as JsonRule, // rules/install/pnpm-install.json
-  rule42 as JsonRule, // rules/install/yarn-install.json
-  rule43 as JsonRule, // rules/lint/biome.json
-  rule44 as JsonRule, // rules/lint/eslint.json
-  rule45 as JsonRule, // rules/lint/oxlint.json
-  rule46 as JsonRule, // rules/lint/prettier-check.json
-  rule47 as JsonRule, // rules/media/ffmpeg.json
-  rule48 as JsonRule, // rules/media/mediainfo.json
-  rule49 as JsonRule, // rules/network/curl.json
-  rule50 as JsonRule, // rules/network/dig.json
-  rule51 as JsonRule, // rules/network/nslookup.json
-  rule52 as JsonRule, // rules/network/ping.json
-  rule53 as JsonRule, // rules/network/ssh.json
-  rule54 as JsonRule, // rules/network/traceroute.json
-  rule55 as JsonRule, // rules/network/wget.json
-  rule56 as JsonRule, // rules/observability/free.json
-  rule57 as JsonRule, // rules/observability/htop.json
-  rule58 as JsonRule, // rules/observability/iostat.json
-  rule59 as JsonRule, // rules/observability/top.json
-  rule60 as JsonRule, // rules/observability/vmstat.json
-  rule61 as JsonRule, // rules/openclaw/sessions-history.json
-  rule62 as JsonRule, // rules/package/apt-install.json
-  rule63 as JsonRule, // rules/package/apt-upgrade.json
-  rule64 as JsonRule, // rules/package/brew-install.json
-  rule65 as JsonRule, // rules/package/brew-upgrade.json
-  rule66 as JsonRule, // rules/package/dnf-install.json
-  rule67 as JsonRule, // rules/package/yum-install.json
-  rule68 as JsonRule, // rules/search/git-grep.json
-  rule69 as JsonRule, // rules/search/grep.json
-  rule70 as JsonRule, // rules/search/rg.json
-  rule71 as JsonRule, // rules/service/journalctl.json
-  rule72 as JsonRule, // rules/service/launchctl.json
-  rule73 as JsonRule, // rules/service/lsof.json
-  rule74 as JsonRule, // rules/service/netstat.json
-  rule75 as JsonRule, // rules/service/service.json
-  rule76 as JsonRule, // rules/service/ss.json
-  rule77 as JsonRule, // rules/service/systemctl-status.json
-  rule78 as JsonRule, // rules/system/df.json
-  rule79 as JsonRule, // rules/system/du.json
-  rule80 as JsonRule, // rules/system/file.json
-  rule81 as JsonRule, // rules/system/ps.json
-  rule82 as JsonRule, // rules/task/just.json
-  rule83 as JsonRule, // rules/task/make.json
-  rule84 as JsonRule, // rules/tests/bun-test.json
-  rule85 as JsonRule, // rules/tests/cargo-test.json
-  rule86 as JsonRule, // rules/tests/go-test.json
-  rule87 as JsonRule, // rules/tests/jest.json
-  rule88 as JsonRule, // rules/tests/mocha.json
-  rule89 as JsonRule, // rules/tests/npm-test.json
-  rule90 as JsonRule, // rules/tests/playwright.json
-  rule91 as JsonRule, // rules/tests/pnpm-test.json
-  rule92 as JsonRule, // rules/tests/pytest.json
-  rule93 as JsonRule, // rules/tests/vitest.json
-  rule94 as JsonRule, // rules/tests/yarn-test.json
-  rule95 as JsonRule, // rules/transfer/rsync.json
-  rule96 as JsonRule, // rules/transfer/scp.json
+  rule8 as JsonRule, // rules/build/xcodebuild.json
+  rule9 as JsonRule, // rules/cloud/aws.json
+  rule10 as JsonRule, // rules/cloud/az.json
+  rule11 as JsonRule, // rules/cloud/flyctl.json
+  rule12 as JsonRule, // rules/cloud/gcloud.json
+  rule13 as JsonRule, // rules/cloud/gh.json
+  rule14 as JsonRule, // rules/cloud/vercel.json
+  rule15 as JsonRule, // rules/database/mongosh.json
+  rule16 as JsonRule, // rules/database/mysql.json
+  rule17 as JsonRule, // rules/database/psql.json
+  rule18 as JsonRule, // rules/database/redis-cli.json
+  rule19 as JsonRule, // rules/database/sqlite3.json
+  rule20 as JsonRule, // rules/devops/docker-build.json
+  rule21 as JsonRule, // rules/devops/docker-compose.json
+  rule22 as JsonRule, // rules/devops/docker-images.json
+  rule23 as JsonRule, // rules/devops/docker-logs.json
+  rule24 as JsonRule, // rules/devops/docker-ps.json
+  rule25 as JsonRule, // rules/devops/kubectl-describe.json
+  rule26 as JsonRule, // rules/devops/kubectl-get.json
+  rule27 as JsonRule, // rules/devops/kubectl-logs.json
+  rule28 as JsonRule, // rules/filesystem/find.json
+  rule29 as JsonRule, // rules/filesystem/ls.json
+  rule30 as JsonRule, // rules/generic/fallback.json
+  rule31 as JsonRule, // rules/generic/help.json
+  rule32 as JsonRule, // rules/git/branch.json
+  rule33 as JsonRule, // rules/git/diff-name-only.json
+  rule34 as JsonRule, // rules/git/diff-stat.json
+  rule35 as JsonRule, // rules/git/diff.json
+  rule36 as JsonRule, // rules/git/log-oneline.json
+  rule37 as JsonRule, // rules/git/remote-v.json
+  rule38 as JsonRule, // rules/git/show.json
+  rule39 as JsonRule, // rules/git/stash-list.json
+  rule40 as JsonRule, // rules/git/status.json
+  rule41 as JsonRule, // rules/install/bun-install.json
+  rule42 as JsonRule, // rules/install/npm-install.json
+  rule43 as JsonRule, // rules/install/pnpm-install.json
+  rule44 as JsonRule, // rules/install/yarn-install.json
+  rule45 as JsonRule, // rules/lint/biome.json
+  rule46 as JsonRule, // rules/lint/eslint.json
+  rule47 as JsonRule, // rules/lint/oxlint.json
+  rule48 as JsonRule, // rules/lint/prettier-check.json
+  rule49 as JsonRule, // rules/media/ffmpeg.json
+  rule50 as JsonRule, // rules/media/mediainfo.json
+  rule51 as JsonRule, // rules/network/curl.json
+  rule52 as JsonRule, // rules/network/dig.json
+  rule53 as JsonRule, // rules/network/nslookup.json
+  rule54 as JsonRule, // rules/network/ping.json
+  rule55 as JsonRule, // rules/network/ssh.json
+  rule56 as JsonRule, // rules/network/traceroute.json
+  rule57 as JsonRule, // rules/network/wget.json
+  rule58 as JsonRule, // rules/observability/free.json
+  rule59 as JsonRule, // rules/observability/htop.json
+  rule60 as JsonRule, // rules/observability/iostat.json
+  rule61 as JsonRule, // rules/observability/top.json
+  rule62 as JsonRule, // rules/observability/vmstat.json
+  rule63 as JsonRule, // rules/openclaw/sessions-history.json
+  rule64 as JsonRule, // rules/package/apt-install.json
+  rule65 as JsonRule, // rules/package/apt-upgrade.json
+  rule66 as JsonRule, // rules/package/brew-install.json
+  rule67 as JsonRule, // rules/package/brew-upgrade.json
+  rule68 as JsonRule, // rules/package/dnf-install.json
+  rule69 as JsonRule, // rules/package/yum-install.json
+  rule70 as JsonRule, // rules/search/git-grep.json
+  rule71 as JsonRule, // rules/search/grep.json
+  rule72 as JsonRule, // rules/search/rg.json
+  rule73 as JsonRule, // rules/service/journalctl.json
+  rule74 as JsonRule, // rules/service/launchctl.json
+  rule75 as JsonRule, // rules/service/lsof.json
+  rule76 as JsonRule, // rules/service/netstat.json
+  rule77 as JsonRule, // rules/service/service.json
+  rule78 as JsonRule, // rules/service/ss.json
+  rule79 as JsonRule, // rules/service/systemctl-status.json
+  rule80 as JsonRule, // rules/system/df.json
+  rule81 as JsonRule, // rules/system/du.json
+  rule82 as JsonRule, // rules/system/file.json
+  rule83 as JsonRule, // rules/system/ps.json
+  rule84 as JsonRule, // rules/task/just.json
+  rule85 as JsonRule, // rules/task/make.json
+  rule86 as JsonRule, // rules/tests/bun-test.json
+  rule87 as JsonRule, // rules/tests/cargo-test.json
+  rule88 as JsonRule, // rules/tests/go-test.json
+  rule89 as JsonRule, // rules/tests/jest.json
+  rule90 as JsonRule, // rules/tests/mocha.json
+  rule91 as JsonRule, // rules/tests/npm-test.json
+  rule92 as JsonRule, // rules/tests/playwright.json
+  rule93 as JsonRule, // rules/tests/pnpm-test.json
+  rule94 as JsonRule, // rules/tests/pytest.json
+  rule95 as JsonRule, // rules/tests/vitest.json
+  rule96 as JsonRule, // rules/tests/yarn-test.json
+  rule97 as JsonRule, // rules/transfer/rsync.json
+  rule98 as JsonRule, // rules/transfer/scp.json
 ];

--- a/src/rules/build/xcodebuild.json
+++ b/src/rules/build/xcodebuild.json
@@ -1,0 +1,80 @@
+{
+  "id": "build/xcodebuild",
+  "family": "build-xcode",
+  "description": "Compact xcodebuild output while preserving real diagnostics, failed commands, and final status.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludesAny": ["xcodebuild ", "&& xcodebuild ", "; xcodebuild ", "\nxcodebuild "]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^Fetching from https?://.+",
+      "^Resolve Package Graph$",
+      "^Resolved source packages:$",
+      "^Command line invocation:$",
+      "^\\s+/Applications/Xcode\\.app/.+/xcodebuild .+$",
+      "^Prepare packages$",
+      "^CreateBuildRequest$",
+      "^SendProjectDescription$",
+      "^CreateBuildOperation$",
+      "^Build description signature: .+$",
+      "^Build description path: .+$",
+      "^note: Building targets in dependency order$",
+      "^note: Target dependency graph \\(.+ targets\\)$",
+      "^\\s*Target '.+' in project '.+'.*$",
+      "^\\s*➜ .+$",
+      "^SwiftDriver(?:JobDiscovery| Compilation)? normal .+$",
+      "^SwiftCompile normal .+$",
+      "^CompileSwift(?:Sources)? normal .+$",
+      "^Ld .+$",
+      "^CodeSign .+$",
+      "^ProcessProductPackaging .+$",
+      "^CompileAssetCatalog .+$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^The following build commands failed:$",
+      "^\\t.+$",
+      "^\\*\\* BUILD (?:SUCCEEDED|FAILED) \\*\\*$",
+      "^\\*\\* TEST (?:SUCCEEDED|FAILED) \\*\\*$",
+      "^Testing failed:$"
+    ]
+  },
+  "summarize": {
+    "head": 18,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 24,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "failed command",
+      "pattern": "^\\t.+$",
+      "flags": "m"
+    }
+  ]
+}

--- a/src/rules/fixtures/build/xcodebuild.fixture.json
+++ b/src/rules/fixtures/build/xcodebuild.fixture.json
@@ -1,0 +1,27 @@
+{
+  "id": "build-xcodebuild-failure-basic",
+  "ruleId": "build/xcodebuild",
+  "input": {
+    "toolName": "exec",
+    "command": "bash -lc 'cd apps/ios && xcodebuild -project App.xcodeproj -scheme App build'",
+    "combinedText": "Command line invocation:\n    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj -scheme App build\n\nResolve Package Graph\nFetching from https://github.com/apple/swift-syntax\nFetching from https://github.com/pointfreeco/swift-snapshot-testing (cached)\n\nSwiftCompile normal arm64 Compiling\\ Foo.swift /Users/guti/projects/App/apps/ios/Sources/Foo.swift (in target 'App' from project 'App')\n/Users/guti/projects/App/apps/ios/Sources/Foo.swift:17:12: error: cannot find 'missingSymbol' in scope\n/Users/guti/projects/App/apps/ios/Sources/Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used\nnote: Building targets in dependency order\n\nThe following build commands failed:\n\tSwiftCompile normal arm64 /Users/guti/projects/App/apps/ios/Sources/Foo.swift\n\tBuilding project App with scheme App\n(2 failures)\n** BUILD FAILED **\n",
+    "exitCode": 65
+  },
+  "expect": {
+    "matchedReducer": "build/xcodebuild",
+    "family": "build-xcode",
+    "contains": [
+      "error",
+      "warning",
+      "failed command",
+      "Foo.swift:17:12: error: cannot find 'missingSymbol' in scope",
+      "Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used",
+      "The following build commands failed:",
+      "** BUILD FAILED **"
+    ],
+    "excludes": [
+      "Fetching from https://github.com/apple/swift-syntax",
+      "SwiftCompile normal arm64 Compiling\\ Foo.swift"
+    ]
+  }
+}

--- a/src/rules/fixtures/build/xcodebuild.fixture.json
+++ b/src/rules/fixtures/build/xcodebuild.fixture.json
@@ -4,7 +4,7 @@
   "input": {
     "toolName": "exec",
     "command": "bash -lc 'cd apps/ios && xcodebuild -project App.xcodeproj -scheme App build'",
-    "combinedText": "Command line invocation:\n    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj -scheme App build\n\nResolve Package Graph\nFetching from https://github.com/apple/swift-syntax\nFetching from https://github.com/pointfreeco/swift-snapshot-testing (cached)\n\nSwiftCompile normal arm64 Compiling\\ Foo.swift /Users/guti/projects/App/apps/ios/Sources/Foo.swift (in target 'App' from project 'App')\n/Users/guti/projects/App/apps/ios/Sources/Foo.swift:17:12: error: cannot find 'missingSymbol' in scope\n/Users/guti/projects/App/apps/ios/Sources/Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used\nnote: Building targets in dependency order\n\nThe following build commands failed:\n\tSwiftCompile normal arm64 /Users/guti/projects/App/apps/ios/Sources/Foo.swift\n\tBuilding project App with scheme App\n(2 failures)\n** BUILD FAILED **\n",
+    "combinedText": "Command line invocation:\n    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj -scheme App build\n\nResolve Package Graph\nFetching from https://github.com/apple/swift-syntax\nFetching from https://github.com/pointfreeco/swift-snapshot-testing (cached)\n\nSwiftCompile normal arm64 Compiling\\ Foo.swift /repo/apps/ios/Sources/Foo.swift (in target 'App' from project 'App')\n/repo/apps/ios/Sources/Foo.swift:17:12: error: cannot find 'missingSymbol' in scope\n/repo/apps/ios/Sources/Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used\nnote: Building targets in dependency order\n\nThe following build commands failed:\n\tSwiftCompile normal arm64 /repo/apps/ios/Sources/Foo.swift\n\tBuilding project App with scheme App\n(2 failures)\n** BUILD FAILED **\n",
     "exitCode": 65
   },
   "expect": {
@@ -14,8 +14,8 @@
       "error",
       "warning",
       "failed command",
-      "Foo.swift:17:12: error: cannot find 'missingSymbol' in scope",
-      "Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used",
+      "/repo/apps/ios/Sources/Foo.swift:17:12: error: cannot find 'missingSymbol' in scope",
+      "/repo/apps/ios/Sources/Bar.swift:4:9: warning: initialization of immutable value 'unused' was never used",
       "The following build commands failed:",
       "** BUILD FAILED **"
     ],

--- a/src/rules/fixtures/git/diff.fixture.json
+++ b/src/rules/fixtures/git/diff.fixture.json
@@ -3,7 +3,7 @@
   "ruleId": "git/diff",
   "input": {
     "toolName": "exec",
-    "command": "cd /repo && git diff -- src/app.ts src/util.ts",
+    "command": "cd /workspace/example-app && git diff -- src/app.ts src/util.ts",
     "combinedText": "diff --git a/src/app.ts b/src/app.ts\nindex 1111111..2222222 100644\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,5 +1,6 @@\n import { start } from './start';\n-console.log('old');\n+console.log('new');\n+console.log('added');\n export function main() {\n   start();\n }\ndiff --git a/src/util.ts b/src/util.ts\nindex 3333333..4444444 100644\n--- a/src/util.ts\n+++ b/src/util.ts\n@@ -10,4 +10,3 @@ export function helper() {\n-  return 'old';\n+  return 'new';\n }\n\\ No newline at end of file\n",
     "exitCode": 0
   },

--- a/src/rules/fixtures/git/diff.fixture.json
+++ b/src/rules/fixtures/git/diff.fixture.json
@@ -1,0 +1,26 @@
+{
+  "id": "git-diff-patch-basic",
+  "ruleId": "git/diff",
+  "input": {
+    "toolName": "exec",
+    "command": "cd /repo && git diff -- src/app.ts src/util.ts",
+    "combinedText": "diff --git a/src/app.ts b/src/app.ts\nindex 1111111..2222222 100644\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,5 +1,6 @@\n import { start } from './start';\n-console.log('old');\n+console.log('new');\n+console.log('added');\n export function main() {\n   start();\n }\ndiff --git a/src/util.ts b/src/util.ts\nindex 3333333..4444444 100644\n--- a/src/util.ts\n+++ b/src/util.ts\n@@ -10,4 +10,3 @@ export function helper() {\n-  return 'old';\n+  return 'new';\n }\n\\ No newline at end of file\n",
+    "exitCode": 0
+  },
+  "expect": {
+    "matchedReducer": "git/diff",
+    "family": "git-diff",
+    "contains": [
+      "changed file",
+      "hunk",
+      "added line",
+      "removed line",
+      "diff --git a/src/app.ts b/src/app.ts",
+      "@@ -1,5 +1,6 @@",
+      "+console.log('added');"
+    ],
+    "excludes": [
+      "index 1111111..2222222 100644"
+    ]
+  }
+}

--- a/src/rules/git/diff.json
+++ b/src/rules/git/diff.json
@@ -1,0 +1,65 @@
+{
+  "id": "git/diff",
+  "family": "git-diff",
+  "description": "Compact full git diff patch output while preserving file and hunk headers plus changed lines.",
+  "match": {
+    "toolNames": ["exec"],
+    "commandIncludesAny": ["git diff ", "&& git diff ", "; git diff ", "\ngit diff "]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "keepPatterns": [
+      "^diff --git\\s+.+",
+      "^new file mode\\s+.+",
+      "^deleted file mode\\s+.+",
+      "^similarity index\\s+.+",
+      "^rename from\\s+.+",
+      "^rename to\\s+.+",
+      "^Binary files .+ differ$",
+      "^---\\s+.+",
+      "^\\+\\+\\+\\s+.+",
+      "^@@\\s+.+",
+      "^\\+(?!\\+\\+\\+).+",
+      "^-(?!---).+",
+      "^\\\\ No newline at end of file$",
+      "^\\s*\\d+ files? changed.+",
+      "^\\s*create mode .+",
+      "^\\s*delete mode .+"
+    ]
+  },
+  "summarize": {
+    "head": 20,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 24,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "changed file",
+      "pattern": "^diff --git\\s",
+      "flags": "m"
+    },
+    {
+      "name": "hunk",
+      "pattern": "^@@\\s",
+      "flags": "m"
+    },
+    {
+      "name": "added line",
+      "pattern": "^\\+(?!\\+\\+\\+).+",
+      "flags": "m"
+    },
+    {
+      "name": "removed line",
+      "pattern": "^-(?!---).+",
+      "flags": "m"
+    }
+  ]
+}

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -50,6 +50,7 @@ describe("rules", () => {
       "build/tsdown",
       "build/vite",
       "build/webpack",
+      "build/xcodebuild",
       "cloud/aws",
       "cloud/az",
       "cloud/flyctl",
@@ -73,6 +74,7 @@ describe("rules", () => {
       "filesystem/ls",
       "generic/help",
       "git/branch",
+      "git/diff",
       "git/diff-name-only",
       "git/diff-stat",
       "git/log-oneline",
@@ -153,7 +155,7 @@ describe("rules", () => {
 
   it("loads builtin fixtures successfully", async () => {
     const fixtures = await loadBuiltinFixtures();
-    expect(fixtures).toHaveLength(101);
+    expect(fixtures).toHaveLength(103);
   });
 
   it("keeps builtin fixture inventory aligned with builtin rules", async () => {


### PR DESCRIPTION
## Summary
- add a builtin `git/diff` rule for full patch output
- add a builtin `build/xcodebuild` rule for direct and wrapped `xcodebuild` output
- add fixture coverage for both new reducers
- regenerate bundled builtin rules and update rule inventory assertions

## Tests
- `pnpm test test/rules.test.ts`
- `pnpm test test/reduce.test.ts test/rules.test.ts`
- `pnpm exec tsc --noEmit`

## Manual pi test
Used a fresh pi session in `~/projects/openclaw/copy-1` to compare an iOS build with vs without tokenjuice around `xcodebuild` output.

Results:
- without tokenjuice bash payload: `51271` chars
- with tokenjuice bash payload: `1040` chars
- saved: `50231` chars
- estimated saved tokens: `~12558` (`chars / 4`)
- matched reducer: `build/xcodebuild`
- build outcome: succeeded in both runs

Report:
- `/tmp/pi-xcodebuild-tokenjuice-report.md`
