### PR TITLE
feat(cursor): add integration with robust shell normalization

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,6 +8,7 @@ import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifa
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
 import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook } from "../core/claude-code.js";
 import { doctorCodexHook, installCodexHook, runCodexPostToolUseHook, uninstallCodexHook } from "../core/codex.js";
+import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../core/cursor.js";
 import { doctorInstalledHooks } from "../core/hook-doctor.js";
 import { doctorPiExtension, installPiExtension } from "../core/pi.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
@@ -35,6 +36,8 @@ type ParsedArgs = {
   maxCaptureBytes: number | undefined;
   maxInputBytes: number | undefined;
   timeZone: string | undefined;
+  wrapLauncher: string | undefined;
+  trace: boolean;
   positionals: string[];
   passthrough: string[];
 };
@@ -55,15 +58,17 @@ function printUsage(): void {
       "  tokenjuice reduce [file] [--format text|json] [--classifier <id>] [--store] [--raw|--full]",
       "  tokenjuice reduce-json [file]",
       "  tokenjuice wrap [--raw|--full] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
+      "  tokenjuice <command> ... [--trace]",
       "  tokenjuice install codex [--local]",
       "  tokenjuice install claude-code",
+      "  tokenjuice install cursor",
       "  tokenjuice install pi [--local]",
       "  tokenjuice uninstall codex",
       "  tokenjuice ls",
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
-      "  tokenjuice doctor [file|hooks|codex|claude-code|pi] [--local] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|codex|claude-code|cursor|pi] [--local] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>]",
     ].join("\n"),
   );
@@ -89,6 +94,8 @@ function parseArgs(argv: string[]): ParsedArgs {
   let maxCaptureBytes: number | undefined;
   let maxInputBytes: number | undefined;
   let timeZone: string | undefined;
+  let wrapLauncher: string | undefined;
+  let trace = false;
 
   let index = 1;
   while (index < argv.length) {
@@ -197,6 +204,17 @@ function parseArgs(argv: string[]): ParsedArgs {
         timeZone = next;
         index += 2;
         break;
+      case "--wrap-launcher":
+        if (!next) {
+          throw new Error("--wrap-launcher requires a value");
+        }
+        wrapLauncher = next;
+        index += 2;
+        break;
+      case "--trace":
+        trace = true;
+        index += 1;
+        break;
       default:
         throw new Error(`unknown flag: ${current}`);
     }
@@ -219,6 +237,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     maxCaptureBytes,
     maxInputBytes,
     timeZone,
+    wrapLauncher,
+    trace,
     positionals,
     passthrough,
   };
@@ -276,6 +296,7 @@ async function runReduce(args: ParsedArgs): Promise<number> {
     {
       ...(args.classifier ? { classifier: args.classifier } : {}),
       ...(args.raw ? { raw: true } : {}),
+      ...(args.trace ? { trace: true } : {}),
       recordStats: true,
       ...(args.store ? { store: true } : {}),
       ...(args.storeDir ? { storeDir: args.storeDir } : {}),
@@ -298,6 +319,7 @@ async function runReduceJson(args: ParsedArgs): Promise<number> {
     ...(request.options ?? {}),
     ...(args.classifier ? { classifier: args.classifier } : {}),
     ...(args.raw ? { raw: true } : {}),
+    ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
     ...(args.storeDir ? { storeDir: args.storeDir } : {}),
@@ -311,6 +333,7 @@ async function runWrap(args: ParsedArgs): Promise<number> {
   const wrapped = await runWrappedCommand(args.passthrough, {
     tee: args.tee,
     ...(args.raw ? { raw: true } : {}),
+    ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
     ...(args.storeDir ? { storeDir: args.storeDir } : {}),
@@ -365,6 +388,23 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "cursor") {
+    const result = await installCursorHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`installed cursor hook: ${result.hooksPath}\n`);
+    process.stdout.write(`command: ${result.command}\n`);
+    if (result.backupPath) {
+      process.stdout.write(`backup: ${result.backupPath}\n`);
+    }
+    process.stdout.write("doctor: tokenjuice doctor hooks\n");
+    process.stdout.write("escape hatch: tokenjuice wrap --raw -- <command>\n");
+    return 0;
+  }
+
   if (target === "pi") {
     const result = await installPiExtension(undefined, { local: args.local });
     if (args.format === "json") {
@@ -381,7 +421,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: codex, claude-code, pi");
+  throw new Error("install currently supports: codex, claude-code, cursor, pi");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -683,6 +723,36 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     return report.status === "broken" ? 1 : 0;
   }
 
+  if (args.positionals[0] === "cursor") {
+    const report = await doctorCursorHook();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`hooks path: ${report.hooksPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    process.stdout.write(`expected command: ${report.expectedCommand}\n`);
+    if (report.detectedCommand) {
+      process.stdout.write(`configured command: ${report.detectedCommand}\n`);
+    }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
   if (args.positionals[0] === "claude-code") {
     const report = await doctorClaudeCodeHook();
 
@@ -847,6 +917,8 @@ async function main(): Promise<number> {
       return await runCodexPostToolUseHook(await readStdin(args.maxInputBytes));
     case "claude-code-post-tool-use":
       return await runClaudeCodePostToolUseHook(await readStdin(args.maxInputBytes));
+    case "cursor-pre-tool-use":
+      return await runCursorPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     default:
       printUsage();
       return 1;

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -6,6 +6,40 @@ function includesAll(argv: string[], expected: string[]): boolean {
   return expected.every((part) => argv.includes(part));
 }
 
+function isWordLikeChar(char: string | undefined): boolean {
+  return typeof char === "string" && /[A-Za-z0-9_]/u.test(char);
+}
+
+function includesCommandPart(command: string, part: string): boolean {
+  if (!part) {
+    return true;
+  }
+
+  let fromIndex = 0;
+  while (fromIndex <= command.length) {
+    const index = command.indexOf(part, fromIndex);
+    if (index === -1) {
+      return false;
+    }
+
+    const end = index + part.length;
+    const partStartsWord = isWordLikeChar(part[0]);
+    const partEndsWord = isWordLikeChar(part.at(-1));
+    const prev = index > 0 ? command[index - 1] : undefined;
+    const next = end < command.length ? command[end] : undefined;
+    const leftBoundaryOk = !partStartsWord || !isWordLikeChar(prev);
+    const rightBoundaryOk = !partEndsWord || !isWordLikeChar(next);
+
+    if (leftBoundaryOk && rightBoundaryOk) {
+      return true;
+    }
+
+    fromIndex = index + 1;
+  }
+
+  return false;
+}
+
 type RuleLike = JsonRule | CompiledRule;
 
 function getJsonRule(rule: RuleLike): JsonRule {
@@ -38,11 +72,11 @@ export function matchesRule(ruleLike: RuleLike, input: ToolExecutionInput): bool
     return false;
   }
 
-  if (rule.match.commandIncludes && !rule.match.commandIncludes.every((part) => command.includes(part))) {
+  if (rule.match.commandIncludes && !rule.match.commandIncludes.every((part) => includesCommandPart(command, part))) {
     return false;
   }
 
-  if (rule.match.commandIncludesAny && !rule.match.commandIncludesAny.some((part) => command.includes(part))) {
+  if (rule.match.commandIncludesAny && !rule.match.commandIncludesAny.some((part) => includesCommandPart(command, part))) {
     return false;
   }
 

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -341,7 +341,7 @@ export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutio
 
 function unwrapShellLauncherCommand(input: ToolExecutionInput): string | null {
   const argv = input.argv;
-  if (!argv || argv.length < 3) {
+  if (!argv || argv.length !== 3) {
     return null;
   }
 
@@ -350,7 +350,7 @@ function unwrapShellLauncherCommand(input: ToolExecutionInput): string | null {
   const nestedCommand = argv[2];
   if (
     !launcher
-    || !SHELL_COMMAND_LAUNCHERS.has(launcher)
+    || !isLikelyShellLauncher(launcher, argv[0])
     || (launchFlag !== "-c" && launchFlag !== "-lc")
     || typeof nestedCommand !== "string"
     || nestedCommand.trim().length === 0
@@ -359,4 +359,42 @@ function unwrapShellLauncherCommand(input: ToolExecutionInput): string | null {
   }
 
   return nestedCommand;
+}
+
+function isLikelyShellLauncher(launcherName: string, launcherPath?: string): boolean {
+  const normalized = launcherName.toLowerCase().replace(/\.exe$/u, "");
+  if (SHELL_COMMAND_LAUNCHERS.has(normalized)) {
+    return true;
+  }
+
+  if (
+    normalized === "dash"
+    || normalized === "ksh"
+    || normalized === "mksh"
+    || normalized === "ash"
+    || normalized === "csh"
+    || normalized === "tcsh"
+  ) {
+    return true;
+  }
+
+  const pathNormalized = launcherPath?.toLowerCase().replace(/\\/gu, "/");
+  if (!pathNormalized) return false;
+  if (!pathNormalized.includes("/bin/")) return false;
+  return (
+    pathNormalized.endsWith("/bash")
+    || pathNormalized.endsWith("/sh")
+    || pathNormalized.endsWith("/zsh")
+    || pathNormalized.endsWith("/fish")
+    || pathNormalized.endsWith("/dash")
+    || pathNormalized.endsWith("/ksh")
+    || pathNormalized.endsWith("/mksh")
+    || pathNormalized.endsWith("/ash")
+    || pathNormalized.endsWith("/csh")
+    || pathNormalized.endsWith("/tcsh")
+    || pathNormalized.endsWith("/bash.exe")
+    || pathNormalized.endsWith("/sh.exe")
+    || pathNormalized.endsWith("/zsh.exe")
+    || pathNormalized.endsWith("/fish.exe")
+  );
 }

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -7,6 +7,7 @@ type ShellOperator = ";" | "\n" | "|" | "&&" | "||";
 const FILE_CONTENT_INSPECTION_COMMANDS = new Set(["cat", "sed", "head", "tail", "nl", "bat", "batcat", "jq", "yq"]);
 const COMPOUND_SHELL_OPERATORS = new Set<ShellOperator>([";", "\n", "|", "&&", "||"]);
 const SEQUENTIAL_SHELL_OPERATORS = new Set<ShellOperator>([";", "\n", "&&", "||"]);
+const SHELL_COMMAND_LAUNCHERS = new Set(["bash", "sh", "zsh", "fish"]);
 
 function getNormalizedArgv(input: Pick<ToolExecutionInput, "argv" | "command">): string[] {
   if (input.argv?.length) {
@@ -292,6 +293,32 @@ function matchLeadingCdChain(command: string): string | null {
 
 
 export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutionInput {
+  const shellWrapped = unwrapShellLauncherCommand(input);
+  if (shellWrapped) {
+    const effectiveCommand = stripLeadingCdPrefix(shellWrapped);
+    if (isCompoundShellCommand(effectiveCommand)) {
+      const { argv: _argv, ...restInput } = input;
+      return {
+        ...restInput,
+        command: effectiveCommand,
+      };
+    }
+
+    const argv = tokenizeCommand(effectiveCommand);
+    if (argv.length === 0) {
+      return {
+        ...input,
+        command: effectiveCommand,
+      };
+    }
+
+    return {
+      ...input,
+      command: effectiveCommand,
+      argv,
+    };
+  }
+
   if (input.argv?.length || !input.command) {
     return input;
   }
@@ -310,4 +337,26 @@ export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutio
     ...input,
     argv,
   };
+}
+
+function unwrapShellLauncherCommand(input: ToolExecutionInput): string | null {
+  const argv = input.argv;
+  if (!argv || argv.length < 3) {
+    return null;
+  }
+
+  const launcher = getCommandName(argv);
+  const launchFlag = argv[1];
+  const nestedCommand = argv[2];
+  if (
+    !launcher
+    || !SHELL_COMMAND_LAUNCHERS.has(launcher)
+    || (launchFlag !== "-c" && launchFlag !== "-lc")
+    || typeof nestedCommand !== "string"
+    || nestedCommand.trim().length === 0
+  ) {
+    return null;
+  }
+
+  return nestedCommand;
 }

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -43,6 +43,9 @@ export type CursorDoctorReport = {
 };
 
 const TOKENJUICE_CURSOR_FIX_COMMAND = "tokenjuice install cursor";
+const TOKENJUICE_CURSOR_WSL_FIX_COMMAND = "run Cursor in WSL, then run tokenjuice install cursor";
+const TOKENJUICE_CURSOR_WINDOWS_ISSUE = "tokenjuice cursor integration does not support native Windows shells yet. run Cursor in WSL instead.";
+const TOKENJUICE_CURSOR_WINDOWS_HOOK_ISSUE = "configured Cursor hook cannot run on native Windows; use Cursor in WSL instead.";
 
 function getCursorHome(): string {
   return process.env.CURSOR_HOME || join(homedir(), ".cursor");
@@ -50,6 +53,10 @@ function getCursorHome(): string {
 
 function getDefaultHooksPath(): string {
   return join(getCursorHome(), "hooks.json");
+}
+
+function isNativeWindowsCursorUnsupported(): boolean {
+  return process.platform === "win32";
 }
 
 function shellQuote(value: string): string {
@@ -292,6 +299,10 @@ export async function installCursorHook(
   hooksPath = getDefaultHooksPath(),
   options: CursorHookCommandOptions = {},
 ): Promise<InstallCursorHookResult> {
+  if (isNativeWindowsCursorUnsupported()) {
+    throw new Error(TOKENJUICE_CURSOR_WINDOWS_ISSUE);
+  }
+
   const { config, backupPath } = await loadCursorHooksConfig(hooksPath);
   const command = await buildCursorHookCommand(options);
   const preToolUse = Array.isArray(config.hooks.preToolUse) ? config.hooks.preToolUse : [];
@@ -318,6 +329,22 @@ export async function doctorCursorHook(
   hooksPath = getDefaultHooksPath(),
   options: CursorHookCommandOptions = {},
 ): Promise<CursorDoctorReport> {
+  if (isNativeWindowsCursorUnsupported()) {
+    const { config, exists } = await readCursorHooksConfig(hooksPath);
+    const detectedCommand = findTokenjuiceCursorHookCommand(config);
+    const checkedPaths = detectedCommand ? extractHookCommandPaths(detectedCommand) : [];
+    return {
+      hooksPath,
+      status: exists && detectedCommand ? "broken" : "disabled",
+      issues: [exists && detectedCommand ? TOKENJUICE_CURSOR_WINDOWS_HOOK_ISSUE : TOKENJUICE_CURSOR_WINDOWS_ISSUE],
+      fixCommand: TOKENJUICE_CURSOR_WSL_FIX_COMMAND,
+      expectedCommand: TOKENJUICE_CURSOR_WSL_FIX_COMMAND,
+      ...(detectedCommand ? { detectedCommand } : {}),
+      checkedPaths,
+      missingPaths: [],
+    };
+  }
+
   const expectedCommand = await buildCursorHookCommand(options);
   const { config, exists } = await readCursorHooksConfig(hooksPath);
   const detectedCommand = findTokenjuiceCursorHookCommand(config);
@@ -389,7 +416,7 @@ export async function runCursorPreToolUseHook(rawText: string, wrapLauncher = "t
   if (process.platform === "win32") {
     const response = {
       permission: "deny",
-      user_message: "tokenjuice cursor integration does not support native Windows shells yet. please run Cursor in WSL.",
+      user_message: "tokenjuice cursor integration does not support native Windows shells yet. run Cursor in WSL instead.",
       agent_message: "Shell command blocked by tokenjuice: native Windows shell interception is not supported yet. Use Cursor in WSL and retry.",
     };
     process.stdout.write(`${JSON.stringify(response)}\n`);

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -22,6 +22,7 @@ type CursorPreToolUsePayload = {
 
 type CursorToolInput = {
   command?: unknown;
+  shell?: unknown;
 } & Record<string, unknown>;
 
 export type InstallCursorHookResult = {
@@ -87,6 +88,49 @@ async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
       if (await isExecutableFile(candidatePath)) {
         return candidatePath;
       }
+    }
+  }
+
+  return undefined;
+}
+
+async function resolveShellPath(shell: string): Promise<string | undefined> {
+  const trimmed = shell.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.includes("/") || trimmed.includes("\\")) {
+    return await isExecutableFile(trimmed) ? trimmed : undefined;
+  }
+
+  const pathValue = process.env.PATH;
+  if (!pathValue) {
+    return undefined;
+  }
+  for (const segment of pathValue.split(delimiter)) {
+    if (!segment) {
+      continue;
+    }
+    const candidatePath = join(segment, trimmed);
+    if (await isExecutableFile(candidatePath)) {
+      return candidatePath;
+    }
+  }
+  return undefined;
+}
+
+async function resolveCursorHostShell(toolInput: CursorToolInput): Promise<string | undefined> {
+  const shellCandidates = [
+    typeof toolInput.shell === "string" ? toolInput.shell : undefined,
+    process.env.TOKENJUICE_CURSOR_SHELL,
+    process.env.SHELL,
+    "sh",
+  ].filter((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+
+  for (const candidate of shellCandidates) {
+    const resolved = await resolveShellPath(candidate);
+    if (resolved) {
+      return resolved;
     }
   }
 
@@ -351,11 +395,15 @@ export async function runCursorPreToolUseHook(rawText: string, wrapLauncher = "t
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return 0;
   }
+  const shellPath = await resolveCursorHostShell(toolInput);
+  if (!shellPath) {
+    return 0;
+  }
 
   const launcherCommand = wrapLauncher.endsWith(".js")
     ? `${shellQuote(process.execPath)} ${shellQuote(wrapLauncher)}`
     : shellQuote(wrapLauncher);
-  const wrappedCommand = `${launcherCommand} wrap -- sh -lc ${shellQuote(command)}`;
+  const wrappedCommand = `${launcherCommand} wrap -- ${shellQuote(shellPath)} -lc ${shellQuote(command)}`;
   const response = {
     permission: "allow",
     updated_input: {

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -1,6 +1,6 @@
 import { constants as fsConstants } from "node:fs";
 import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 import { tokenizeCommand } from "./command.js";
@@ -95,13 +95,14 @@ async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
 
 async function buildCursorHookCommand(options: CursorHookCommandOptions = {}): Promise<string> {
   const rawBinaryPath = options.binaryPath ?? process.argv[1];
+  const binaryPath = rawBinaryPath && !isAbsolute(rawBinaryPath) ? resolve(rawBinaryPath) : rawBinaryPath;
   const nodePath = options.nodePath ?? process.execPath;
-  if (!rawBinaryPath) {
+  if (!binaryPath) {
     throw new Error("unable to resolve tokenjuice binary path for cursor install");
   }
 
   const installedBinaryPath = await resolveInstalledTokenjuicePath();
-  const launcher = installedBinaryPath ?? rawBinaryPath;
+  const launcher = installedBinaryPath ?? binaryPath;
   const launcherCommand = launcher.endsWith(".js")
     ? `${shellQuote(nodePath)} ${shellQuote(launcher)}`
     : shellQuote(launcher);
@@ -341,11 +342,20 @@ export async function runCursorPreToolUseHook(rawText: string, wrapLauncher = "t
   if (commandAlreadyWrapped(command)) {
     return 0;
   }
+  if (process.platform === "win32") {
+    const response = {
+      permission: "deny",
+      user_message: "tokenjuice cursor integration does not support native Windows shells yet. please run Cursor in WSL.",
+      agent_message: "Shell command blocked by tokenjuice: native Windows shell interception is not supported yet. Use Cursor in WSL and retry.",
+    };
+    process.stdout.write(`${JSON.stringify(response)}\n`);
+    return 0;
+  }
 
   const launcherCommand = wrapLauncher.endsWith(".js")
     ? `${shellQuote(process.execPath)} ${shellQuote(wrapLauncher)}`
     : shellQuote(wrapLauncher);
-  const wrappedCommand = `${launcherCommand} wrap -- bash -lc ${shellQuote(command)}`;
+  const wrappedCommand = `${launcherCommand} wrap -- sh -lc ${shellQuote(command)}`;
   const response = {
     permission: "allow",
     updated_input: {

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -1,0 +1,358 @@
+import { constants as fsConstants } from "node:fs";
+import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { delimiter, dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+import { tokenizeCommand } from "./command.js";
+
+type CursorHooksConfig = Record<string, unknown> & {
+  version?: number;
+  hooks: Record<string, unknown>;
+};
+
+type CursorHookCommandOptions = {
+  binaryPath?: string;
+  nodePath?: string;
+};
+
+type CursorPreToolUsePayload = {
+  tool_name?: unknown;
+  tool_input?: unknown;
+};
+
+type CursorToolInput = {
+  command?: unknown;
+} & Record<string, unknown>;
+
+export type InstallCursorHookResult = {
+  hooksPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+export type CursorDoctorReport = {
+  hooksPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_CURSOR_FIX_COMMAND = "tokenjuice install cursor";
+
+function getCursorHome(): string {
+  return process.env.CURSOR_HOME || join(homedir(), ".cursor");
+}
+
+function getDefaultHooksPath(): string {
+  return join(getCursorHome(), "hooks.json");
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+async function isExecutableFile(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
+  const pathValue = process.env.PATH;
+  if (!pathValue) {
+    return undefined;
+  }
+
+  const candidateNames = process.platform === "win32"
+    ? ["tokenjuice.exe", "tokenjuice.cmd", "tokenjuice.bat", "tokenjuice"]
+    : ["tokenjuice"];
+
+  for (const segment of pathValue.split(delimiter)) {
+    if (!segment) {
+      continue;
+    }
+
+    for (const candidateName of candidateNames) {
+      const candidatePath = join(segment, candidateName);
+      if (await isExecutableFile(candidatePath)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function buildCursorHookCommand(options: CursorHookCommandOptions = {}): Promise<string> {
+  const rawBinaryPath = options.binaryPath ?? process.argv[1];
+  const nodePath = options.nodePath ?? process.execPath;
+  if (!rawBinaryPath) {
+    throw new Error("unable to resolve tokenjuice binary path for cursor install");
+  }
+
+  const installedBinaryPath = await resolveInstalledTokenjuicePath();
+  const launcher = installedBinaryPath ?? rawBinaryPath;
+  const launcherCommand = launcher.endsWith(".js")
+    ? `${shellQuote(nodePath)} ${shellQuote(launcher)}`
+    : shellQuote(launcher);
+
+  return `${launcherCommand} cursor-pre-tool-use --wrap-launcher ${shellQuote(launcher)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTokenjuiceCursorHook(rawHook: unknown): boolean {
+  if (!isRecord(rawHook) || typeof rawHook.command !== "string") {
+    return false;
+  }
+  return rawHook.command.includes("cursor-pre-tool-use");
+}
+
+function createTokenjuiceCursorHook(command: string): Record<string, unknown> {
+  return {
+    type: "command",
+    matcher: "Shell",
+    command,
+  };
+}
+
+function sanitizeCursorHooksConfig(raw: unknown): CursorHooksConfig {
+  if (!isRecord(raw)) {
+    return { version: 1, hooks: {} };
+  }
+
+  return {
+    ...raw,
+    version: typeof raw.version === "number" ? raw.version : 1,
+    hooks: isRecord(raw.hooks) ? { ...raw.hooks } : {},
+  };
+}
+
+async function loadCursorHooksConfig(hooksPath: string): Promise<{ config: CursorHooksConfig; backupPath?: string }> {
+  try {
+    const rawText = await readFile(hooksPath, "utf8");
+    const parsed = JSON.parse(rawText) as unknown;
+    const config = sanitizeCursorHooksConfig(parsed);
+    const backupPath = `${hooksPath}.bak`;
+    await writeFile(backupPath, rawText, "utf8");
+    return { config, backupPath };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { version: 1, hooks: {} } };
+    }
+    throw new Error(`failed to load cursor hooks from ${hooksPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function readCursorHooksConfig(hooksPath: string): Promise<{ config: CursorHooksConfig; exists: boolean }> {
+  try {
+    const rawText = await readFile(hooksPath, "utf8");
+    const parsed = JSON.parse(rawText) as unknown;
+    return {
+      config: sanitizeCursorHooksConfig(parsed),
+      exists: true,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {
+        config: { version: 1, hooks: {} },
+        exists: false,
+      };
+    }
+    throw new Error(`failed to read cursor hooks from ${hooksPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function findTokenjuiceCursorHookCommand(config: CursorHooksConfig): string | undefined {
+  const preToolUse = config.hooks.preToolUse;
+  if (!Array.isArray(preToolUse)) {
+    return undefined;
+  }
+
+  for (const hook of preToolUse) {
+    if (!isRecord(hook) || typeof hook.command !== "string") {
+      continue;
+    }
+    if (isTokenjuiceCursorHook(hook)) {
+      return hook.command;
+    }
+  }
+
+  return undefined;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function extractHookCommandPaths(command: string): string[] {
+  const argv = tokenizeCommand(command);
+  if (argv.length === 0) {
+    return [];
+  }
+
+  const paths = new Set<string>();
+  const first = argv[0];
+  if (first && (first.includes("/") || first.includes("\\"))) {
+    paths.add(first);
+  }
+
+  const second = argv[1];
+  if (first && second && (first.endsWith("/node") || first.endsWith("\\node.exe")) && second.endsWith(".js")) {
+    paths.add(second);
+  }
+
+  return [...paths];
+}
+
+function commandAlreadyWrapped(command: string): boolean {
+  const argv = tokenizeCommand(command);
+  if (argv.length < 2) {
+    return false;
+  }
+
+  if (argv[0] === "tokenjuice" && argv[1] === "wrap") {
+    return true;
+  }
+  if (
+    typeof argv[0] === "string"
+    && (argv[0] === "node" || argv[0] === "node.exe" || argv[0].endsWith("/node") || argv[0].endsWith("\\node.exe"))
+    && typeof argv[1] === "string"
+    && argv[1].endsWith(".js")
+    && argv.slice(2).includes("wrap")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export async function installCursorHook(
+  hooksPath = getDefaultHooksPath(),
+  options: CursorHookCommandOptions = {},
+): Promise<InstallCursorHookResult> {
+  const { config, backupPath } = await loadCursorHooksConfig(hooksPath);
+  const command = await buildCursorHookCommand(options);
+  const preToolUse = Array.isArray(config.hooks.preToolUse) ? config.hooks.preToolUse : [];
+  const retained = preToolUse.filter((hook) => !isTokenjuiceCursorHook(hook));
+  retained.push(createTokenjuiceCursorHook(command));
+  config.hooks.preToolUse = retained;
+  if (typeof config.version !== "number") {
+    config.version = 1;
+  }
+
+  await mkdir(dirname(hooksPath), { recursive: true });
+  const tempPath = `${hooksPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await rename(tempPath, hooksPath);
+
+  return {
+    hooksPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+export async function doctorCursorHook(
+  hooksPath = getDefaultHooksPath(),
+  options: CursorHookCommandOptions = {},
+): Promise<CursorDoctorReport> {
+  const expectedCommand = await buildCursorHookCommand(options);
+  const { config, exists } = await readCursorHooksConfig(hooksPath);
+  const detectedCommand = findTokenjuiceCursorHookCommand(config);
+
+  if (!exists || !detectedCommand) {
+    return {
+      hooksPath,
+      status: "disabled",
+      issues: [],
+      fixCommand: TOKENJUICE_CURSOR_FIX_COMMAND,
+      expectedCommand,
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  const checkedPaths = extractHookCommandPaths(detectedCommand);
+  const missingPaths: string[] = [];
+  for (const path of checkedPaths) {
+    if (!(await isExecutableFile(path)) && !(path.endsWith(".js") && await pathExists(path))) {
+      missingPaths.push(path);
+    }
+  }
+
+  const issues: string[] = [];
+  if (detectedCommand !== expectedCommand) {
+    if (detectedCommand.includes("/Cellar/")) {
+      issues.push("configured Cursor hook is pinned to a versioned Homebrew Cellar path");
+    } else {
+      issues.push("configured Cursor hook command does not match the current recommended command");
+    }
+  }
+  if (missingPaths.length > 0) {
+    issues.push(`configured Cursor hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
+  }
+
+  return {
+    hooksPath,
+    status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
+    issues,
+    fixCommand: TOKENJUICE_CURSOR_FIX_COMMAND,
+    expectedCommand,
+    detectedCommand,
+    checkedPaths,
+    missingPaths,
+  };
+}
+
+export async function runCursorPreToolUseHook(rawText: string, wrapLauncher = "tokenjuice"): Promise<number> {
+  let payload: CursorPreToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as CursorPreToolUsePayload;
+  } catch {
+    return 0;
+  }
+
+  if (payload.tool_name !== "Shell" || !isRecord(payload.tool_input)) {
+    return 0;
+  }
+
+  const toolInput = payload.tool_input as CursorToolInput;
+  const command = typeof toolInput.command === "string" ? toolInput.command : undefined;
+  if (!command || !command.trim()) {
+    return 0;
+  }
+  if (commandAlreadyWrapped(command)) {
+    return 0;
+  }
+
+  const launcherCommand = wrapLauncher.endsWith(".js")
+    ? `${shellQuote(process.execPath)} ${shellQuote(wrapLauncher)}`
+    : shellQuote(wrapLauncher);
+  const wrappedCommand = `${launcherCommand} wrap -- bash -lc ${shellQuote(command)}`;
+  const response = {
+    permission: "allow",
+    updated_input: {
+      ...toolInput,
+      command: wrappedCommand,
+    },
+  };
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+  return 0;
+}

--- a/src/core/hook-doctor.ts
+++ b/src/core/hook-doctor.ts
@@ -1,9 +1,11 @@
 import { doctorClaudeCodeHook } from "./claude-code.js";
 import { doctorCodexHook } from "./codex.js";
+import { doctorCursorHook } from "./cursor.js";
 import { doctorPiExtension } from "./pi.js";
 
 import type { ClaudeCodeDoctorReport } from "./claude-code.js";
 import type { CodexDoctorReport, CodexHookCommandOptions } from "./codex.js";
+import type { CursorDoctorReport } from "./cursor.js";
 import type { PiDoctorReport } from "./pi.js";
 
 type HookHealthStatus = "ok" | "warn" | "broken" | "disabled";
@@ -11,6 +13,7 @@ type HookHealthStatus = "ok" | "warn" | "broken" | "disabled";
 export type HookIntegrationDoctorReport = {
   codex: CodexDoctorReport;
   "claude-code": ClaudeCodeDoctorReport;
+  cursor: CursorDoctorReport;
   pi: PiDoctorReport;
 };
 
@@ -38,13 +41,15 @@ function mergeStatus(left: HookHealthStatus, right: HookHealthStatus): HookHealt
 export async function doctorInstalledHooks(codexOptions: CodexHookCommandOptions = {}): Promise<HookDoctorReport> {
   const codex = await doctorCodexHook(undefined, codexOptions);
   const claudeCode = await doctorClaudeCodeHook();
+  const cursor = await doctorCursorHook();
   const pi = await doctorPiExtension();
 
   return {
-    status: mergeStatus(mergeStatus(codex.status, claudeCode.status), pi.status),
+    status: mergeStatus(mergeStatus(mergeStatus(codex.status, claudeCode.status), cursor.status), pi.status),
     integrations: {
       codex,
       "claude-code": claudeCode,
+      cursor,
       pi,
     },
   };

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -562,6 +562,14 @@ export async function reduceExecutionWithRules(
   const rawText = buildRawText(normalizedInput);
   const measuredRawChars = countTextChars(stripAnsi(rawText));
   const classification = classifyExecution(normalizedInput, rules, opts.classifier);
+  const trace = opts.trace
+    ? {
+        ...(normalizedInput.command ? { normalizedCommand: normalizedInput.command } : {}),
+        ...(normalizedInput.argv?.length ? { normalizedArgv: normalizedInput.argv } : {}),
+        ...(classification.matchedReducer ? { matchedReducer: classification.matchedReducer } : {}),
+        family: classification.family,
+      }
+    : undefined;
 
   if (opts.raw) {
     const rawRef = opts.store
@@ -597,6 +605,7 @@ export async function reduceExecutionWithRules(
 
     return {
       inlineText: rawText,
+      ...(trace ? { trace } : {}),
       ...(rawRef ? { rawRef } : {}),
       stats: {
         rawChars: measuredRawChars,
@@ -626,6 +635,7 @@ export async function reduceExecutionWithRules(
 
     return {
       inlineText: rawText,
+      ...(trace ? { trace } : {}),
       stats: {
         rawChars: measuredRawChars,
         reducedChars: measuredRawChars,
@@ -693,6 +703,7 @@ export async function reduceExecutionWithRules(
     inlineText,
     ...(summary ? { previewText: summary } : {}),
     ...(Object.keys(facts).length > 0 ? { facts } : {}),
+    ...(trace ? { trace } : {}),
     ...(rawRef ? { rawRef } : {}),
     stats,
     classification,

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -104,6 +104,7 @@ export async function runWrappedCommand(argv: string[], opts: WrapOptions = {}):
           },
           {
             raw: opts.raw ?? false,
+            trace: opts.trace ?? false,
             recordStats: opts.recordStats ?? false,
             store: opts.store ?? false,
             ...(opts.storeDir ? { storeDir: opts.storeDir } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   uninstallCodexHook,
 } from "./core/codex.js";
 export type { CodexFeatureFlagStatus } from "./core/codex.js";
+export { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "./core/cursor.js";
 export { doctorInstalledHooks } from "./core/hook-doctor.js";
 export { doctorPiExtension, installPiExtension } from "./core/pi.js";
 export { runReduceJsonCli } from "./core/cli-client.js";
@@ -41,4 +42,5 @@ export type {
   WrapResult,
 } from "./types.js";
 export type { InstallPiExtensionResult, PiDoctorReport, PiExtensionCommandOptions } from "./core/pi.js";
+export type { CursorDoctorReport, InstallCursorHookResult } from "./core/cursor.js";
 export type { StatsOptions, StatsReport } from "./core/analysis.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,12 @@ export type CompactResult = {
   inlineText: string;
   previewText?: string;
   facts?: Record<string, number>;
+  trace?: {
+    normalizedCommand?: string;
+    normalizedArgv?: string[];
+    matchedReducer?: string;
+    family: string;
+  };
   rawRef?: StoredArtifactRef;
   stats: {
     rawChars: number;
@@ -163,6 +169,7 @@ export type StoredArtifact = {
 export type ReduceOptions = {
   classifier?: string;
   maxInlineChars?: number;
+  trace?: boolean;
   raw?: boolean;
   recordStats?: boolean;
   store?: boolean;
@@ -207,6 +214,7 @@ export type WrapOptions = {
   storeDir?: string;
   tee?: boolean;
   raw?: boolean;
+  trace?: boolean;
   maxInlineChars?: number;
   maxCaptureBytes?: number;
 };

--- a/test/classify.test.ts
+++ b/test/classify.test.ts
@@ -14,6 +14,17 @@ function buildRule(commandIncludes: string[]): JsonRule {
   };
 }
 
+function buildAnyRule(commandIncludesAny: string[]): JsonRule {
+  return {
+    id: "test/any-rule",
+    family: "test",
+    match: {
+      toolNames: ["exec"],
+      commandIncludesAny,
+    },
+  };
+}
+
 describe("matchesRule commandIncludes", () => {
   it("matches terminal token patterns even when they end the command", () => {
     const rule = buildRule([" && git diff"]);
@@ -27,6 +38,16 @@ describe("matchesRule commandIncludes", () => {
 
   it("does not match partial tokens", () => {
     const rule = buildRule([" && git diff"]);
+    const input: ToolExecutionInput = {
+      toolName: "exec",
+      command: "git status && git diffx",
+    };
+
+    expect(matchesRule(rule, input)).toBe(false);
+  });
+
+  it("applies the same boundary protection to commandIncludesAny", () => {
+    const rule = buildAnyRule(["git diff"]);
     const input: ToolExecutionInput = {
       toolName: "exec",
       command: "git status && git diffx",

--- a/test/classify.test.ts
+++ b/test/classify.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesRule } from "../src/core/classify.js";
+import type { JsonRule, ToolExecutionInput } from "../src/types.js";
+
+function buildRule(commandIncludes: string[]): JsonRule {
+  return {
+    id: "test/rule",
+    family: "test",
+    match: {
+      toolNames: ["exec"],
+      commandIncludes,
+    },
+  };
+}
+
+describe("matchesRule commandIncludes", () => {
+  it("matches terminal token patterns even when they end the command", () => {
+    const rule = buildRule([" && git diff"]);
+    const input: ToolExecutionInput = {
+      toolName: "exec",
+      command: "git status && git diff",
+    };
+
+    expect(matchesRule(rule, input)).toBe(true);
+  });
+
+  it("does not match partial tokens", () => {
+    const rule = buildRule([" && git diff"]);
+    const input: ToolExecutionInput = {
+      toolName: "exec",
+      command: "git status && git diffx",
+    };
+
+    expect(matchesRule(rule, input)).toBe(false);
+  });
+});

--- a/test/claude-code.test.ts
+++ b/test/claude-code.test.ts
@@ -12,6 +12,7 @@ const originalPath = process.env.PATH;
 afterEach(async () => {
   delete process.env.CLAUDE_HOME;
   delete process.env.CODEX_HOME;
+  delete process.env.CURSOR_HOME;
   delete process.env.PI_CODING_AGENT_DIR;
   process.env.PATH = originalPath;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -355,6 +356,7 @@ describe("doctorInstalledHooks", () => {
     process.env.PATH = binDir;
     process.env.CODEX_HOME = home;
     process.env.CLAUDE_HOME = home;
+    process.env.CURSOR_HOME = home;
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
@@ -379,6 +381,7 @@ describe("doctorInstalledHooks", () => {
     process.env.PATH = binDir;
     process.env.CODEX_HOME = home;
     process.env.CLAUDE_HOME = home;
+    process.env.CURSOR_HOME = home;
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });

--- a/test/codex-feature-flag.test.ts
+++ b/test/codex-feature-flag.test.ts
@@ -122,6 +122,10 @@ describe("inspectCodexHooksFeatureFlag", () => {
     if (process.platform === "win32") {
       return;
     }
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      // root can read files regardless of mode bits; unreadable chmod tests are not meaningful.
+      return;
+    }
 
     await withTempCodexHome(async ({ configPath }) => {
       await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -59,6 +59,26 @@ describe("normalizeExecutionInput", () => {
     expect(normalized.argv).toEqual(["git", "status", "--short"]);
   });
 
+  it("unwraps absolute-path shell launchers used by cursor hooks", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "/usr/bin/zsh -lc 'git status --short'",
+      argv: ["/usr/bin/zsh", "-lc", "git status --short"],
+    });
+    expect(normalized.command).toBe("git status --short");
+    expect(normalized.argv).toEqual(["git", "status", "--short"]);
+  });
+
+  it("does not unwrap non-shell launchers such as ssh -c", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "/usr/bin/ssh -c aes128-ctr host",
+      argv: ["/usr/bin/ssh", "-c", "aes128-ctr", "host"],
+    });
+    expect(normalized.command).toBe("/usr/bin/ssh -c aes128-ctr host");
+    expect(normalized.argv).toEqual(["/usr/bin/ssh", "-c", "aes128-ctr", "host"]);
+  });
+
   it("unwraps bash -lc but keeps compound nested commands as command-only", () => {
     const normalized = normalizeExecutionInput({
       toolName: "exec",

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -48,6 +48,26 @@ describe("normalizeExecutionInput", () => {
       command: "rg --files | rg TODO src",
     }).argv).toBeUndefined();
   });
+
+  it("unwraps bash -lc wrappers and classifies the nested command", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "bash -lc 'git status --short'",
+      argv: ["bash", "-lc", "git status --short"],
+    });
+    expect(normalized.command).toBe("git status --short");
+    expect(normalized.argv).toEqual(["git", "status", "--short"]);
+  });
+
+  it("unwraps bash -lc but keeps compound nested commands as command-only", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "bash -lc 'rg --files | rg TODO src'",
+      argv: ["bash", "-lc", "rg --files | rg TODO src"],
+    });
+    expect(normalized.command).toBe("rg --files | rg TODO src");
+    expect(normalized.argv).toBeUndefined();
+  });
 });
 
 describe("hasSequentialShellCommands", () => {

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -8,9 +8,21 @@ import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "..
 
 const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
+const originalShell = process.env.SHELL;
+const originalCursorShell = process.env.TOKENJUICE_CURSOR_SHELL;
 
 afterEach(async () => {
   process.env.PATH = originalPath;
+  if (originalShell === undefined) {
+    delete process.env.SHELL;
+  } else {
+    process.env.SHELL = originalShell;
+  }
+  if (originalCursorShell === undefined) {
+    delete process.env.TOKENJUICE_CURSOR_SHELL;
+  } else {
+    process.env.TOKENJUICE_CURSOR_SHELL = originalCursorShell;
+  }
   delete process.env.CURSOR_HOME;
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
@@ -108,11 +120,16 @@ describe("doctorCursorHook", () => {
 });
 
 describe("runCursorPreToolUseHook", () => {
-  it("wraps shell commands with tokenjuice wrap", async () => {
+  it("wraps shell commands with tokenjuice wrap using the provided host shell", async () => {
+    const home = await createTempDir();
+    const hostShellPath = join(home, "host-shell");
+    await writeFile(hostShellPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
     const payload = JSON.stringify({
       tool_name: "Shell",
       tool_input: {
         command: "git status --short",
+        shell: hostShellPath,
         working_directory: "/repo",
       },
     });
@@ -123,7 +140,7 @@ describe("runCursorPreToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.updated_input.command).toBe("/usr/local/bin/tokenjuice wrap -- sh -lc 'git status --short'");
+    expect(response.updated_input.command).toBe(`/usr/local/bin/tokenjuice wrap -- ${hostShellPath} -lc 'git status --short'`);
     expect(response.updated_input.working_directory).toBe("/repo");
   });
 
@@ -142,10 +159,15 @@ describe("runCursorPreToolUseHook", () => {
   });
 
   it("uses node to execute a js wrap launcher path", async () => {
+    const home = await createTempDir();
+    const hostShellPath = join(home, "host-shell");
+    await writeFile(hostShellPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
     const payload = JSON.stringify({
       tool_name: "Shell",
       tool_input: {
         command: "git status --short",
+        shell: hostShellPath,
       },
     });
 
@@ -157,7 +179,7 @@ describe("runCursorPreToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- sh -lc 'git status --short'`);
+    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- ${hostShellPath} -lc 'git status --short'`);
   });
 
   it("skips node-based local wrap commands to preserve raw bypass", async () => {
@@ -169,6 +191,47 @@ describe("runCursorPreToolUseHook", () => {
     });
 
     const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
+  it("falls back to SHELL when tool_input.shell is absent", async () => {
+    const home = await createTempDir();
+    const shellDir = join(home, "bin");
+    const hostShellPath = join(shellDir, "zsh");
+    process.env.PATH = shellDir;
+    process.env.SHELL = "zsh";
+    await mkdir(shellDir, { recursive: true });
+    await writeFile(hostShellPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "git status --short",
+      },
+    });
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+    const response = JSON.parse(output) as {
+      updated_input: { command: string };
+    };
+
+    expect(code).toBe(0);
+    expect(response.updated_input.command).toBe(`/usr/local/bin/tokenjuice wrap -- ${hostShellPath} -lc 'git status --short'`);
+  });
+
+  it("leaves command unchanged when no host shell can be resolved", async () => {
+    process.env.PATH = "";
+    process.env.SHELL = "/definitely/missing-shell";
+    process.env.TOKENJUICE_CURSOR_SHELL = "/definitely/missing-shell";
+
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "git status --short",
+      },
+    });
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
 
     expect(code).toBe(0);
     expect(output).toBe("");

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -10,6 +10,7 @@ const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
 const originalShell = process.env.SHELL;
 const originalCursorShell = process.env.TOKENJUICE_CURSOR_SHELL;
+const originalPlatform = process.platform;
 
 afterEach(async () => {
   process.env.PATH = originalPath;
@@ -24,6 +25,7 @@ afterEach(async () => {
     process.env.TOKENJUICE_CURSOR_SHELL = originalCursorShell;
   }
   delete process.env.CURSOR_HOME;
+  Object.defineProperty(process, "platform", { value: originalPlatform });
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -47,6 +49,10 @@ async function captureStdout(run: () => Promise<number>): Promise<{ code: number
   } finally {
     process.stdout.write = originalWrite;
   }
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value });
 }
 
 describe("installCursorHook", () => {
@@ -97,6 +103,16 @@ describe("installCursorHook", () => {
     expect(result.command).toContain(`${resolve("dist/cli/main.js")} cursor-pre-tool-use`);
     expect(result.command).toContain("--wrap-launcher");
   });
+
+  it("rejects native Windows installs instead of writing a broken hook", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    setPlatform("win32");
+
+    await expect(installCursorHook(hooksPath)).rejects.toThrow(
+      "tokenjuice cursor integration does not support native Windows shells yet. run Cursor in WSL instead.",
+    );
+  });
 });
 
 describe("doctorCursorHook", () => {
@@ -116,6 +132,35 @@ describe("doctorCursorHook", () => {
     expect(report.status).toBe("ok");
     expect(report.detectedCommand).toContain(`${launcherPath} cursor-pre-tool-use`);
     expect(report.issues).toEqual([]);
+  });
+
+  it("flags a configured native Windows hook as broken", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          preToolUse: [
+            {
+              type: "command",
+              matcher: "Shell",
+              command: String.raw`C:\Users\andre\bin\tokenjuice.exe cursor-pre-tool-use --wrap-launcher C:\Users\andre\bin\tokenjuice.exe`,
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    setPlatform("win32");
+
+    const report = await doctorCursorHook(hooksPath);
+
+    expect(report.status).toBe("broken");
+    expect(report.issues).toContain("configured Cursor hook cannot run on native Windows; use Cursor in WSL instead.");
+    expect(report.detectedCommand).toContain("cursor-pre-tool-use");
+    expect(report.fixCommand).toBe("run Cursor in WSL, then run tokenjuice install cursor");
   });
 });
 
@@ -235,5 +280,25 @@ describe("runCursorPreToolUseHook", () => {
 
     expect(code).toBe(0);
     expect(output).toBe("");
+  });
+
+  it("denies native Windows shell interception with a WSL message", async () => {
+    setPlatform("win32");
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "git status --short",
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+    const response = JSON.parse(output) as {
+      permission: string;
+      user_message: string;
+    };
+
+    expect(code).toBe(0);
+    expect(response.permission).toBe("deny");
+    expect(response.user_message).toBe("tokenjuice cursor integration does not support native Windows shells yet. run Cursor in WSL instead.");
   });
 });

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -74,6 +74,17 @@ describe("installCursorHook", () => {
     expect(result.command).toContain(`${launcherPath} cursor-pre-tool-use`);
     expect(parsed.hooks.preToolUse[0]?.command).toContain(`${launcherPath} cursor-pre-tool-use`);
   });
+
+  it("persists absolute launcher path when installing from relative binaryPath", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    process.env.PATH = "";
+
+    const result = await installCursorHook(hooksPath, { binaryPath: "dist/cli/main.js", nodePath: "/usr/bin/node" });
+
+    expect(result.command).toContain(`${resolve("dist/cli/main.js")} cursor-pre-tool-use`);
+    expect(result.command).toContain("--wrap-launcher");
+  });
 });
 
 describe("doctorCursorHook", () => {
@@ -112,7 +123,7 @@ describe("runCursorPreToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.updated_input.command).toBe("/usr/local/bin/tokenjuice wrap -- bash -lc 'git status --short'");
+    expect(response.updated_input.command).toBe("/usr/local/bin/tokenjuice wrap -- sh -lc 'git status --short'");
     expect(response.updated_input.working_directory).toBe("/repo");
   });
 
@@ -146,7 +157,7 @@ describe("runCursorPreToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- bash -lc 'git status --short'`);
+    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- sh -lc 'git status --short'`);
   });
 
   it("skips node-based local wrap commands to preserve raw bypass", async () => {

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -1,0 +1,165 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../src/index.js";
+
+const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  delete process.env.CURSOR_HOME;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-cursor-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("installCursorHook", () => {
+  it("installs a single tokenjuice preToolUse shell hook", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+
+    const result = await installCursorHook(hooksPath);
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ command: string; matcher?: string; type?: string }>>;
+    };
+
+    expect(result.hooksPath).toBe(hooksPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(parsed.hooks.preToolUse).toHaveLength(1);
+    expect(parsed.hooks.preToolUse[0]?.matcher).toBe("Shell");
+    expect(parsed.hooks.preToolUse[0]?.type).toBe("command");
+    expect(parsed.hooks.preToolUse[0]?.command).toContain("cursor-pre-tool-use");
+    expect(parsed.hooks.preToolUse[0]?.command).toContain("--wrap-launcher");
+  });
+
+  it("prefers a stable tokenjuice launcher from PATH", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const result = await installCursorHook(hooksPath);
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ command: string }>>;
+    };
+
+    expect(result.command).toContain(`${launcherPath} cursor-pre-tool-use`);
+    expect(parsed.hooks.preToolUse[0]?.command).toContain(`${launcherPath} cursor-pre-tool-use`);
+  });
+});
+
+describe("doctorCursorHook", () => {
+  it("reports a healthy installed launcher hook", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await installCursorHook(hooksPath);
+
+    const report = await doctorCursorHook(hooksPath);
+
+    expect(report.status).toBe("ok");
+    expect(report.detectedCommand).toContain(`${launcherPath} cursor-pre-tool-use`);
+    expect(report.issues).toEqual([]);
+  });
+});
+
+describe("runCursorPreToolUseHook", () => {
+  it("wraps shell commands with tokenjuice wrap", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "git status --short",
+        working_directory: "/repo",
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+    const response = JSON.parse(output) as {
+      updated_input: { command: string; working_directory?: string };
+    };
+
+    expect(code).toBe(0);
+    expect(response.updated_input.command).toBe("/usr/local/bin/tokenjuice wrap -- bash -lc 'git status --short'");
+    expect(response.updated_input.working_directory).toBe("/repo");
+  });
+
+  it("skips commands that are already wrapped", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "tokenjuice wrap -- git status",
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
+  it("uses node to execute a js wrap launcher path", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "git status --short",
+      },
+    });
+
+    const { code, output } = await captureStdout(() =>
+      runCursorPreToolUseHook(payload, "/repo/dist/cli/main.js")
+    );
+    const response = JSON.parse(output) as {
+      updated_input: { command: string };
+    };
+
+    expect(code).toBe(0);
+    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- bash -lc 'git status --short'`);
+  });
+
+  it("skips node-based local wrap commands to preserve raw bypass", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "node dist/cli/main.js wrap --raw -- git status",
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+});

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { reduceExecution, runWrappedCommand } from "../src/index.js";
+
+describe("reduce trace", () => {
+  it("includes normalized command and argv when trace is enabled", async () => {
+    const result = await reduceExecution(
+      {
+        toolName: "exec",
+        command: "bash -lc 'git status --short'",
+        argv: ["bash", "-lc", "git status --short"],
+        combinedText: " M src/core/reduce.ts\n",
+        exitCode: 0,
+      },
+      { trace: true },
+    );
+
+    expect(result.trace?.normalizedCommand).toBe("git status --short");
+    expect(result.trace?.normalizedArgv).toEqual(["git", "status", "--short"]);
+    expect(result.trace?.matchedReducer).toBe("git/status");
+  });
+
+  it("does not emit trace block when trace is disabled", async () => {
+    const result = await reduceExecution(
+      {
+        toolName: "exec",
+        command: "git status --short",
+        combinedText: " M src/core/reduce.ts\n",
+        exitCode: 0,
+      },
+      {},
+    );
+
+    expect(result.trace).toBeUndefined();
+  });
+
+  it("propagates trace through wrap execution", async () => {
+    const wrapped = await runWrappedCommand(["bash", "-lc", "git status --short"], {
+      trace: true,
+    });
+
+    expect(wrapped.result.trace?.normalizedCommand).toBe("git status --short");
+    expect(wrapped.result.trace?.normalizedArgv).toEqual(["git", "status", "--short"]);
+    expect(wrapped.result.trace?.matchedReducer).toBe("git/status");
+  });
+});

--- a/test/trace.test.ts
+++ b/test/trace.test.ts
@@ -34,6 +34,23 @@ describe("reduce trace", () => {
     expect(result.trace).toBeUndefined();
   });
 
+  it("classifies wrapped commands from absolute-path shell launchers", async () => {
+    const result = await reduceExecution(
+      {
+        toolName: "exec",
+        command: "/usr/bin/zsh -lc 'rg --files src'",
+        argv: ["/usr/bin/zsh", "-lc", "rg --files src"],
+        combinedText: "src/index.ts\nsrc/core/command.ts\nsrc/core/classify.ts\n",
+        exitCode: 0,
+      },
+      { trace: true },
+    );
+
+    expect(result.trace?.normalizedCommand).toBe("rg --files src");
+    expect(result.trace?.normalizedArgv).toEqual(["rg", "--files", "src"]);
+    expect(result.trace?.matchedReducer).toBe("filesystem/rg-files");
+  });
+
   it("propagates trace through wrap execution", async () => {
     const wrapped = await runWrappedCommand(["bash", "-lc", "git status --short"], {
       trace: true,


### PR DESCRIPTION
## Summary
- add Cursor integration install/doctor/runtime wiring and aggregate hook doctor support
- improve command normalization and classification so wrapped shell commands keep matching specific reducers
- harden matching and test stability with boundary-aware commandIncludes logic and root-safe chmod test handling

## Compatibility note
- native Windows shell interception is intentionally not supported in this PR
- Cursor integration is supported on Linux/macOS and in WSL
- on native Windows, users should run Cursor inside WSL to use tokenjuice integration

## Test plan
- [x] pnpm typecheck
- [x] pnpm test

Made with [Cursor](https://cursor.com)