### PR TITLE
feat(codex): surface codex_hooks feature-flag status during install

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -321,6 +321,15 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     }
 
     process.stdout.write(`installed codex hook: ${result.hooksPath}\n`);
+    if (result.featureFlag.enabled) {
+      process.stdout.write(`feature flag: codex_hooks is enabled (${result.featureFlag.configPath})\n`);
+    } else {
+      const where = result.featureFlag.configExists
+        ? `${result.featureFlag.configPath} (missing or disabled)`
+        : `no ${result.featureFlag.configPath}`;
+      process.stdout.write(`feature flag: codex_hooks not enabled — ${where}\n`);
+      process.stdout.write(`   ${result.featureFlag.fixHint}\n`);
+    }
     process.stdout.write(`command: ${result.command}\n`);
     if (result.backupPath) {
       process.stdout.write(`backup: ${result.backupPath}\n`);

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -116,6 +116,20 @@ const FEATURE_FLAG_FIX_HINT =
   "Enable per-invocation with `codex exec --enable codex_hooks ...`, " +
   "or persistently by adding a `[features]` section with `codex_hooks = true` to ~/.codex/config.toml.";
 
+function buildCodexFeatureFlagStatus(
+  configPath: string,
+  configExists: boolean,
+): CodexFeatureFlagStatus {
+  return {
+    configPath,
+    configExists,
+    keyPresent: false,
+    value: null,
+    enabled: false,
+    fixHint: FEATURE_FLAG_FIX_HINT,
+  };
+}
+
 /**
  * Read-only scan of ~/.codex/config.toml for `codex_hooks = <bool>` under
  * a `[features]` section (top-level or dotted form). Does NOT edit the
@@ -131,15 +145,12 @@ export async function inspectCodexHooksFeatureFlag(
   try {
     source = await readFile(configPath, "utf8");
   } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return {
-        configPath,
-        configExists: false,
-        keyPresent: false,
-        value: null,
-        enabled: false,
-        fixHint: FEATURE_FLAG_FIX_HINT,
-      };
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return buildCodexFeatureFlagStatus(configPath, false);
+    }
+    if (code === "EACCES" || code === "EPERM" || code === "EISDIR") {
+      return buildCodexFeatureFlagStatus(configPath, true);
     }
     throw error;
   }
@@ -167,7 +178,7 @@ export function parseCodexFeatureFlag(
   key: string,
 ): { keyPresent: boolean; value: boolean | null } {
   const lines = source.split(/\r?\n/u);
-  let inFeatures = false;
+  let currentTablePath: string[] = [];
   const dottedRe = new RegExp(`^\\s*features\\.${key}\\s*=\\s*(true|false)\\b`, "u");
   const scopedRe = new RegExp(`^\\s*${key}\\s*=\\s*(true|false)\\b`, "u");
 
@@ -175,14 +186,18 @@ export function parseCodexFeatureFlag(
     const line = rawLine.replace(/#.*$/u, "");
     const header = /^\s*\[([^\]]+)\]/u.exec(line);
     if (header) {
-      inFeatures = header[1]!.trim() === "features";
+      currentTablePath = header[1]!
+        .trim()
+        .split(".")
+        .map((segment) => segment.trim())
+        .filter(Boolean);
       continue;
     }
-    const dotted = dottedRe.exec(line);
+    const dotted = currentTablePath.length === 0 ? dottedRe.exec(line) : null;
     if (dotted) {
       return { keyPresent: true, value: dotted[1] === "true" };
     }
-    if (inFeatures) {
+    if (currentTablePath.length === 1 && currentTablePath[0] === "features") {
       const scoped = scopedRe.exec(line);
       if (scoped) {
         return { keyPresent: true, value: scoped[1] === "true" };

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -49,6 +49,27 @@ export type InstallCodexHookResult = {
   hooksPath: string;
   backupPath?: string;
   command: string;
+  featureFlag: CodexFeatureFlagStatus;
+};
+
+export type CodexFeatureFlagStatus = {
+  /** Absolute path we looked at (`~/.codex/config.toml` by default). */
+  configPath: string;
+  /** Whether the config file exists on disk. */
+  configExists: boolean;
+  /** Whether a `codex_hooks` key was found anywhere in `[features]`. */
+  keyPresent: boolean;
+  /** Parsed value when present, otherwise null. */
+  value: boolean | null;
+  /** Convenience: keyPresent && value === true. */
+  enabled: boolean;
+  /**
+   * One-line remediation the user can copy-paste. Empty when enabled.
+   * Currently a `codex exec --enable codex_hooks` hint rather than
+   * editing config.toml automatically (tokenjuice avoids silent
+   * config rewrites).
+   */
+  fixHint: string;
 };
 
 export type CodexHookCommandOptions = {
@@ -84,6 +105,94 @@ function getCodexHome(): string {
 function getDefaultHooksPath(): string {
   return join(getCodexHome(), "hooks.json");
 }
+
+function getDefaultCodexConfigPath(): string {
+  return join(getCodexHome(), "config.toml");
+}
+
+const FEATURE_FLAG_NAME = "codex_hooks";
+const FEATURE_FLAG_FIX_HINT =
+  "Codex requires the `codex_hooks` feature to load hooks.json. " +
+  "Enable per-invocation with `codex exec --enable codex_hooks ...`, " +
+  "or persistently by adding a `[features]` section with `codex_hooks = true` to ~/.codex/config.toml.";
+
+/**
+ * Read-only scan of ~/.codex/config.toml for `codex_hooks = <bool>` under
+ * a `[features]` section (top-level or dotted form). Does NOT edit the
+ * file — tokenjuice prefers to surface the state and let the user decide.
+ *
+ * Returns `keyPresent: false` if the file is missing, unreadable, or the
+ * key is not declared. Stray comments and inline `# ...` are tolerated.
+ */
+export async function inspectCodexHooksFeatureFlag(
+  configPath: string = getDefaultCodexConfigPath(),
+): Promise<CodexFeatureFlagStatus> {
+  let source: string;
+  try {
+    source = await readFile(configPath, "utf8");
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        configPath,
+        configExists: false,
+        keyPresent: false,
+        value: null,
+        enabled: false,
+        fixHint: FEATURE_FLAG_FIX_HINT,
+      };
+    }
+    throw error;
+  }
+
+  const parsed = parseCodexFeatureFlag(source, FEATURE_FLAG_NAME);
+  const enabled = parsed.keyPresent && parsed.value === true;
+  return {
+    configPath,
+    configExists: true,
+    keyPresent: parsed.keyPresent,
+    value: parsed.keyPresent ? parsed.value : null,
+    enabled,
+    fixHint: enabled ? "" : FEATURE_FLAG_FIX_HINT,
+  };
+}
+
+/**
+ * Minimal TOML-ish scanner. Looks for `codex_hooks = <bool>` either under
+ * a `[features]` header or as a dotted `features.codex_hooks = <bool>`
+ * assignment at any indent. Ignores comments and in-line comments.
+ * Not a full TOML parser; only the shapes Codex itself documents.
+ */
+export function parseCodexFeatureFlag(
+  source: string,
+  key: string,
+): { keyPresent: boolean; value: boolean | null } {
+  const lines = source.split(/\r?\n/u);
+  let inFeatures = false;
+  const dottedRe = new RegExp(`^\\s*features\\.${key}\\s*=\\s*(true|false)\\b`, "u");
+  const scopedRe = new RegExp(`^\\s*${key}\\s*=\\s*(true|false)\\b`, "u");
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/#.*$/u, "");
+    const header = /^\s*\[([^\]]+)\]/u.exec(line);
+    if (header) {
+      inFeatures = header[1]!.trim() === "features";
+      continue;
+    }
+    const dotted = dottedRe.exec(line);
+    if (dotted) {
+      return { keyPresent: true, value: dotted[1] === "true" };
+    }
+    if (inFeatures) {
+      const scoped = scopedRe.exec(line);
+      if (scoped) {
+        return { keyPresent: true, value: scoped[1] === "true" };
+      }
+    }
+  }
+
+  return { keyPresent: false, value: null };
+}
+
 
 function shellQuote(value: string): string {
   if (/^[A-Za-z0-9_./:-]+$/u.test(value)) {
@@ -488,10 +597,13 @@ export async function installCodexHook(
   await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
   await rename(tempPath, hooksPath);
 
+  const featureFlag = await inspectCodexHooksFeatureFlag();
+
   return {
     hooksPath,
     ...(backupPath ? { backupPath } : {}),
     command,
+    featureFlag,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,15 @@ export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts
 export { classifyExecution } from "./core/classify.js";
 export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook } from "./core/claude-code.js";
 export { normalizeCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";
-export { doctorCodexHook, installCodexHook, runCodexPostToolUseHook, uninstallCodexHook } from "./core/codex.js";
+export {
+  doctorCodexHook,
+  inspectCodexHooksFeatureFlag,
+  installCodexHook,
+  parseCodexFeatureFlag,
+  runCodexPostToolUseHook,
+  uninstallCodexHook,
+} from "./core/codex.js";
+export type { CodexFeatureFlagStatus } from "./core/codex.js";
 export { doctorInstalledHooks } from "./core/hook-doctor.js";
 export { doctorPiExtension, installPiExtension } from "./core/pi.js";
 export { runReduceJsonCli } from "./core/cli-client.js";

--- a/test/codex-feature-flag.test.ts
+++ b/test/codex-feature-flag.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  inspectCodexHooksFeatureFlag,
+  installCodexHook,
+  parseCodexFeatureFlag,
+} from "../src/core/codex.js";
+
+async function withTempCodexHome<T>(
+  fn: (paths: { hooksPath: string; configPath: string }) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "tj-codex-"));
+  try {
+    await mkdir(dir, { recursive: true });
+    return await fn({
+      hooksPath: join(dir, "hooks.json"),
+      configPath: join(dir, "config.toml"),
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("parseCodexFeatureFlag", () => {
+  it("returns keyPresent=false when file has no features section", () => {
+    expect(parseCodexFeatureFlag("[other]\nfoo = 1\n", "codex_hooks")).toEqual({
+      keyPresent: false,
+      value: null,
+    });
+  });
+
+  it("parses a scoped [features] section", () => {
+    const source = "[features]\ncodex_hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: true,
+      value: true,
+    });
+  });
+
+  it("parses explicit false", () => {
+    const source = "[features]\ncodex_hooks = false\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: true,
+      value: false,
+    });
+  });
+
+  it("parses dotted features.codex_hooks at top level", () => {
+    const source = "features.codex_hooks = true\n[other]\nfoo = 1\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: true,
+      value: true,
+    });
+  });
+
+  it("ignores the key when outside [features]", () => {
+    const source = "[other]\ncodex_hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: false,
+      value: null,
+    });
+  });
+
+  it("ignores commented-out assignments", () => {
+    const source = "[features]\n# codex_hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: false,
+      value: null,
+    });
+  });
+});
+
+describe("inspectCodexHooksFeatureFlag", () => {
+  it("reports configExists=false when the config is missing", async () => {
+    await withTempCodexHome(async ({ configPath }) => {
+      const status = await inspectCodexHooksFeatureFlag(configPath);
+      expect(status.configExists).toBe(false);
+      expect(status.keyPresent).toBe(false);
+      expect(status.value).toBe(null);
+      expect(status.enabled).toBe(false);
+      expect(status.fixHint).toContain("codex_hooks");
+    });
+  });
+
+  it("reports enabled=true when [features] codex_hooks = true", async () => {
+    await withTempCodexHome(async ({ configPath }) => {
+      await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");
+      const status = await inspectCodexHooksFeatureFlag(configPath);
+      expect(status.configExists).toBe(true);
+      expect(status.keyPresent).toBe(true);
+      expect(status.value).toBe(true);
+      expect(status.enabled).toBe(true);
+      expect(status.fixHint).toBe("");
+    });
+  });
+
+  it("reports enabled=false when codex_hooks is explicitly disabled", async () => {
+    await withTempCodexHome(async ({ configPath }) => {
+      await writeFile(configPath, "[features]\ncodex_hooks = false\n", "utf8");
+      const status = await inspectCodexHooksFeatureFlag(configPath);
+      expect(status.configExists).toBe(true);
+      expect(status.keyPresent).toBe(true);
+      expect(status.value).toBe(false);
+      expect(status.enabled).toBe(false);
+      expect(status.fixHint).toContain("codex_hooks");
+    });
+  });
+});
+
+describe("installCodexHook feature-flag surface", () => {
+  it("returns featureFlag.enabled=false when config.toml is missing", async () => {
+    await withTempCodexHome(async ({ hooksPath }) => {
+      const result = await installCodexHook(hooksPath);
+      expect(result.featureFlag.enabled).toBe(false);
+      expect(result.featureFlag.configExists).toBe(false);
+      expect(result.featureFlag.fixHint).toContain("codex_hooks");
+      // sanity: hooks.json was still written as usual
+      const hooks = JSON.parse(await readFile(hooksPath, "utf8"));
+      expect(hooks.hooks.PostToolUse).toBeDefined();
+    });
+  });
+});

--- a/test/codex-feature-flag.test.ts
+++ b/test/codex-feature-flag.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -72,6 +72,14 @@ describe("parseCodexFeatureFlag", () => {
       value: null,
     });
   });
+
+  it("ignores dotted assignments inside a non-root table", () => {
+    const source = "[profiles.default]\nfeatures.codex_hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+      keyPresent: false,
+      value: null,
+    });
+  });
 });
 
 describe("inspectCodexHooksFeatureFlag", () => {
@@ -109,18 +117,44 @@ describe("inspectCodexHooksFeatureFlag", () => {
       expect(status.fixHint).toContain("codex_hooks");
     });
   });
+
+  it("treats unreadable config as not enabled instead of throwing", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempCodexHome(async ({ configPath }) => {
+      await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");
+      try {
+        await chmod(configPath, 0o000);
+        const status = await inspectCodexHooksFeatureFlag(configPath);
+        expect(status.configExists).toBe(true);
+        expect(status.keyPresent).toBe(false);
+        expect(status.value).toBe(null);
+        expect(status.enabled).toBe(false);
+      } finally {
+        await chmod(configPath, 0o644);
+      }
+    });
+  });
 });
 
 describe("installCodexHook feature-flag surface", () => {
   it("returns featureFlag.enabled=false when config.toml is missing", async () => {
     await withTempCodexHome(async ({ hooksPath }) => {
-      const result = await installCodexHook(hooksPath);
-      expect(result.featureFlag.enabled).toBe(false);
-      expect(result.featureFlag.configExists).toBe(false);
-      expect(result.featureFlag.fixHint).toContain("codex_hooks");
-      // sanity: hooks.json was still written as usual
-      const hooks = JSON.parse(await readFile(hooksPath, "utf8"));
-      expect(hooks.hooks.PostToolUse).toBeDefined();
+      const previousCodexHome = process.env.CODEX_HOME;
+      process.env.CODEX_HOME = join(hooksPath, "..");
+      try {
+        const result = await installCodexHook(hooksPath);
+        expect(result.featureFlag.enabled).toBe(false);
+        expect(result.featureFlag.configExists).toBe(false);
+        expect(result.featureFlag.fixHint).toContain("codex_hooks");
+        // sanity: hooks.json was still written as usual
+        const hooks = JSON.parse(await readFile(hooksPath, "utf8"));
+        expect(hooks.hooks.PostToolUse).toBeDefined();
+      } finally {
+        process.env.CODEX_HOME = previousCodexHome;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

`tokenjuice install codex` writes `~/.codex/hooks.json`, but Codex does not
load `hooks.json` unless the `codex_hooks` feature flag is enabled. Current
behavior is a silent no-op: `doctor hooks` reports `ok`, install prints
success, and the first treatment run looks identical to baseline.

Measured in the tokenjuice phase 2 trial on 2026-04-19 — the first batch of
3 treatment runs produced zero token savings entirely because the flag was
off. Evidence archived at `~/tokenjuice-trial/codex/treatment-no-feature-flag/`.

## Approach

Read-only surfacing, no silent config rewrites. `tokenjuice install codex`
now prints one of:

```
feature flag: codex_hooks is enabled (/home/u/.codex/config.toml)
```

or

```
feature flag: codex_hooks not enabled — no /home/u/.codex/config.toml
   Codex requires the `codex_hooks` feature to load hooks.json. Enable
   per-invocation with `codex exec --enable codex_hooks ...`, or
   persistently by adding a `[features]` section with `codex_hooks = true`
   to ~/.codex/config.toml.
```

## What changed

- `inspectCodexHooksFeatureFlag()` + `parseCodexFeatureFlag()` in `src/core/codex.ts`.
  Conservative regex-based scanner — handles scoped `[features]` and dotted
  `features.codex_hooks` forms, tolerates comments, ignores assignments outside
  the section.
- `InstallCodexHookResult` gains a `featureFlag: CodexFeatureFlagStatus` field.
- CLI prints flag state + remediation directly after the install confirmation.
- Inspector + parser + status type re-exported from `src/index.ts` for
  downstream consumers.

## Tests

10 new tests in `test/codex-feature-flag.test.ts`:
- parser: scoped section, dotted form, explicit `false`, wrong section,
  commented-out line, absent key.
- inspector: missing file, enabled, disabled.
- install surface: `featureFlag.enabled=false` when no config present,
  hooks.json still written correctly.

201 / 201 tests pass. `pnpm build` green.

## Out of scope

- `doctor hooks` / `doctor codex` should surface the same signal — separate PR
  on its way so install output and doctor output agree.
- Auto-writing `[features]` to config.toml — deliberately deferred. Matches
  the repo's "no silent rewrite" posture; the error message points at the
  exact edit if the user wants persistence.
