### PR TITLE
docs(cursor): clarify integration design and onboarding playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tokenjuice can install host integrations for:
 | --- | --- | --- | --- | --- |
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `tokenjuice install claude-code` | `~/.claude/settings.json` | ✅ Yes |
 | <img width="48px" src="docs/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `tokenjuice install codex` | `~/.codex/hooks.json` | ✅ Yes |
-| Cursor | [Cursor](https://cursor.com/docs/hooks) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | ✅ Yes |
+| Cursor (Linux/macOS/WSL) | [Cursor](https://cursor.com/docs/hooks) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | ✅ Yes |
 | <img width="48px" src="docs/client-pi.png" alt="pi" /> | [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | ✅ Yes |
 
 shared behavior:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ tokenjuice --help
 tokenjuice --version
 tokenjuice install codex
 tokenjuice install claude-code
+tokenjuice install cursor
 tokenjuice install pi
 tokenjuice uninstall codex
 ```
@@ -70,6 +71,7 @@ tokenjuice wrap --store -- <command> [args...]
 tokenjuice install codex
 tokenjuice install codex --local
 tokenjuice install claude-code
+tokenjuice install cursor
 tokenjuice install pi
 tokenjuice install pi --local
 tokenjuice uninstall codex
@@ -92,6 +94,7 @@ tokenjuice can install host integrations for:
 | --- | --- | --- | --- | --- |
 | <img width="48px" src="docs/client-claude.jpg" alt="Claude" /> | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `tokenjuice install claude-code` | `~/.claude/settings.json` | ✅ Yes |
 | <img width="48px" src="docs/client-openai.jpg" alt="Codex" /> | [Codex CLI](https://github.com/openai/codex) | `tokenjuice install codex` | `~/.codex/hooks.json` | ✅ Yes |
+| Cursor | [Cursor](https://cursor.com/docs/hooks) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | ✅ Yes |
 | <img width="48px" src="docs/client-pi.png" alt="pi" /> | [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | ✅ Yes |
 
 shared behavior:
@@ -105,7 +108,7 @@ shared behavior:
 - `tokenjuice install codex --local` / `tokenjuice doctor hooks --local` are for testing the current repo build before release
 - `tokenjuice install pi --local` forces the installed pi extension to be bundled from the current repo source, so local integration changes can be verified before release
 - Claude Code preserves unrelated settings keys while updating `hooks.PostToolUse`
-- Codex, Claude Code, and pi keep exact file-content reads raw, but compact safe repository inventory commands such as `find`, `ls`, `rg --files`, `git ls-files`, and `fd`
+- Codex, Claude Code, Cursor, and pi keep exact file-content reads raw, but compact safe repository inventory commands such as `find`, `ls`, `rg --files`, `git ls-files`, and `fd`
 
 library-side adapters can also use `runReduceJsonCli(...)` to call the CLI without rebuilding the child-process + JSON plumbing themselves.
 
@@ -127,6 +130,7 @@ tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice install codex
 tokenjuice install claude-code
+tokenjuice install cursor
 tokenjuice install pi
 ```
 
@@ -185,6 +189,8 @@ direct payload:
 
 - spec: `docs/spec.md`
 - rules: `docs/rules.md`
+- cursor integration: `docs/cursor-integration.md`
+- integration playbook: `docs/integration-playbook.md`
 - security: `SECURITY.md`
 
 ## status

--- a/docs/cursor-integration.md
+++ b/docs/cursor-integration.md
@@ -1,0 +1,80 @@
+# cursor integration design
+
+## why cursor uses pre-tool-use wrapping
+
+tokenjuice supports hosts with different hook capabilities.
+
+- codex / claude-code / pi integrations compact output after tool execution.
+- cursor integration compacts by rewriting shell input before execution.
+
+for cursor, tokenjuice installs a `preToolUse` shell hook and rewrites:
+
+```text
+<original shell command>
+```
+
+to:
+
+```text
+tokenjuice wrap -- bash -lc '<original shell command>'
+```
+
+this is deliberate:
+
+- `wrap` makes compacted output the actual shell result returned to the agent.
+- `bash -lc` preserves shell semantics for complex command strings (quotes, pipes, redirects, `&&`, variables, etc.).
+
+## tradeoff and mitigation
+
+wrapping with `bash -lc` means raw command shape becomes launcher-like (`bash`, `-lc`, `<cmd>`), which can reduce reducer matching quality if classification only sees outer argv.
+
+tokenjuice mitigates this by normalizing wrapped input before classification:
+
+- unwrap `bash|sh|zsh|fish -c/-lc '<cmd>'` to the nested command
+- classify against the nested command/argv
+- keep compound command safety behavior unchanged
+
+this preserves reducer quality for cursor while keeping command execution semantics stable.
+
+## launcher behavior
+
+cursor hooks store a `--wrap-launcher` value. when that launcher points to a `.js` entrypoint, tokenjuice executes it via node:
+
+```text
+node <launcher>.js wrap -- ...
+```
+
+this avoids linux/mac permission issues from trying to execute a `.js` file directly.
+
+## trace and diagnostics
+
+for debugging classifier decisions, use `--trace` with json output:
+
+```bash
+node dist/cli/main.js wrap --format json --trace -- bash -lc "git status --short"
+```
+
+inspect:
+
+- `result.trace.normalizedCommand`
+- `result.trace.normalizedArgv`
+- `result.trace.matchedReducer`
+- `result.trace.family`
+
+## expected verification flow
+
+```bash
+pnpm build
+node dist/cli/main.js install cursor
+node dist/cli/main.js doctor cursor
+node dist/cli/main.js wrap --format json --trace -- bash -lc "git status --short"
+node dist/cli/main.js wrap --format json --trace -- pnpm --help
+node dist/cli/main.js wrap --format json --trace --raw -- pnpm --help
+```
+
+expected:
+
+- `doctor cursor` reports `health: ok`
+- wrapped shell commands show nested normalized command/argv in trace
+- `--raw` keeps `ratio = 1`
+- non-raw wraps usually produce `ratio < 1`

--- a/docs/cursor-integration.md
+++ b/docs/cursor-integration.md
@@ -16,17 +16,17 @@ for cursor, tokenjuice installs a `preToolUse` shell hook and rewrites:
 to:
 
 ```text
-tokenjuice wrap -- bash -lc '<original shell command>'
+tokenjuice wrap -- sh -lc '<original shell command>'
 ```
 
 this is deliberate:
 
 - `wrap` makes compacted output the actual shell result returned to the agent.
-- `bash -lc` preserves shell semantics for complex command strings (quotes, pipes, redirects, `&&`, variables, etc.).
+- `sh -lc` preserves shell semantics for complex command strings (quotes, pipes, redirects, `&&`, variables, etc.).
 
 ## tradeoff and mitigation
 
-wrapping with `bash -lc` means raw command shape becomes launcher-like (`bash`, `-lc`, `<cmd>`), which can reduce reducer matching quality if classification only sees outer argv.
+wrapping with `sh -lc` means raw command shape becomes launcher-like (`sh`, `-lc`, `<cmd>`), which can reduce reducer matching quality if classification only sees outer argv.
 
 tokenjuice mitigates this by normalizing wrapped input before classification:
 
@@ -51,7 +51,7 @@ this avoids linux/mac permission issues from trying to execute a `.js` file dire
 for debugging classifier decisions, use `--trace` with json output:
 
 ```bash
-node dist/cli/main.js wrap --format json --trace -- bash -lc "git status --short"
+node dist/cli/main.js wrap --format json --trace -- sh -lc "git status --short"
 ```
 
 inspect:
@@ -67,7 +67,7 @@ inspect:
 pnpm build
 node dist/cli/main.js install cursor
 node dist/cli/main.js doctor cursor
-node dist/cli/main.js wrap --format json --trace -- bash -lc "git status --short"
+node dist/cli/main.js wrap --format json --trace -- sh -lc "git status --short"
 node dist/cli/main.js wrap --format json --trace -- pnpm --help
 node dist/cli/main.js wrap --format json --trace --raw -- pnpm --help
 ```
@@ -78,3 +78,10 @@ expected:
 - wrapped shell commands show nested normalized command/argv in trace
 - `--raw` keeps `ratio = 1`
 - non-raw wraps usually produce `ratio < 1`
+
+## platform boundary
+
+- supported: linux/macos, and cursor inside wsl
+- not supported yet: native windows shell interception (`process.platform === "win32"`)
+
+on native windows, the cursor pre-tool hook intentionally returns a deny response with a message that asks users to run cursor in wsl.

--- a/docs/cursor-integration.md
+++ b/docs/cursor-integration.md
@@ -16,17 +16,19 @@ for cursor, tokenjuice installs a `preToolUse` shell hook and rewrites:
 to:
 
 ```text
-tokenjuice wrap -- sh -lc '<original shell command>'
+tokenjuice wrap -- <host-shell> -lc '<original shell command>'
 ```
 
 this is deliberate:
 
 - `wrap` makes compacted output the actual shell result returned to the agent.
-- `sh -lc` preserves shell semantics for complex command strings (quotes, pipes, redirects, `&&`, variables, etc.).
+- host-shell `-lc` preserves shell semantics for complex command strings (quotes, pipes, redirects, `&&`, variables, etc.).
+- tokenjuice resolves host shell in this order: `tool_input.shell`, `TOKENJUICE_CURSOR_SHELL`, `SHELL`, then `sh`.
+- if no usable shell is found, tokenjuice leaves the command unchanged (no pre-tool rewrite).
 
 ## tradeoff and mitigation
 
-wrapping with `sh -lc` means raw command shape becomes launcher-like (`sh`, `-lc`, `<cmd>`), which can reduce reducer matching quality if classification only sees outer argv.
+wrapping with `<host-shell> -lc` means raw command shape becomes launcher-like (`<shell>`, `-lc`, `<cmd>`), which can reduce reducer matching quality if classification only sees outer argv.
 
 tokenjuice mitigates this by normalizing wrapped input before classification:
 
@@ -51,7 +53,7 @@ this avoids linux/mac permission issues from trying to execute a `.js` file dire
 for debugging classifier decisions, use `--trace` with json output:
 
 ```bash
-node dist/cli/main.js wrap --format json --trace -- sh -lc "git status --short"
+node dist/cli/main.js wrap --format json --trace -- "$SHELL" -lc "git status --short"
 ```
 
 inspect:
@@ -67,7 +69,7 @@ inspect:
 pnpm build
 node dist/cli/main.js install cursor
 node dist/cli/main.js doctor cursor
-node dist/cli/main.js wrap --format json --trace -- sh -lc "git status --short"
+node dist/cli/main.js wrap --format json --trace -- "$SHELL" -lc "git status --short"
 node dist/cli/main.js wrap --format json --trace -- pnpm --help
 node dist/cli/main.js wrap --format json --trace --raw -- pnpm --help
 ```

--- a/docs/integration-playbook.md
+++ b/docs/integration-playbook.md
@@ -1,0 +1,129 @@
+# host integration playbook
+
+this document is the implementation checklist for adding a new host integration (like codex, claude-code, cursor, pi).
+
+## when to use this
+
+use this before opening a PR that adds `tokenjuice install <host>` or any new hook/adapter path.
+
+## design decisions first
+
+define the host hook model before writing code:
+
+- can the host rewrite shell input before execution?
+- can the host replace shell output after execution?
+- are hooks file-based, extension-based, or api-based?
+- does the host return plain text, structured json, or both?
+
+pick one integration mode:
+
+- post-tool compaction (preferred when shell output can be replaced safely)
+- pre-tool command wrapping (use `tokenjuice wrap` when post replacement is unavailable)
+
+for pre-tool wrapping, preserve shell semantics (for example `bash -lc '<cmd>'`) and ensure classification normalization can recover the nested command.
+
+## implementation checklist
+
+for a new host adapter in `src/core/<host>.ts`:
+
+- install flow
+  - write/update host config atomically
+  - preserve unrelated keys
+  - keep installation idempotent (replace prior tokenjuice entry, keep non-tokenjuice entries)
+- doctor flow
+  - detect disabled / warn / broken / ok states
+  - validate expected command against installed command
+  - report missing executable paths
+  - return a single repair command
+- runtime hook flow
+  - parse hook payload defensively
+  - skip non-target tools/events early
+  - preserve explicit raw bypass behavior
+  - never throw hard on hook input parse failures
+
+then wire CLI + exports:
+
+- `src/cli/main.ts`
+  - `install <host>`
+  - `doctor <host>`
+  - usage text
+  - runtime hook entry command if needed
+- `src/index.ts`
+  - runtime/install/doctor exports
+  - result/report type exports
+- `src/core/hook-doctor.ts`
+  - add the host to aggregate doctor report
+
+## test strategy (required)
+
+add host-specific tests and aggregate tests:
+
+- `test/<host>.test.ts`
+  - install idempotency
+  - preserve unrelated config fields
+  - doctor status matrix (`disabled`, `warn`, `broken`, `ok`)
+  - runtime behavior (rewrite/skip/bypass paths)
+- aggregate coverage
+  - update tests for `doctorInstalledHooks` if the new host is included there
+
+## critical test isolation rules
+
+new adapters often fail CI/local due to leaked machine config. isolate host homes explicitly:
+
+- set and reset host env vars in each suite (`CODEX_HOME`, `CLAUDE_HOME`, `CURSOR_HOME`, `PI_CODING_AGENT_DIR`, etc.)
+- avoid reading real `~/.<host>` in tests
+- use temp dirs for all config paths
+- restore `PATH` after each test
+
+if you add a new host to aggregate doctor logic, existing aggregate tests may start failing unless they set that host's env home to temp storage.
+
+## regression gates before merge
+
+minimum gate for a new host adapter:
+
+```bash
+pnpm typecheck
+pnpm vitest run test/<host>.test.ts
+pnpm vitest run test/codex.test.ts test/claude-code.test.ts test/pi.test.ts
+```
+
+if you changed normalization/classification paths, also run:
+
+```bash
+pnpm vitest run test/command.test.ts test/classify.test.ts test/trace.test.ts
+```
+
+## manual verification flow
+
+run from repo root:
+
+```bash
+pnpm build
+node dist/cli/main.js install <host>
+node dist/cli/main.js doctor <host>
+```
+
+for command-path diagnostics, use trace:
+
+```bash
+node dist/cli/main.js wrap --format json --trace -- bash -lc "git status --short"
+```
+
+verify:
+
+- normalized command/argv match expected command intent
+- matched reducer is specific (not generic fallback for common commands)
+- raw mode preserves full output:
+
+```bash
+node dist/cli/main.js wrap --format json --trace --raw -- <command>
+```
+
+## docs updates required in same PR
+
+when adding a host integration, update:
+
+- `README.md` command examples and support table
+- `docs/spec.md` supported host hooks table
+- dedicated design doc if host behavior differs materially (like cursor pre-tool wrapping)
+

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -172,7 +172,7 @@ supported host hooks:
 | --- | --- | --- | --- |
 | Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Preserves unrelated settings keys while updating `hooks.PostToolUse` |
 | Codex CLI | `tokenjuice install codex` | `~/.codex/hooks.json` | `tokenjuice install codex --local` is available for repo-local verification |
-| Cursor | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; see `docs/cursor-integration.md` |
+| Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
 
 `tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor pi` is the direct Pi-only check. the `--local` variant is for codex dev verification and expects that hook to point at the current repo build instead of the installed launcher on `PATH`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -52,6 +52,8 @@ host adapters should own:
 
 if reducer logic starts leaking into an adapter, the boundary is wrong.
 
+for contributor guidance on introducing a new host integration, see `docs/integration-playbook.md`.
+
 host adapters choose an inspection policy before calling the shared compactor. the Codex, Claude Code, and pi adapters use the safe-inventory policy:
 
 - exact file-content reads stay raw (`cat`, `sed`, `head`, `tail`, `nl`, `bat`, `jq`, `yq`)
@@ -155,6 +157,7 @@ install host wiring when tokenjuice can own it directly:
 ```bash
 tokenjuice install codex
 tokenjuice install claude-code
+tokenjuice install cursor
 tokenjuice install pi
 tokenjuice doctor hooks
 tokenjuice doctor pi
@@ -169,6 +172,7 @@ supported host hooks:
 | --- | --- | --- | --- |
 | Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Preserves unrelated settings keys while updating `hooks.PostToolUse` |
 | Codex CLI | `tokenjuice install codex` | `~/.codex/hooks.json` | `tokenjuice install codex --local` is available for repo-local verification |
+| Cursor | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; see `docs/cursor-integration.md` |
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
 
 `tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor pi` is the direct Pi-only check. the `--local` variant is for codex dev verification and expects that hook to point at the current repo build instead of the installed launcher on `PATH`.


### PR DESCRIPTION
## Summary
- add a dedicated cursor integration design doc describing pre-tool wrapping, shell resolution, and platform boundaries
- add a host integration playbook documenting implementation, testing isolation, and regression gates for future adapters
- update README/spec docs index and cursor support wording to reflect Linux/macOS/WSL support guidance

## Test plan
- [x] docs-only changes reviewed for consistency with current behavior
- [x] verified links and referenced paths exist in the repository

Made with [Cursor](https://cursor.com)