### PR TITLE
Fix Windows hook command handling

### DIFF
--- a/src/core/claude-code.ts
+++ b/src/core/claude-code.ts
@@ -3,6 +3,7 @@ import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
 import { homedir } from "node:os";
 
+import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "./hook-command.js";
 import { compactBashResult } from "./integrations/compact-bash-result.js";
 
 import type { CompactResult, ReduceOptions } from "../types.js";
@@ -64,13 +65,6 @@ function getClaudeCodeHome(): string {
 
 function getDefaultSettingsPath(): string {
   return join(getClaudeCodeHome(), "settings.json");
-}
-
-function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:-]+$/u.test(value)) {
-    return value;
-  }
-  return `'${value.replace(/'/gu, `'\\''`)}'`;
 }
 
 async function isExecutableFile(path: string): Promise<boolean> {
@@ -196,76 +190,6 @@ function findTokenjuiceClaudeCodeHookCommand(config: ClaudeCodeSettings): string
   }
 
   return undefined;
-}
-
-function parseShellWords(command: string): string[] {
-  const words: string[] = [];
-  let current = "";
-  let quote: "'" | "\"" | null = null;
-  let escaping = false;
-
-  for (const char of command) {
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
-    }
-
-    if (char === "\\") {
-      escaping = true;
-      continue;
-    }
-
-    if (quote) {
-      if (char === quote) {
-        quote = null;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-
-    if (char === "'" || char === "\"") {
-      quote = char;
-      continue;
-    }
-
-    if (/\s/u.test(char)) {
-      if (current) {
-        words.push(current);
-        current = "";
-      }
-      continue;
-    }
-
-    current += char;
-  }
-
-  if (current) {
-    words.push(current);
-  }
-
-  return words;
-}
-
-function extractHookCommandPaths(command: string): string[] {
-  const argv = parseShellWords(command);
-  if (argv.length === 0) {
-    return [];
-  }
-
-  const paths = new Set<string>();
-  const first = argv[0];
-  if (first && (first.includes("/") || first.includes("\\"))) {
-    paths.add(first);
-  }
-
-  const second = argv[1];
-  if (first && second && (first.endsWith("/node") || first.endsWith("\\node.exe")) && second.endsWith(".js")) {
-    paths.add(second);
-  }
-
-  return [...paths];
 }
 
 function sanitizeHooksSubtree(raw: unknown): Record<string, unknown> {
@@ -437,7 +361,7 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
     wrapIndex = 1;
   } else if (
     typeof first === "string"
-    && first.endsWith("/node")
+    && isNodeExecutablePath(first)
     && typeof second === "string"
     && second.endsWith(".js")
     && argv.slice(1).some((part) => part.includes("tokenjuice"))

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -5,6 +5,7 @@ import { homedir } from "node:os";
 import packageJson from "../../package.json" with { type: "json" };
 
 import { isRepositoryInspectionCommand } from "./command.js";
+import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "./hook-command.js";
 import { compactBashResult } from "./integrations/compact-bash-result.js";
 import { classifyOnly } from "./reduce.js";
 import { storeArtifactMetadata } from "./artifacts.js";
@@ -83,13 +84,6 @@ function getCodexHome(): string {
 
 function getDefaultHooksPath(): string {
   return join(getCodexHome(), "hooks.json");
-}
-
-function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_./:-]+$/u.test(value)) {
-    return value;
-  }
-  return `'${value.replace(/'/gu, `'\\''`)}'`;
 }
 
 async function isExecutableFile(path: string): Promise<boolean> {
@@ -362,76 +356,6 @@ async function readHooksConfig(hooksPath: string): Promise<{ config: CodexHooksC
   }
 }
 
-function parseShellWords(command: string): string[] {
-  const words: string[] = [];
-  let current = "";
-  let quote: "'" | "\"" | null = null;
-  let escaping = false;
-
-  for (const char of command) {
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
-    }
-
-    if (char === "\\") {
-      escaping = true;
-      continue;
-    }
-
-    if (quote) {
-      if (char === quote) {
-        quote = null;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-
-    if (char === "'" || char === "\"") {
-      quote = char;
-      continue;
-    }
-
-    if (/\s/u.test(char)) {
-      if (current) {
-        words.push(current);
-        current = "";
-      }
-      continue;
-    }
-
-    current += char;
-  }
-
-  if (current) {
-    words.push(current);
-  }
-
-  return words;
-}
-
-function extractHookCommandPaths(command: string): string[] {
-  const argv = parseShellWords(command);
-  if (argv.length === 0) {
-    return [];
-  }
-
-  const paths = new Set<string>();
-  const first = argv[0];
-  if (first && (first.includes("/") || first.includes("\\"))) {
-    paths.add(first);
-  }
-
-  const second = argv[1];
-  if (first && second && (first.endsWith("/node") || first.endsWith("\\node.exe")) && second.endsWith(".js")) {
-    paths.add(second);
-  }
-
-  return [...paths];
-}
-
 function commandRequestsTokenjuiceRawBypass(command: string): boolean {
   const argv = parseShellWords(command);
   if (argv.length < 3) {
@@ -445,7 +369,7 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
     wrapIndex = 1;
   } else if (
     typeof first === "string"
-    && first.endsWith("/node")
+    && isNodeExecutablePath(first)
     && typeof second === "string"
     && second.endsWith(".js")
     && argv.slice(1).some((part) => part.includes("tokenjuice"))

--- a/src/core/hook-command.ts
+++ b/src/core/hook-command.ts
@@ -1,0 +1,116 @@
+const POSIX_SAFE_SHELL_WORD = /^[A-Za-z0-9_./:-]+$/u;
+const WINDOWS_SAFE_SHELL_WORD = /^[A-Za-z0-9_./:\\-]+$/u;
+
+function isTokenjuiceExecutablePath(value: string): boolean {
+  return /(?:^|[\\/])tokenjuice(?:\.(?:exe|cmd|bat))?$/iu.test(value);
+}
+
+function isHookExecutablePath(value: string): boolean {
+  return isNodeExecutablePath(value) || isTokenjuiceExecutablePath(value);
+}
+
+function coalesceLeadingWindowsExecutable(words: string[]): string[] {
+  if (words.length < 2 || isHookExecutablePath(words[0] ?? "")) {
+    return words;
+  }
+
+  for (let index = 1; index < words.length; index += 1) {
+    const candidate = words.slice(0, index + 1).join(" ");
+    if (isHookExecutablePath(candidate)) {
+      return [candidate, ...words.slice(index + 1)];
+    }
+  }
+
+  return words;
+}
+
+export function shellQuote(value: string, platform = process.platform): string {
+  const safePattern = platform === "win32" ? WINDOWS_SAFE_SHELL_WORD : POSIX_SAFE_SHELL_WORD;
+  if (safePattern.test(value)) {
+    return value;
+  }
+
+  if (platform === "win32") {
+    return `"${value}"`;
+  }
+
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+export function parseShellWords(command: string, platform = process.platform): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+
+  for (const char of command) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (platform !== "win32" && char === "\\") {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/u.test(char)) {
+      if (current) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+
+  if (current) {
+    words.push(current);
+  }
+
+  return platform === "win32" ? coalesceLeadingWindowsExecutable(words) : words;
+}
+
+export function isNodeExecutablePath(value: string): boolean {
+  return /(?:^|[\\/])node(?:\.exe)?$/iu.test(value);
+}
+
+export function extractHookCommandPaths(command: string, platform = process.platform): string[] {
+  const argv = parseShellWords(command, platform);
+  if (argv.length === 0) {
+    return [];
+  }
+
+  const paths = new Set<string>();
+  const first = argv[0];
+  if (first && (first.includes("/") || first.includes("\\"))) {
+    paths.add(first);
+  }
+
+  const second = argv[1];
+  if (first && second && isNodeExecutablePath(first) && second.endsWith(".js")) {
+    paths.add(second);
+  }
+
+  return [...paths];
+}

--- a/test/hook-command.test.ts
+++ b/test/hook-command.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { extractHookCommandPaths, parseShellWords, shellQuote } from "../src/core/hook-command.js";
+
+describe("shellQuote", () => {
+  it("leaves unspaced Windows paths unquoted", () => {
+    expect(shellQuote(String.raw`C:\Users\andre\bin\tokenjuice.exe`, "win32")).toBe(
+      String.raw`C:\Users\andre\bin\tokenjuice.exe`,
+    );
+  });
+
+  it("wraps spaced Windows paths in double quotes", () => {
+    expect(shellQuote(String.raw`C:\Program Files\nodejs\node.exe`, "win32")).toBe(
+      `"${String.raw`C:\Program Files\nodejs\node.exe`}"`,
+    );
+  });
+});
+
+describe("parseShellWords", () => {
+  it("preserves backslashes in unquoted Windows launcher commands", () => {
+    expect(parseShellWords(String.raw`C:\Users\andre\bin\tokenjuice.exe codex-post-tool-use`, "win32")).toEqual([
+      String.raw`C:\Users\andre\bin\tokenjuice.exe`,
+      "codex-post-tool-use",
+    ]);
+  });
+
+  it("preserves backslashes inside quoted Windows node commands", () => {
+    expect(
+      parseShellWords(
+        `"${String.raw`C:\Program Files\nodejs\node.exe`}" "${String.raw`C:\Users\andre\OneDrive\Documents\Github\tokenjuice\dist\cli\main.js`}" codex-post-tool-use`,
+        "win32",
+      ),
+    ).toEqual([
+      String.raw`C:\Program Files\nodejs\node.exe`,
+      String.raw`C:\Users\andre\OneDrive\Documents\Github\tokenjuice\dist\cli\main.js`,
+      "codex-post-tool-use",
+    ]);
+  });
+
+  it("coalesces an unquoted leading Windows node path with spaces", () => {
+    expect(
+      parseShellWords(
+        `${String.raw`C:\Program Files\nodejs\node.exe`} /opt/homebrew/Cellar/tokenjuice/0.2.0/libexec/dist/cli/main.js codex-post-tool-use`,
+        "win32",
+      ),
+    ).toEqual([
+      String.raw`C:\Program Files\nodejs\node.exe`,
+      "/opt/homebrew/Cellar/tokenjuice/0.2.0/libexec/dist/cli/main.js",
+      "codex-post-tool-use",
+    ]);
+  });
+});
+
+describe("extractHookCommandPaths", () => {
+  it("extracts Windows launcher and script paths from quoted node commands", () => {
+    const nodePath = String.raw`C:\Program Files\nodejs\node.exe`;
+    const scriptPath = String.raw`C:\Users\andre\OneDrive\Documents\Github\tokenjuice\dist\cli\main.js`;
+
+    expect(
+      extractHookCommandPaths(
+        `"${nodePath}" "${scriptPath}" codex-post-tool-use`,
+        "win32",
+      ),
+    ).toEqual([nodePath, scriptPath]);
+  });
+});


### PR DESCRIPTION
﻿## Summary
- extract shared hook command quoting/parsing helpers for Codex and Claude Code
- preserve Windows backslashes during doctor parsing and avoid POSIX single-quote wrapping for native Windows paths
- add regression coverage for Windows hook command strings, including unquoted `node.exe` paths with spaces

## Verification
- `corepack pnpm test test/hook-command.test.ts`
- `corepack pnpm test test/codex.test.ts -t "prefers a stable tokenjuice launcher from PATH when installing the hook|can install a local codex hook without preferring PATH|reports a healthy installed launcher hook|flags stale Homebrew Cellar hook commands as broken|reports a healthy local codex hook when asked to check local mode|flags stale local codex builds when source is newer than dist"`
- `corepack pnpm test test/claude-code.test.ts -t "prefers a stable tokenjuice launcher from PATH when installing the hook|reports a healthy installed launcher hook|flags stale Homebrew Cellar hook commands as broken"`
- `corepack pnpm typecheck`

## Notes
- `corepack pnpm test test/codex.test.ts test/claude-code.test.ts test/hook-command.test.ts` still hits the existing Windows-only metadata history test failure in `test/codex.test.ts`, which appears unrelated to hook command handling.
