### PR TITLE
Bucket stats daily totals in local time by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ tokenjuice doctor
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice stats
+tokenjuice stats --timezone utc
 ```
 
 ## overview

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -143,7 +143,10 @@ summarize stored artifact history:
 ```bash
 tokenjuice stats
 tokenjuice stats --format json
+tokenjuice stats --timezone utc
 ```
+
+daily stats are bucketed in the local timezone by default. pass `--timezone utc` for UTC buckets or an IANA timezone such as `America/New_York` for explicit reporting.
 
 ### install
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -34,6 +34,7 @@ type ParsedArgs = {
   maxInlineChars: number | undefined;
   maxCaptureBytes: number | undefined;
   maxInputBytes: number | undefined;
+  timeZone: string | undefined;
   positionals: string[];
   passthrough: string[];
 };
@@ -63,7 +64,7 @@ function printUsage(): void {
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice doctor [file|hooks|codex|claude-code|pi] [--local] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
-      "  tokenjuice stats",
+      "  tokenjuice stats [--timezone local|utc|<iana-timezone>]",
     ].join("\n"),
   );
   process.stderr.write("\n");
@@ -87,6 +88,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let maxInlineChars: number | undefined;
   let maxCaptureBytes: number | undefined;
   let maxInputBytes: number | undefined;
+  let timeZone: string | undefined;
 
   let index = 1;
   while (index < argv.length) {
@@ -188,6 +190,13 @@ function parseArgs(argv: string[]): ParsedArgs {
         maxInputBytes = Number(next);
         index += 2;
         break;
+      case "--timezone":
+        if (!next) {
+          throw new Error("--timezone requires a value");
+        }
+        timeZone = next;
+        index += 2;
+        break;
       default:
         throw new Error(`unknown flag: ${current}`);
     }
@@ -209,6 +218,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     maxInlineChars,
     maxCaptureBytes,
     maxInputBytes,
+    timeZone,
     positionals,
     passthrough,
   };
@@ -755,7 +765,7 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
 
 async function runStats(args: ParsedArgs): Promise<number> {
   const entries = await listArtifactMetadata(args.storeDir);
-  const report = statsArtifacts(entries);
+  const report = statsArtifacts(entries, { timeZone: args.timeZone ?? "local" });
 
   if (args.format === "json") {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -1,5 +1,6 @@
 import type { CompactResult, StoredArtifactMetadata, ToolExecutionInput } from "../types.js";
 import { normalizeCommandSignature } from "./command.js";
+import { buildCalendarDayFormatter } from "./time.js";
 
 export type AnalysisEntry = {
   metadata: StoredArtifactMetadata;
@@ -64,6 +65,10 @@ export type StatsReport = {
     reducedChars: number;
     savedChars: number;
   }>;
+};
+
+export type StatsOptions = {
+  timeZone?: string;
 };
 
 type GroupState = {
@@ -256,14 +261,11 @@ function avgRatioFromGroup(group: StatsGroup): number | null {
   return group.ratioCount > 0 ? group.ratioSum / group.ratioCount : null;
 }
 
-function isoDay(createdAt: string): string {
-  return createdAt.slice(0, 10);
-}
-
-export function statsArtifacts(entries: AnalysisEntry[]): StatsReport {
+export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions = {}): StatsReport {
   const reducers = new Map<string, StatsGroup>();
   const commands = new Map<string, StatsGroup>();
   const daily = new Map<string, StatsGroup>();
+  const formatDay = buildCalendarDayFormatter(options.timeZone);
 
   let rawChars = 0;
   let reducedChars = 0;
@@ -273,7 +275,7 @@ export function statsArtifacts(entries: AnalysisEntry[]): StatsReport {
   for (const entry of entries) {
     const reducer = entry.metadata.classification.matchedReducer ?? "generic/fallback";
     const signature = normalizeCommandSignature(entry.metadata.command) ?? "(unknown)";
-    const day = isoDay(entry.metadata.createdAt);
+    const day = formatDay(entry.metadata.createdAt);
     const reduced = effectiveReducedChars(entry.metadata);
     const ratio = effectiveRatio(entry.metadata);
 

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -1,0 +1,53 @@
+function isoDay(createdAt: string): string {
+  return createdAt.slice(0, 10);
+}
+
+function padTwo(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function formatLocalDay(date: Date): string {
+  return `${date.getFullYear()}-${padTwo(date.getMonth() + 1)}-${padTwo(date.getDate())}`;
+}
+
+function formatUtcDay(date: Date): string {
+  return `${date.getUTCFullYear()}-${padTwo(date.getUTCMonth() + 1)}-${padTwo(date.getUTCDate())}`;
+}
+
+export function buildCalendarDayFormatter(timeZone = "utc"): (createdAt: string) => string {
+  const normalizedTimeZone = timeZone.toLowerCase();
+
+  if (normalizedTimeZone === "local") {
+    return (createdAt) => {
+      const date = new Date(createdAt);
+      return Number.isNaN(date.getTime()) ? isoDay(createdAt) : formatLocalDay(date);
+    };
+  }
+
+  if (normalizedTimeZone === "utc") {
+    return (createdAt) => {
+      const date = new Date(createdAt);
+      return Number.isNaN(date.getTime()) ? isoDay(createdAt) : formatUtcDay(date);
+    };
+  }
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  return (createdAt) => {
+    const date = new Date(createdAt);
+    if (Number.isNaN(date.getTime())) {
+      return isoDay(createdAt);
+    }
+
+    const parts = formatter.formatToParts(date);
+    const year = parts.find((part) => part.type === "year")?.value;
+    const month = parts.find((part) => part.type === "month")?.value;
+    const day = parts.find((part) => part.type === "day")?.value;
+    return year && month && day ? `${year}-${month}-${day}` : isoDay(createdAt);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,3 +41,4 @@ export type {
   WrapResult,
 } from "./types.js";
 export type { InstallPiExtensionResult, PiDoctorReport, PiExtensionCommandOptions } from "./core/pi.js";
+export type { StatsOptions, StatsReport } from "./core/analysis.js";

--- a/test/analysis.test.ts
+++ b/test/analysis.test.ts
@@ -131,6 +131,29 @@ describe("analysis", () => {
     expect(report.daily.length).toBe(1);
   });
 
+  it("buckets daily stats by the requested timezone", () => {
+    const entries = [
+      {
+        metadata: {
+          createdAt: "2026-04-20T03:30:00.000Z",
+          command: "pnpm test",
+          classification: {
+            family: "tests",
+            confidence: 1,
+            matchedReducer: "tests/pnpm-test",
+          },
+          rawChars: 100,
+          reducedChars: 25,
+          ratio: 0.25,
+        },
+      },
+    ];
+
+    expect(statsArtifacts(entries, { timeZone: "America/New_York" }).daily[0]?.day).toBe("2026-04-19");
+    expect(statsArtifacts(entries, { timeZone: "utc" }).daily[0]?.day).toBe("2026-04-20");
+    expect(statsArtifacts(entries).daily[0]?.day).toBe("2026-04-20");
+  });
+
   it("clamps expanded artifact ratios in stats and doctor output", () => {
     const entries = [
       {

--- a/test/time.test.ts
+++ b/test/time.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCalendarDayFormatter } from "../src/core/time.js";
+
+describe("time helpers", () => {
+  it("formats calendar days in utc and explicit timezones", () => {
+    const createdAt = "2026-04-20T03:30:00.000Z";
+
+    expect(buildCalendarDayFormatter("utc")(createdAt)).toBe("2026-04-20");
+    expect(buildCalendarDayFormatter("UTC")(createdAt)).toBe("2026-04-20");
+    expect(buildCalendarDayFormatter("America/New_York")(createdAt)).toBe("2026-04-19");
+  });
+
+  it("preserves the stored iso day when timestamps are malformed", () => {
+    expect(buildCalendarDayFormatter("utc")("2026-04-20-not-a-date")).toBe("2026-04-20");
+  });
+});


### PR DESCRIPTION
## Summary

`tokenjuice stats` was grouping daily totals by slicing the UTC ISO
timestamp stored in artifact metadata. That made late-night local usage show
up under the next calendar day, for example 11 PM EDT on April 19 appearing
as April 20.

This keeps artifact timestamps stored as UTC ISO strings, but moves daily
stats bucketing through an explicit calendar-day formatter. The CLI now uses
local time by default for human-facing `stats` output, while callers can pass
`--timezone utc` or an IANA timezone such as `America/New_York` for explicit
reporting.

The library API preserves UTC as the default for compatibility.

## Changes

- Add a reusable calendar-day formatter for local, UTC, and IANA timezones.
- Add `StatsOptions.timeZone` to `statsArtifacts()`.
- Make `tokenjuice stats` default to local-time daily buckets.
- Add `tokenjuice stats --timezone local|utc|<iana-timezone>`.
- Document timezone behavior in the spec and README.
- Add regression coverage for the EDT midnight-boundary case.

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- Manual local check:
  - default `stats` buckets current 11 PM EDT usage under April 19
  - `stats --timezone utc` buckets the same entries under April 20
