### PR TITLE
feat(rules): add swift build and test reducers

### DIFF
--- a/src/core/builtin-rules.generated.ts
+++ b/src/core/builtin-rules.generated.ts
@@ -5,200 +5,204 @@ import rule0 from "../rules/archive/tar.json" with { type: "json" };
 import rule1 from "../rules/archive/unzip.json" with { type: "json" };
 import rule2 from "../rules/archive/zip.json" with { type: "json" };
 import rule3 from "../rules/build/esbuild.json" with { type: "json" };
-import rule4 from "../rules/build/tsc.json" with { type: "json" };
-import rule5 from "../rules/build/tsdown.json" with { type: "json" };
-import rule6 from "../rules/build/vite.json" with { type: "json" };
-import rule7 from "../rules/build/webpack.json" with { type: "json" };
-import rule8 from "../rules/build/xcodebuild.json" with { type: "json" };
-import rule9 from "../rules/cloud/aws.json" with { type: "json" };
-import rule10 from "../rules/cloud/az.json" with { type: "json" };
-import rule11 from "../rules/cloud/flyctl.json" with { type: "json" };
-import rule12 from "../rules/cloud/gcloud.json" with { type: "json" };
-import rule13 from "../rules/cloud/gh.json" with { type: "json" };
-import rule14 from "../rules/cloud/vercel.json" with { type: "json" };
-import rule15 from "../rules/database/mongosh.json" with { type: "json" };
-import rule16 from "../rules/database/mysql.json" with { type: "json" };
-import rule17 from "../rules/database/psql.json" with { type: "json" };
-import rule18 from "../rules/database/redis-cli.json" with { type: "json" };
-import rule19 from "../rules/database/sqlite3.json" with { type: "json" };
-import rule20 from "../rules/devops/docker-build.json" with { type: "json" };
-import rule21 from "../rules/devops/docker-compose.json" with { type: "json" };
-import rule22 from "../rules/devops/docker-images.json" with { type: "json" };
-import rule23 from "../rules/devops/docker-logs.json" with { type: "json" };
-import rule24 from "../rules/devops/docker-ps.json" with { type: "json" };
-import rule25 from "../rules/devops/kubectl-describe.json" with { type: "json" };
-import rule26 from "../rules/devops/kubectl-get.json" with { type: "json" };
-import rule27 from "../rules/devops/kubectl-logs.json" with { type: "json" };
-import rule28 from "../rules/filesystem/find.json" with { type: "json" };
-import rule29 from "../rules/filesystem/ls.json" with { type: "json" };
-import rule30 from "../rules/generic/fallback.json" with { type: "json" };
-import rule31 from "../rules/generic/help.json" with { type: "json" };
-import rule32 from "../rules/git/branch.json" with { type: "json" };
-import rule33 from "../rules/git/diff-name-only.json" with { type: "json" };
-import rule34 from "../rules/git/diff-stat.json" with { type: "json" };
-import rule35 from "../rules/git/diff.json" with { type: "json" };
-import rule36 from "../rules/git/log-oneline.json" with { type: "json" };
-import rule37 from "../rules/git/remote-v.json" with { type: "json" };
-import rule38 from "../rules/git/show.json" with { type: "json" };
-import rule39 from "../rules/git/stash-list.json" with { type: "json" };
-import rule40 from "../rules/git/status.json" with { type: "json" };
-import rule41 from "../rules/install/bun-install.json" with { type: "json" };
-import rule42 from "../rules/install/npm-install.json" with { type: "json" };
-import rule43 from "../rules/install/pnpm-install.json" with { type: "json" };
-import rule44 from "../rules/install/yarn-install.json" with { type: "json" };
-import rule45 from "../rules/lint/biome.json" with { type: "json" };
-import rule46 from "../rules/lint/eslint.json" with { type: "json" };
-import rule47 from "../rules/lint/oxlint.json" with { type: "json" };
-import rule48 from "../rules/lint/prettier-check.json" with { type: "json" };
-import rule49 from "../rules/media/ffmpeg.json" with { type: "json" };
-import rule50 from "../rules/media/mediainfo.json" with { type: "json" };
-import rule51 from "../rules/network/curl.json" with { type: "json" };
-import rule52 from "../rules/network/dig.json" with { type: "json" };
-import rule53 from "../rules/network/nslookup.json" with { type: "json" };
-import rule54 from "../rules/network/ping.json" with { type: "json" };
-import rule55 from "../rules/network/ssh.json" with { type: "json" };
-import rule56 from "../rules/network/traceroute.json" with { type: "json" };
-import rule57 from "../rules/network/wget.json" with { type: "json" };
-import rule58 from "../rules/observability/free.json" with { type: "json" };
-import rule59 from "../rules/observability/htop.json" with { type: "json" };
-import rule60 from "../rules/observability/iostat.json" with { type: "json" };
-import rule61 from "../rules/observability/top.json" with { type: "json" };
-import rule62 from "../rules/observability/vmstat.json" with { type: "json" };
-import rule63 from "../rules/openclaw/sessions-history.json" with { type: "json" };
-import rule64 from "../rules/package/apt-install.json" with { type: "json" };
-import rule65 from "../rules/package/apt-upgrade.json" with { type: "json" };
-import rule66 from "../rules/package/brew-install.json" with { type: "json" };
-import rule67 from "../rules/package/brew-upgrade.json" with { type: "json" };
-import rule68 from "../rules/package/dnf-install.json" with { type: "json" };
-import rule69 from "../rules/package/yum-install.json" with { type: "json" };
-import rule70 from "../rules/search/git-grep.json" with { type: "json" };
-import rule71 from "../rules/search/grep.json" with { type: "json" };
-import rule72 from "../rules/search/rg.json" with { type: "json" };
-import rule73 from "../rules/service/journalctl.json" with { type: "json" };
-import rule74 from "../rules/service/launchctl.json" with { type: "json" };
-import rule75 from "../rules/service/lsof.json" with { type: "json" };
-import rule76 from "../rules/service/netstat.json" with { type: "json" };
-import rule77 from "../rules/service/service.json" with { type: "json" };
-import rule78 from "../rules/service/ss.json" with { type: "json" };
-import rule79 from "../rules/service/systemctl-status.json" with { type: "json" };
-import rule80 from "../rules/system/df.json" with { type: "json" };
-import rule81 from "../rules/system/du.json" with { type: "json" };
-import rule82 from "../rules/system/file.json" with { type: "json" };
-import rule83 from "../rules/system/ps.json" with { type: "json" };
-import rule84 from "../rules/task/just.json" with { type: "json" };
-import rule85 from "../rules/task/make.json" with { type: "json" };
-import rule86 from "../rules/tests/bun-test.json" with { type: "json" };
-import rule87 from "../rules/tests/cargo-test.json" with { type: "json" };
-import rule88 from "../rules/tests/go-test.json" with { type: "json" };
-import rule89 from "../rules/tests/jest.json" with { type: "json" };
-import rule90 from "../rules/tests/mocha.json" with { type: "json" };
-import rule91 from "../rules/tests/npm-test.json" with { type: "json" };
-import rule92 from "../rules/tests/playwright.json" with { type: "json" };
-import rule93 from "../rules/tests/pnpm-test.json" with { type: "json" };
-import rule94 from "../rules/tests/pytest.json" with { type: "json" };
-import rule95 from "../rules/tests/vitest.json" with { type: "json" };
-import rule96 from "../rules/tests/yarn-test.json" with { type: "json" };
-import rule97 from "../rules/transfer/rsync.json" with { type: "json" };
-import rule98 from "../rules/transfer/scp.json" with { type: "json" };
+import rule4 from "../rules/build/swift-build.json" with { type: "json" };
+import rule5 from "../rules/build/tsc.json" with { type: "json" };
+import rule6 from "../rules/build/tsdown.json" with { type: "json" };
+import rule7 from "../rules/build/vite.json" with { type: "json" };
+import rule8 from "../rules/build/webpack.json" with { type: "json" };
+import rule9 from "../rules/build/xcodebuild.json" with { type: "json" };
+import rule10 from "../rules/cloud/aws.json" with { type: "json" };
+import rule11 from "../rules/cloud/az.json" with { type: "json" };
+import rule12 from "../rules/cloud/flyctl.json" with { type: "json" };
+import rule13 from "../rules/cloud/gcloud.json" with { type: "json" };
+import rule14 from "../rules/cloud/gh.json" with { type: "json" };
+import rule15 from "../rules/cloud/vercel.json" with { type: "json" };
+import rule16 from "../rules/database/mongosh.json" with { type: "json" };
+import rule17 from "../rules/database/mysql.json" with { type: "json" };
+import rule18 from "../rules/database/psql.json" with { type: "json" };
+import rule19 from "../rules/database/redis-cli.json" with { type: "json" };
+import rule20 from "../rules/database/sqlite3.json" with { type: "json" };
+import rule21 from "../rules/devops/docker-build.json" with { type: "json" };
+import rule22 from "../rules/devops/docker-compose.json" with { type: "json" };
+import rule23 from "../rules/devops/docker-images.json" with { type: "json" };
+import rule24 from "../rules/devops/docker-logs.json" with { type: "json" };
+import rule25 from "../rules/devops/docker-ps.json" with { type: "json" };
+import rule26 from "../rules/devops/kubectl-describe.json" with { type: "json" };
+import rule27 from "../rules/devops/kubectl-get.json" with { type: "json" };
+import rule28 from "../rules/devops/kubectl-logs.json" with { type: "json" };
+import rule29 from "../rules/filesystem/find.json" with { type: "json" };
+import rule30 from "../rules/filesystem/ls.json" with { type: "json" };
+import rule31 from "../rules/generic/fallback.json" with { type: "json" };
+import rule32 from "../rules/generic/help.json" with { type: "json" };
+import rule33 from "../rules/git/branch.json" with { type: "json" };
+import rule34 from "../rules/git/diff-name-only.json" with { type: "json" };
+import rule35 from "../rules/git/diff-stat.json" with { type: "json" };
+import rule36 from "../rules/git/diff.json" with { type: "json" };
+import rule37 from "../rules/git/log-oneline.json" with { type: "json" };
+import rule38 from "../rules/git/remote-v.json" with { type: "json" };
+import rule39 from "../rules/git/show.json" with { type: "json" };
+import rule40 from "../rules/git/stash-list.json" with { type: "json" };
+import rule41 from "../rules/git/status.json" with { type: "json" };
+import rule42 from "../rules/install/bun-install.json" with { type: "json" };
+import rule43 from "../rules/install/npm-install.json" with { type: "json" };
+import rule44 from "../rules/install/pnpm-install.json" with { type: "json" };
+import rule45 from "../rules/install/yarn-install.json" with { type: "json" };
+import rule46 from "../rules/lint/biome.json" with { type: "json" };
+import rule47 from "../rules/lint/eslint.json" with { type: "json" };
+import rule48 from "../rules/lint/oxlint.json" with { type: "json" };
+import rule49 from "../rules/lint/prettier-check.json" with { type: "json" };
+import rule50 from "../rules/media/ffmpeg.json" with { type: "json" };
+import rule51 from "../rules/media/mediainfo.json" with { type: "json" };
+import rule52 from "../rules/network/curl.json" with { type: "json" };
+import rule53 from "../rules/network/dig.json" with { type: "json" };
+import rule54 from "../rules/network/nslookup.json" with { type: "json" };
+import rule55 from "../rules/network/ping.json" with { type: "json" };
+import rule56 from "../rules/network/ssh.json" with { type: "json" };
+import rule57 from "../rules/network/traceroute.json" with { type: "json" };
+import rule58 from "../rules/network/wget.json" with { type: "json" };
+import rule59 from "../rules/observability/free.json" with { type: "json" };
+import rule60 from "../rules/observability/htop.json" with { type: "json" };
+import rule61 from "../rules/observability/iostat.json" with { type: "json" };
+import rule62 from "../rules/observability/top.json" with { type: "json" };
+import rule63 from "../rules/observability/vmstat.json" with { type: "json" };
+import rule64 from "../rules/openclaw/sessions-history.json" with { type: "json" };
+import rule65 from "../rules/package/apt-install.json" with { type: "json" };
+import rule66 from "../rules/package/apt-upgrade.json" with { type: "json" };
+import rule67 from "../rules/package/brew-install.json" with { type: "json" };
+import rule68 from "../rules/package/brew-upgrade.json" with { type: "json" };
+import rule69 from "../rules/package/dnf-install.json" with { type: "json" };
+import rule70 from "../rules/package/yum-install.json" with { type: "json" };
+import rule71 from "../rules/search/git-grep.json" with { type: "json" };
+import rule72 from "../rules/search/grep.json" with { type: "json" };
+import rule73 from "../rules/search/rg.json" with { type: "json" };
+import rule74 from "../rules/service/journalctl.json" with { type: "json" };
+import rule75 from "../rules/service/launchctl.json" with { type: "json" };
+import rule76 from "../rules/service/lsof.json" with { type: "json" };
+import rule77 from "../rules/service/netstat.json" with { type: "json" };
+import rule78 from "../rules/service/service.json" with { type: "json" };
+import rule79 from "../rules/service/ss.json" with { type: "json" };
+import rule80 from "../rules/service/systemctl-status.json" with { type: "json" };
+import rule81 from "../rules/system/df.json" with { type: "json" };
+import rule82 from "../rules/system/du.json" with { type: "json" };
+import rule83 from "../rules/system/file.json" with { type: "json" };
+import rule84 from "../rules/system/ps.json" with { type: "json" };
+import rule85 from "../rules/task/just.json" with { type: "json" };
+import rule86 from "../rules/task/make.json" with { type: "json" };
+import rule87 from "../rules/tests/bun-test.json" with { type: "json" };
+import rule88 from "../rules/tests/cargo-test.json" with { type: "json" };
+import rule89 from "../rules/tests/go-test.json" with { type: "json" };
+import rule90 from "../rules/tests/jest.json" with { type: "json" };
+import rule91 from "../rules/tests/mocha.json" with { type: "json" };
+import rule92 from "../rules/tests/npm-test.json" with { type: "json" };
+import rule93 from "../rules/tests/playwright.json" with { type: "json" };
+import rule94 from "../rules/tests/pnpm-test.json" with { type: "json" };
+import rule95 from "../rules/tests/pytest.json" with { type: "json" };
+import rule96 from "../rules/tests/swift-test.json" with { type: "json" };
+import rule97 from "../rules/tests/vitest.json" with { type: "json" };
+import rule98 from "../rules/tests/yarn-test.json" with { type: "json" };
+import rule99 from "../rules/transfer/rsync.json" with { type: "json" };
+import rule100 from "../rules/transfer/scp.json" with { type: "json" };
 
 export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule0 as JsonRule, // rules/archive/tar.json
   rule1 as JsonRule, // rules/archive/unzip.json
   rule2 as JsonRule, // rules/archive/zip.json
   rule3 as JsonRule, // rules/build/esbuild.json
-  rule4 as JsonRule, // rules/build/tsc.json
-  rule5 as JsonRule, // rules/build/tsdown.json
-  rule6 as JsonRule, // rules/build/vite.json
-  rule7 as JsonRule, // rules/build/webpack.json
-  rule8 as JsonRule, // rules/build/xcodebuild.json
-  rule9 as JsonRule, // rules/cloud/aws.json
-  rule10 as JsonRule, // rules/cloud/az.json
-  rule11 as JsonRule, // rules/cloud/flyctl.json
-  rule12 as JsonRule, // rules/cloud/gcloud.json
-  rule13 as JsonRule, // rules/cloud/gh.json
-  rule14 as JsonRule, // rules/cloud/vercel.json
-  rule15 as JsonRule, // rules/database/mongosh.json
-  rule16 as JsonRule, // rules/database/mysql.json
-  rule17 as JsonRule, // rules/database/psql.json
-  rule18 as JsonRule, // rules/database/redis-cli.json
-  rule19 as JsonRule, // rules/database/sqlite3.json
-  rule20 as JsonRule, // rules/devops/docker-build.json
-  rule21 as JsonRule, // rules/devops/docker-compose.json
-  rule22 as JsonRule, // rules/devops/docker-images.json
-  rule23 as JsonRule, // rules/devops/docker-logs.json
-  rule24 as JsonRule, // rules/devops/docker-ps.json
-  rule25 as JsonRule, // rules/devops/kubectl-describe.json
-  rule26 as JsonRule, // rules/devops/kubectl-get.json
-  rule27 as JsonRule, // rules/devops/kubectl-logs.json
-  rule28 as JsonRule, // rules/filesystem/find.json
-  rule29 as JsonRule, // rules/filesystem/ls.json
-  rule30 as JsonRule, // rules/generic/fallback.json
-  rule31 as JsonRule, // rules/generic/help.json
-  rule32 as JsonRule, // rules/git/branch.json
-  rule33 as JsonRule, // rules/git/diff-name-only.json
-  rule34 as JsonRule, // rules/git/diff-stat.json
-  rule35 as JsonRule, // rules/git/diff.json
-  rule36 as JsonRule, // rules/git/log-oneline.json
-  rule37 as JsonRule, // rules/git/remote-v.json
-  rule38 as JsonRule, // rules/git/show.json
-  rule39 as JsonRule, // rules/git/stash-list.json
-  rule40 as JsonRule, // rules/git/status.json
-  rule41 as JsonRule, // rules/install/bun-install.json
-  rule42 as JsonRule, // rules/install/npm-install.json
-  rule43 as JsonRule, // rules/install/pnpm-install.json
-  rule44 as JsonRule, // rules/install/yarn-install.json
-  rule45 as JsonRule, // rules/lint/biome.json
-  rule46 as JsonRule, // rules/lint/eslint.json
-  rule47 as JsonRule, // rules/lint/oxlint.json
-  rule48 as JsonRule, // rules/lint/prettier-check.json
-  rule49 as JsonRule, // rules/media/ffmpeg.json
-  rule50 as JsonRule, // rules/media/mediainfo.json
-  rule51 as JsonRule, // rules/network/curl.json
-  rule52 as JsonRule, // rules/network/dig.json
-  rule53 as JsonRule, // rules/network/nslookup.json
-  rule54 as JsonRule, // rules/network/ping.json
-  rule55 as JsonRule, // rules/network/ssh.json
-  rule56 as JsonRule, // rules/network/traceroute.json
-  rule57 as JsonRule, // rules/network/wget.json
-  rule58 as JsonRule, // rules/observability/free.json
-  rule59 as JsonRule, // rules/observability/htop.json
-  rule60 as JsonRule, // rules/observability/iostat.json
-  rule61 as JsonRule, // rules/observability/top.json
-  rule62 as JsonRule, // rules/observability/vmstat.json
-  rule63 as JsonRule, // rules/openclaw/sessions-history.json
-  rule64 as JsonRule, // rules/package/apt-install.json
-  rule65 as JsonRule, // rules/package/apt-upgrade.json
-  rule66 as JsonRule, // rules/package/brew-install.json
-  rule67 as JsonRule, // rules/package/brew-upgrade.json
-  rule68 as JsonRule, // rules/package/dnf-install.json
-  rule69 as JsonRule, // rules/package/yum-install.json
-  rule70 as JsonRule, // rules/search/git-grep.json
-  rule71 as JsonRule, // rules/search/grep.json
-  rule72 as JsonRule, // rules/search/rg.json
-  rule73 as JsonRule, // rules/service/journalctl.json
-  rule74 as JsonRule, // rules/service/launchctl.json
-  rule75 as JsonRule, // rules/service/lsof.json
-  rule76 as JsonRule, // rules/service/netstat.json
-  rule77 as JsonRule, // rules/service/service.json
-  rule78 as JsonRule, // rules/service/ss.json
-  rule79 as JsonRule, // rules/service/systemctl-status.json
-  rule80 as JsonRule, // rules/system/df.json
-  rule81 as JsonRule, // rules/system/du.json
-  rule82 as JsonRule, // rules/system/file.json
-  rule83 as JsonRule, // rules/system/ps.json
-  rule84 as JsonRule, // rules/task/just.json
-  rule85 as JsonRule, // rules/task/make.json
-  rule86 as JsonRule, // rules/tests/bun-test.json
-  rule87 as JsonRule, // rules/tests/cargo-test.json
-  rule88 as JsonRule, // rules/tests/go-test.json
-  rule89 as JsonRule, // rules/tests/jest.json
-  rule90 as JsonRule, // rules/tests/mocha.json
-  rule91 as JsonRule, // rules/tests/npm-test.json
-  rule92 as JsonRule, // rules/tests/playwright.json
-  rule93 as JsonRule, // rules/tests/pnpm-test.json
-  rule94 as JsonRule, // rules/tests/pytest.json
-  rule95 as JsonRule, // rules/tests/vitest.json
-  rule96 as JsonRule, // rules/tests/yarn-test.json
-  rule97 as JsonRule, // rules/transfer/rsync.json
-  rule98 as JsonRule, // rules/transfer/scp.json
+  rule4 as JsonRule, // rules/build/swift-build.json
+  rule5 as JsonRule, // rules/build/tsc.json
+  rule6 as JsonRule, // rules/build/tsdown.json
+  rule7 as JsonRule, // rules/build/vite.json
+  rule8 as JsonRule, // rules/build/webpack.json
+  rule9 as JsonRule, // rules/build/xcodebuild.json
+  rule10 as JsonRule, // rules/cloud/aws.json
+  rule11 as JsonRule, // rules/cloud/az.json
+  rule12 as JsonRule, // rules/cloud/flyctl.json
+  rule13 as JsonRule, // rules/cloud/gcloud.json
+  rule14 as JsonRule, // rules/cloud/gh.json
+  rule15 as JsonRule, // rules/cloud/vercel.json
+  rule16 as JsonRule, // rules/database/mongosh.json
+  rule17 as JsonRule, // rules/database/mysql.json
+  rule18 as JsonRule, // rules/database/psql.json
+  rule19 as JsonRule, // rules/database/redis-cli.json
+  rule20 as JsonRule, // rules/database/sqlite3.json
+  rule21 as JsonRule, // rules/devops/docker-build.json
+  rule22 as JsonRule, // rules/devops/docker-compose.json
+  rule23 as JsonRule, // rules/devops/docker-images.json
+  rule24 as JsonRule, // rules/devops/docker-logs.json
+  rule25 as JsonRule, // rules/devops/docker-ps.json
+  rule26 as JsonRule, // rules/devops/kubectl-describe.json
+  rule27 as JsonRule, // rules/devops/kubectl-get.json
+  rule28 as JsonRule, // rules/devops/kubectl-logs.json
+  rule29 as JsonRule, // rules/filesystem/find.json
+  rule30 as JsonRule, // rules/filesystem/ls.json
+  rule31 as JsonRule, // rules/generic/fallback.json
+  rule32 as JsonRule, // rules/generic/help.json
+  rule33 as JsonRule, // rules/git/branch.json
+  rule34 as JsonRule, // rules/git/diff-name-only.json
+  rule35 as JsonRule, // rules/git/diff-stat.json
+  rule36 as JsonRule, // rules/git/diff.json
+  rule37 as JsonRule, // rules/git/log-oneline.json
+  rule38 as JsonRule, // rules/git/remote-v.json
+  rule39 as JsonRule, // rules/git/show.json
+  rule40 as JsonRule, // rules/git/stash-list.json
+  rule41 as JsonRule, // rules/git/status.json
+  rule42 as JsonRule, // rules/install/bun-install.json
+  rule43 as JsonRule, // rules/install/npm-install.json
+  rule44 as JsonRule, // rules/install/pnpm-install.json
+  rule45 as JsonRule, // rules/install/yarn-install.json
+  rule46 as JsonRule, // rules/lint/biome.json
+  rule47 as JsonRule, // rules/lint/eslint.json
+  rule48 as JsonRule, // rules/lint/oxlint.json
+  rule49 as JsonRule, // rules/lint/prettier-check.json
+  rule50 as JsonRule, // rules/media/ffmpeg.json
+  rule51 as JsonRule, // rules/media/mediainfo.json
+  rule52 as JsonRule, // rules/network/curl.json
+  rule53 as JsonRule, // rules/network/dig.json
+  rule54 as JsonRule, // rules/network/nslookup.json
+  rule55 as JsonRule, // rules/network/ping.json
+  rule56 as JsonRule, // rules/network/ssh.json
+  rule57 as JsonRule, // rules/network/traceroute.json
+  rule58 as JsonRule, // rules/network/wget.json
+  rule59 as JsonRule, // rules/observability/free.json
+  rule60 as JsonRule, // rules/observability/htop.json
+  rule61 as JsonRule, // rules/observability/iostat.json
+  rule62 as JsonRule, // rules/observability/top.json
+  rule63 as JsonRule, // rules/observability/vmstat.json
+  rule64 as JsonRule, // rules/openclaw/sessions-history.json
+  rule65 as JsonRule, // rules/package/apt-install.json
+  rule66 as JsonRule, // rules/package/apt-upgrade.json
+  rule67 as JsonRule, // rules/package/brew-install.json
+  rule68 as JsonRule, // rules/package/brew-upgrade.json
+  rule69 as JsonRule, // rules/package/dnf-install.json
+  rule70 as JsonRule, // rules/package/yum-install.json
+  rule71 as JsonRule, // rules/search/git-grep.json
+  rule72 as JsonRule, // rules/search/grep.json
+  rule73 as JsonRule, // rules/search/rg.json
+  rule74 as JsonRule, // rules/service/journalctl.json
+  rule75 as JsonRule, // rules/service/launchctl.json
+  rule76 as JsonRule, // rules/service/lsof.json
+  rule77 as JsonRule, // rules/service/netstat.json
+  rule78 as JsonRule, // rules/service/service.json
+  rule79 as JsonRule, // rules/service/ss.json
+  rule80 as JsonRule, // rules/service/systemctl-status.json
+  rule81 as JsonRule, // rules/system/df.json
+  rule82 as JsonRule, // rules/system/du.json
+  rule83 as JsonRule, // rules/system/file.json
+  rule84 as JsonRule, // rules/system/ps.json
+  rule85 as JsonRule, // rules/task/just.json
+  rule86 as JsonRule, // rules/task/make.json
+  rule87 as JsonRule, // rules/tests/bun-test.json
+  rule88 as JsonRule, // rules/tests/cargo-test.json
+  rule89 as JsonRule, // rules/tests/go-test.json
+  rule90 as JsonRule, // rules/tests/jest.json
+  rule91 as JsonRule, // rules/tests/mocha.json
+  rule92 as JsonRule, // rules/tests/npm-test.json
+  rule93 as JsonRule, // rules/tests/playwright.json
+  rule94 as JsonRule, // rules/tests/pnpm-test.json
+  rule95 as JsonRule, // rules/tests/pytest.json
+  rule96 as JsonRule, // rules/tests/swift-test.json
+  rule97 as JsonRule, // rules/tests/vitest.json
+  rule98 as JsonRule, // rules/tests/yarn-test.json
+  rule99 as JsonRule, // rules/transfer/rsync.json
+  rule100 as JsonRule, // rules/transfer/scp.json
 ];

--- a/src/rules/build/swift-build.json
+++ b/src/rules/build/swift-build.json
@@ -1,0 +1,56 @@
+{
+  "id": "build/swift-build",
+  "family": "build",
+  "description": "Compact swift build output while preserving compile diagnostics, contention messages, and final build status.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["swift"],
+    "argvIncludes": [["build"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\[\\d+/\\d+\\]\\s+.+$",
+      "^Building for .+\\.\\.\\.$",
+      "^Planning build$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^Another instance of SwiftPM.+$",
+      "^Build complete!.+$",
+      "^Build complete!$",
+      "^Build failed.+$"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    }
+  ]
+}

--- a/src/rules/fixtures/build/swift-build.fixture.json
+++ b/src/rules/fixtures/build/swift-build.fixture.json
@@ -1,0 +1,29 @@
+{
+  "id": "build-swift-build-failure-basic",
+  "ruleId": "build/swift-build",
+  "input": {
+    "toolName": "exec",
+    "argv": ["swift", "build"],
+    "command": "swift build",
+    "combinedText": "[0/1] Planning build\nBuilding for debugging...\n[0/5] Write sources\n[1/5] Write swift-version--A1B2C3.txt\n[3/5] Emitting module TokenJuice\n/repo/Sources/App/main.swift:18:7: warning: initialization of immutable value 'unused' was never used; consider replacing with assignment to '_' or removing it\n/repo/Sources/App/main.swift:22:18: error: cannot find 'missingSymbol' in scope\nerror: emit-module command failed with exit code 1 (use -v to see invocation)\n",
+    "exitCode": 1
+  },
+  "expect": {
+    "matchedReducer": "build/swift-build",
+    "family": "build",
+    "facts": {
+      "error": 2,
+      "warning": 1
+    },
+    "contains": [
+      "exit 1",
+      "/repo/Sources/App/main.swift:18:7: warning: initialization of immutable value 'unused' was never used",
+      "/repo/Sources/App/main.swift:22:18: error: cannot find 'missingSymbol' in scope",
+      "error: emit-module command failed with exit code 1"
+    ],
+    "excludes": [
+      "[3/5] Emitting module TokenJuice",
+      "Building for debugging..."
+    ]
+  }
+}

--- a/src/rules/fixtures/tests/swift-test.fixture.json
+++ b/src/rules/fixtures/tests/swift-test.fixture.json
@@ -1,0 +1,30 @@
+{
+  "id": "tests-swift-test-failure-basic",
+  "ruleId": "tests/swift-test",
+  "input": {
+    "toolName": "exec",
+    "argv": ["swift", "test"],
+    "command": "swift test",
+    "combinedText": "[0/1] Planning build\nBuilding for debugging...\n[0/4] Write sources\n[1/4] Write swift-version--1A2B3C.txt\n[3/6] Compiling TokenTests ParserTests.swift\n/repo/Tests/ParserTests.swift:12: error: ParserTests.testParseNumber : XCTAssertEqual failed: (\"41\") is not equal to (\"42\") - parser should keep the last digit\nTest Case '-[TokenTests.ParserTests testParseNumber]' failed (0.014 seconds)\nTest Suite 'ParserTests' failed at 2026-04-19 19:40:12.345.\n\tExecuted 2 tests, with 1 failure (0 unexpected) in 0.014 (0.015) seconds\nTest Suite 'All tests' failed at 2026-04-19 19:40:12.345.\n\tExecuted 2 tests, with 1 failure (0 unexpected) in 0.014 (0.015) seconds\n",
+    "exitCode": 1
+  },
+  "expect": {
+    "matchedReducer": "tests/swift-test",
+    "family": "test-results",
+    "facts": {
+      "error": 1,
+      "failed test": 1
+    },
+    "contains": [
+      "exit 1",
+      "failed test",
+      "/repo/Tests/ParserTests.swift:12: error: ParserTests.testParseNumber : XCTAssertEqual failed: (\"41\") is not equal to (\"42\") - parser should keep the last digit",
+      "Test Case '-[TokenTests.ParserTests testParseNumber]' failed (0.014 seconds)",
+      "Executed 2 tests, with 1 failure"
+    ],
+    "excludes": [
+      "[3/6] Compiling TokenTests ParserTests.swift",
+      "Building for debugging..."
+    ]
+  }
+}

--- a/src/rules/tests/swift-test.json
+++ b/src/rules/tests/swift-test.json
@@ -1,0 +1,66 @@
+{
+  "id": "tests/swift-test",
+  "family": "test-results",
+  "description": "Compact swift test output while preserving compile diagnostics, failing tests, and final summaries.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["swift"],
+    "argvIncludes": [["test"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^\\[\\d+/\\d+\\]\\s+.+$",
+      "^Building for .+\\.\\.\\.$",
+      "^Planning build$",
+      "^Test Case '.+' started\\.$",
+      "^Test Case '.+' passed .+$",
+      "^Test Suite '.+' started at .+$"
+    ],
+    "keepPatterns": [
+      "^.+:\\d+:\\d+: error: .+",
+      "^.+:\\d+:\\d+: warning: .+",
+      "^.+:\\d+: error: .+",
+      "^.+:\\d+: warning: .+",
+      "^error: .+",
+      "^warning: .+",
+      "^note: .+",
+      "^Test Case '.+' failed .+$",
+      "^Test Suite '.+' failed at .+$",
+      "^\\s*Executed \\d+ tests?, with \\d+ failures?.+$",
+      "^Test run with .+ failed.+$",
+      "^[✘✖✗] .+$",
+      "^.+(?:Assertion|Expectation) failed:.+$"
+    ]
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 16
+  },
+  "counters": [
+    {
+      "name": "error",
+      "pattern": "error",
+      "flags": "i"
+    },
+    {
+      "name": "warning",
+      "pattern": "warning",
+      "flags": "i"
+    },
+    {
+      "name": "failed test",
+      "pattern": "(?:^Test Case '.+' failed .+$|^[✘✖✗] .+$)",
+      "flags": "m"
+    }
+  ]
+}

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -46,6 +46,7 @@ describe("rules", () => {
       "archive/unzip",
       "archive/zip",
       "build/esbuild",
+      "build/swift-build",
       "build/tsc",
       "build/tsdown",
       "build/vite",
@@ -136,6 +137,7 @@ describe("rules", () => {
       "tests/playwright",
       "tests/pnpm-test",
       "tests/pytest",
+      "tests/swift-test",
       "tests/vitest",
       "tests/yarn-test",
       "transfer/rsync",
@@ -155,7 +157,7 @@ describe("rules", () => {
 
   it("loads builtin fixtures successfully", async () => {
     const fixtures = await loadBuiltinFixtures();
-    expect(fixtures).toHaveLength(103);
+    expect(fixtures).toHaveLength(105);
   });
 
   it("keeps builtin fixture inventory aligned with builtin rules", async () => {


### PR DESCRIPTION
## Summary
- add builtin reducers for `swift build` and `swift test`
- add fixture coverage for both reducers and update rule inventory expectations
- regenerate bundled builtin rules

## Validation
- `pnpm test test/rules.test.ts`
- `pnpm test test/reduce.test.ts test/rules.test.ts`
- `pnpm exec tsc --noEmit`

## Manual check
- compared OpenClaw macOS `swift build` and `swift test` logs with and without the new reducers
- additional estimated savings from the new reducers: ~219 tokens
