### PR TITLE
fix(rules/git-status): emit "working tree clean" instead of empty output

### DIFF
--- a/src/rules/git/status.json
+++ b/src/rules/git/status.json
@@ -2,6 +2,7 @@
   "id": "git/status",
   "family": "git-status",
   "description": "Compact human-readable git status output.",
+  "onEmpty": "working tree clean",
   "match": {
     "argv0": ["git"],
     "argvIncludes": [["status"]]

--- a/test/reduce.test.ts
+++ b/test/reduce.test.ts
@@ -44,6 +44,32 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("?? new-file.ts");
   });
 
+  it("reports working tree clean instead of collapsing to empty output", async () => {
+    // Regression: every useful line in a clean long-form `git status` is
+    // matched by skipPatterns (branch, tracking, "nothing to commit..."),
+    // leaving zero lines. Without onEmpty, the reducer returns an empty
+    // summary and the agent reports "(no output)" even though the tree is
+    // clean. Observed in phase 2/3 tokenjuice trials — ~60% of runs
+    // misreported the clean state.
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git status",
+      argv: ["git", "status"],
+      combinedText: [
+        "On branch main",
+        "Your branch is up to date with 'origin/main'.",
+        "",
+        "nothing to commit, working tree clean",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/status");
+    expect(result.inlineText).toContain("working tree clean");
+    expect(result.inlineText).not.toContain("(no output)");
+  });
+
+
   it("derives argv from the command string when callers only pass command", async () => {
     const result = await reduceExecution({
       toolName: "exec",


### PR DESCRIPTION
## Summary

On a clean tree, long-form `git status` output is three lines
("On branch X", "Your branch is up to date", "nothing to commit, working
tree clean"). All three are matched by the reducer's `skipPatterns`, the
filter leaves zero content lines, and the reducer falls through with an
empty summary — which surfaces to the model as the empty passthrough.

## Observed impact

Phase 2 and phase 3 tokenjuice trials:

- ~60% of clean-run `git status` calls were misreported by the model as
  "produced no visible output" / "no output in this capture".
- In phase 2 Codex, that misreport triggered a `tokenjuice wrap --raw`
  escape-hatch retry in 27% of treatment runs, undoing the savings on
  that call and producing a bimodal token delta.

## Fix

The rule schema already supports `onEmpty` for exactly this case
(`install/npm-install.json` uses it with "npm install: ok"). Setting
it to "working tree clean" preserves the signal with a single short
string while keeping every other reduction path identical.

One line in `src/rules/git/status.json`:

```diff
   "description": "Compact human-readable git status output.",
+  "onEmpty": "working tree clean",
   "match": {
```

## Tests

- `test/reduce.test.ts` — regression asserting the long-form clean input
  produces `inlineText` containing "working tree clean" (and no longer an
  empty / "(no output)" passthrough).
- 192 / 192 tests pass; `pnpm build` green. Dirty-tree paths untouched
  — per-file counters + summary behavior unchanged.
