### PR TITLE
fix(rewrite-policy): ignore leading cd-prefix when gating generic fallback

### DIFF
--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -162,6 +162,91 @@ export function normalizeCommandSignature(command?: string): string | null {
   return normalized || null;
 }
 
+/**
+ * Strip trivial leading `cd <dir> && ` (or `pushd`) prefixes from a shell
+ * command. Models sometimes emit `cd /path && git status` even when the
+ * harness provides a cwd, which causes downstream compound-command heuristics
+ * to skip compaction. Stripping the prefix lets classification and the
+ * rewrite policy reason about the effective command.
+ *
+ * Only handles trivially safe chains — a single shell token argument, no
+ * redirections, no nested pipelines. Anything fancier returns the input
+ * unchanged.
+ */
+export function stripLeadingCdPrefix(command: string): string {
+  let current = command.trim();
+  // Guard against pathological inputs; legitimate chains are rarely > 2.
+  for (let iteration = 0; iteration < 8; iteration += 1) {
+    const next = matchLeadingCdChain(current);
+    if (next === null) return current;
+    current = next;
+  }
+  return current;
+}
+
+function matchLeadingCdChain(command: string): string | null {
+  const keywordMatch = /^\s*(cd|pushd)(\s+)/u.exec(command);
+  if (!keywordMatch) return null;
+
+  let index = keywordMatch[0].length;
+  const length = command.length;
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+  let sawArg = false;
+
+  while (index < length) {
+    const char = command[index]!;
+    if (escaping) {
+      escaping = false;
+      index += 1;
+      sawArg = true;
+      continue;
+    }
+    if (char === "\\") {
+      escaping = true;
+      index += 1;
+      sawArg = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      index += 1;
+      sawArg = true;
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      quote = char;
+      index += 1;
+      sawArg = true;
+      continue;
+    }
+    if (/\s/u.test(char)) break;
+    if (
+      char === "&" ||
+      char === "|" ||
+      char === ";" ||
+      char === "<" ||
+      char === ">" ||
+      char === "\n"
+    ) {
+      return null;
+    }
+    sawArg = true;
+    index += 1;
+  }
+
+  if (!sawArg) return null;
+
+  while (index < length && /[ \t]/u.test(command[index]!)) index += 1;
+
+  if (command[index] === "&" && command[index + 1] === "&") {
+    const tail = command.slice(index + 2).trim();
+    return tail.length > 0 ? tail : null;
+  }
+  return null;
+}
+
+
 export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutionInput {
   if (input.argv?.length || !input.command) {
     return input;

--- a/src/core/integrations/rewrite-policy.ts
+++ b/src/core/integrations/rewrite-policy.ts
@@ -1,6 +1,6 @@
 import type { CompactResult } from "../../types.js";
 
-import { isCompoundShellCommand } from "../command.js";
+import { isCompoundShellCommand, stripLeadingCdPrefix } from "../command.js";
 
 export type RewritePolicyOptions = {
   minSavedCharsAny?: number;
@@ -33,7 +33,7 @@ export function getCompactionSkipReason(
     return null;
   }
 
-  if (options.skipGenericFallbackForCompoundCommands && isCompoundShellCommand(command)) {
+  if (options.skipGenericFallbackForCompoundCommands && isCompoundShellCommand(stripLeadingCdPrefix(command))) {
     return "generic-compound-command";
   }
 

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -5,6 +5,7 @@ import {
   isRepositoryInspectionCommand,
   normalizeCommandSignature,
   normalizeExecutionInput,
+  stripLeadingCdPrefix,
   tokenizeCommand,
 } from "../src/core/command.js";
 
@@ -73,5 +74,39 @@ describe("isRepositoryInspectionCommand", () => {
     "pnpm test",
   ])("does not over-match `%s`", (command) => {
     expect(isRepositoryInspectionCommand({ command })).toBe(false);
+  });
+});
+
+describe("stripLeadingCdPrefix", () => {
+  it("strips `cd <dir> && <tail>` prefixes", () => {
+    expect(stripLeadingCdPrefix("cd /repo && git log -30")).toBe("git log -30");
+  });
+
+  it("strips `pushd <dir> && <tail>` prefixes", () => {
+    expect(stripLeadingCdPrefix("pushd /repo && git status")).toBe("git status");
+  });
+
+  it("handles chained cd prefixes", () => {
+    expect(stripLeadingCdPrefix("cd /a && cd b && git status")).toBe("git status");
+  });
+
+  it("handles quoted directory arguments with spaces", () => {
+    expect(stripLeadingCdPrefix("cd \"/home/with spaces\" && npm --help")).toBe("npm --help");
+  });
+
+  it("leaves compound commands without a leading cd unchanged", () => {
+    expect(stripLeadingCdPrefix("git log -30 | head")).toBe("git log -30 | head");
+  });
+
+  it("leaves non-trivial chains alone (redirection in cd arg)", () => {
+    expect(stripLeadingCdPrefix("cd /tmp > /dev/null && ls")).toBe("cd /tmp > /dev/null && ls");
+  });
+
+  it("leaves bare `cd <dir>` without a chained tail alone", () => {
+    expect(stripLeadingCdPrefix("cd /repo")).toBe("cd /repo");
+  });
+
+  it("leaves commands that do not start with cd/pushd alone", () => {
+    expect(stripLeadingCdPrefix("git log -30")).toBe("git log -30");
   });
 });

--- a/test/compact-bash-result.test.ts
+++ b/test/compact-bash-result.test.ts
@@ -68,4 +68,50 @@ describe("compactBashResult", () => {
       expect(outcome.result?.classification.matchedReducer).toBe("generic/fallback");
     }
   });
+
+  it("compacts generic/fallback output when the command is only a cd-prefixed chain", async () => {
+    // Regression: a leading `cd <dir> && <cmd>` is classified as compound by
+    // `isCompoundShellCommand`, which trips `skipGenericFallbackForCompoundCommands`
+    // and drops compaction to zero even though the effective command is a
+    // single inspection. See tokenjuice phase 3 trial — 3/10 Pi runs went from
+    // -25% to 0% solely because the model prefixed `cd <repo> && git log`.
+    const longOutput = Array.from({ length: 30 }, (_, index) => `commit ${index + 1} ${"x".repeat(120)}`).join("\n");
+    const outcome = await compactBashResult({
+      source: "pi",
+      command: "cd /home/clawdbot/repos/astro-portfolio && git log -30",
+      visibleText: longOutput,
+      maxInlineChars: 1200,
+      skipInspectionCommands: true,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    expect(outcome.action).toBe("rewrite");
+    if (outcome.action === "rewrite") {
+      expect(outcome.result.inlineText.length).toBeLessThan(longOutput.length);
+      expect(outcome.result.classification.matchedReducer).toBe("generic/fallback");
+    }
+  });
+
+  it("still skips genuinely compound commands after stripping cd prefixes", async () => {
+    // `cd X && foo | bar` is still compound after stripping the cd; the gate
+    // should continue to apply to the residual pipeline.
+    const outcome = await compactBashResult({
+      source: "pi",
+      command: "cd /repo && echo hi | head -c 4",
+      visibleText: Array.from({ length: 18 }, (_, index) => `line ${index + 1} ${"x".repeat(24)}`).join("\n"),
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    expect(outcome.action).toBe("keep");
+    if (outcome.action === "keep") {
+      expect(outcome.reason).toBe("generic-compound-command");
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary

When a model emits `cd <dir> && <cmd>` (even though the harness provides a cwd),
`isCompoundShellCommand` classifies the command as compound, which trips
`skipGenericFallbackForCompoundCommands` and drops compaction to zero.

## Reproduction

Measured during a tokenjuice Pi trial on 2026-04-19 (n=10 per cohort,
`~/repos/astro-portfolio`, zai/glm-4.6):

| cohort                           |  n | eff input avg | delta vs base |
| -------------------------------- | --:| -------------:| -------------:|
| baseline                         | 10 |        69,779 |          —    |
| tokenjuice — clean               |  7 |        52,111 |      -25.3%   |
| tokenjuice — `cd && cmd` prefix  |  3 |        69,737 |      -0.06%   |

The 3 spike runs hit the gap solely because glm-4.6 prefixed each bash call
with `...` instead of bare
commands. Probe logs + raw jsonl available on request.

## Fix

- New `stripLeadingCdPrefix(command)` helper in `src/core/command.ts`.
  Conservatively unwraps chained `cd` / `pushd <dir> &&` prefixes where the
  directory is a single shell token with no redirections, pipelines, or
  further compounds.
- `rewrite-policy.ts` calls `isCompoundShellCommand(stripLeadingCdPrefix(command))`
  at the gate only. Classification and argv stay untouched to avoid unrelated
  behavior changes.

## Tests

- 8 new unit tests for `stripLeadingCdPrefix` (quotes, chained `cd`s,
  redirection in cd arg, bare `cd`, non-cd commands).
- 2 new integration tests in `compact-bash-result.test.ts`:
  - `cd <repo> && git log -30` now gets `generic/fallback` compaction.
  - `cd X && echo hi | head -c 4` (still compound after strip) continues to
    skip, preserving the defensive intent.
- 201 / 201 tests pass; `pnpm build` green.

## Out of scope

Rules that match on `argv0` (e.g. `git/status`) still do not match `cd X && git status`
— that requires normalizing the argv derivation too, which is a broader
change. Filing as a follow-up.