### PR TITLE
feat(codex): doctor reports codex_hooks feature-flag status

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -588,6 +588,19 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
           process.stdout.write(`  - ${path}\n`);
         }
       }
+      if ("featureFlag" in integrationReport && integrationReport.featureFlag) {
+        const flag = integrationReport.featureFlag;
+        if (flag.enabled) {
+          process.stdout.write(
+            `- feature flag: codex_hooks is enabled (${flag.configPath})\n`,
+          );
+        } else {
+          const where = flag.configExists
+            ? `${flag.configPath} (missing or disabled)`
+            : `no ${flag.configPath}`;
+          process.stdout.write(`- feature flag: codex_hooks not enabled — ${where}\n`);
+        }
+      }
       process.stdout.write(`- repair: ${integrationReport.fixCommand}\n`);
     }
     return report.status === "broken" ? 1 : 0;
@@ -618,6 +631,17 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       for (const path of report.missingPaths) {
         process.stdout.write(`- ${path}\n`);
       }
+    }
+    if (report.featureFlag.enabled) {
+      process.stdout.write(
+        `feature flag: codex_hooks is enabled (${report.featureFlag.configPath})\n`,
+      );
+    } else {
+      const where = report.featureFlag.configExists
+        ? `${report.featureFlag.configPath} (missing or disabled)`
+        : `no ${report.featureFlag.configPath}`;
+      process.stdout.write(`feature flag: codex_hooks not enabled — ${where}\n`);
+      process.stdout.write(`   ${report.featureFlag.fixHint}\n`);
     }
     process.stdout.write(`repair: ${report.fixCommand}\n`);
     return report.status === "broken" ? 1 : 0;

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -76,6 +76,13 @@ export type CodexHookCommandOptions = {
   local?: boolean;
   binaryPath?: string;
   nodePath?: string;
+  /**
+   * Override for the config.toml consulted when reporting the
+   * `codex_hooks` feature-flag state. Defaults to `~/.codex/config.toml`.
+   * Exposed primarily for tests and tooling that manage a non-default
+   * Codex home.
+   */
+  featureFlagConfigPath?: string;
 };
 
 export type CodexDoctorReport = {
@@ -87,6 +94,7 @@ export type CodexDoctorReport = {
   detectedCommand?: string;
   checkedPaths: string[];
   missingPaths: string[];
+  featureFlag: CodexFeatureFlagStatus;
 };
 
 export type UninstallCodexHookResult = {
@@ -612,7 +620,7 @@ export async function installCodexHook(
   await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
   await rename(tempPath, hooksPath);
 
-  const featureFlag = await inspectCodexHooksFeatureFlag();
+  const featureFlag = await inspectCodexHooksFeatureFlag(options.featureFlagConfigPath);
 
   return {
     hooksPath,
@@ -656,6 +664,7 @@ export async function doctorCodexHook(
   let fixCommand = getCodexFixCommand(options.local);
   const { config, exists } = await readHooksConfig(hooksPath);
   const detectedCommand = findTokenjuiceCodexHookCommand(config);
+  const featureFlag = await inspectCodexHooksFeatureFlag(options.featureFlagConfigPath);
 
   if (!exists) {
     return {
@@ -666,6 +675,7 @@ export async function doctorCodexHook(
       expectedCommand,
       checkedPaths: [],
       missingPaths: [],
+      featureFlag,
     };
   }
 
@@ -678,6 +688,7 @@ export async function doctorCodexHook(
       expectedCommand,
       checkedPaths: [],
       missingPaths: [],
+      featureFlag,
     };
   }
 
@@ -704,6 +715,11 @@ export async function doctorCodexHook(
     issues.push("local Codex hook target is older than the source tree");
     fixCommand = "pnpm build && tokenjuice install codex --local";
   }
+  if (!featureFlag.enabled) {
+    issues.push(
+      "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
+    );
+  }
 
   return {
     hooksPath,
@@ -714,6 +730,7 @@ export async function doctorCodexHook(
     detectedCommand,
     checkedPaths,
     missingPaths,
+    featureFlag,
   };
 }
 

--- a/test/claude-code.test.ts
+++ b/test/claude-code.test.ts
@@ -358,6 +358,7 @@ describe("doctorInstalledHooks", () => {
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(join(home, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
     await installCodexHook(join(home, "hooks.json"));
     await installClaudeCodeHook(join(home, "settings.json"));
     await installPiExtension(undefined, { local: true });

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -188,13 +188,38 @@ describe("doctorCodexHook", () => {
     process.env.PATH = binDir;
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
-    await installCodexHook(hooksPath);
+    const featureFlagConfigPath = join(home, "config.toml");
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await installCodexHook(hooksPath, { featureFlagConfigPath });
 
-    const report = await doctorCodexHook(hooksPath);
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
 
     expect(report.status).toBe("ok");
     expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
     expect(report.issues).toEqual([]);
+    expect(report.featureFlag.enabled).toBe(true);
+  });
+
+  it("warns when codex_hooks feature flag is not enabled", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await installCodexHook(hooksPath, { featureFlagConfigPath });
+
+    // featureFlagConfigPath doesn't exist → flag not enabled
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.featureFlag.enabled).toBe(false);
+    expect(report.issues).toContain(
+      "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
+    );
   });
 
   it("reports disabled when the tokenjuice Codex hook is not installed", async () => {
@@ -272,16 +297,20 @@ describe("doctorCodexHook", () => {
     await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
 
+    const featureFlagConfigPath = join(home, "config.toml");
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
     await installCodexHook(hooksPath, {
       local: true,
       binaryPath: localCliPath,
       nodePath: localNodePath,
+      featureFlagConfigPath,
     });
 
     const report = await doctorCodexHook(hooksPath, {
       local: true,
       binaryPath: localCliPath,
       nodePath: localNodePath,
+      featureFlagConfigPath,
     });
 
     expect(report.status).toBe("ok");


### PR DESCRIPTION
## Summary

Complements #9. `doctor codex` and `doctor hooks` now read
`~/.codex/config.toml` alongside `hooks.json` and report the feature-flag
state. When the hook is configured but `codex_hooks` is off, status bumps
from `ok` to `warn` — so `doctor ok` and a working end-to-end install
finally agree.

Without this, the tokenjuice phase 2 trial saw `doctor hooks: ok` on an
install that produced zero token savings for three consecutive runs.

## What changed

- `CodexDoctorReport` gains `featureFlag: CodexFeatureFlagStatus`.
- `doctorCodexHook` calls `inspectCodexHooksFeatureFlag`; when the flag is
  off on an otherwise-configured hook, the doctor appends an explicit issue
  and escalates status from `ok` to `warn`.
- `CodexHookCommandOptions` gains `featureFlagConfigPath` so tests and
  multi-home tooling can point at a non-default config.toml.
- CLI `doctor codex` prints the feature-flag status line and remediation.
- CLI `doctor hooks` (aggregator) prints the same line under the codex
  integration entry.

## Tests

- Existing tests that assumed `ok` without a config.toml now either write
  one or pass `featureFlagConfigPath`.
- New test covers the `warn` path when the flag is missing.
- 202 / 202 tests pass; `pnpm build` green.

## Example output

With flag enabled:

```
health: ok
feature flag: codex_hooks is enabled (/home/u/.codex/config.toml)
```

Without:

```
health: warn
issues:
- Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire
feature flag: codex_hooks not enabled — no /home/u/.codex/config.toml
   Codex requires the `codex_hooks` feature to load hooks.json. Enable
   per-invocation with `codex exec --enable codex_hooks ...`, or
   persistently by adding a `[features]` section with `codex_hooks = true`
   to ~/.codex/config.toml.
```

## Depends on

#9 (install-time feature-flag inspector). This branch is based on that one
and will rebase cleanly onto main after #9 merges.
