### PR TITLE
fix(hosts/claude-code): honor CLAUDE_CONFIG_DIR for config discovery

### DIFF
--- a/docs/integration-playbook.md
+++ b/docs/integration-playbook.md
@@ -70,7 +70,7 @@ add host-specific tests and aggregate tests:
 
 new adapters often fail CI/local due to leaked machine config. isolate host homes explicitly:
 
-- set and reset host env vars in each suite (`CODEX_HOME`, `CLAUDE_HOME`, `CURSOR_HOME`, `PI_CODING_AGENT_DIR`, etc.)
+- set and reset host env vars in each suite (`CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `CLAUDE_HOME`, `CURSOR_HOME`, `PI_CODING_AGENT_DIR`, etc.)
 - avoid reading real `~/.<host>` in tests
 - use temp dirs for all config paths
 - restore `PATH` after each test

--- a/docs/integration-playbook.md
+++ b/docs/integration-playbook.md
@@ -24,7 +24,7 @@ for pre-tool wrapping, preserve shell semantics (for example `bash -lc '<cmd>'`)
 
 ## implementation checklist
 
-for a new host adapter in `src/core/<host>.ts`:
+for a new host adapter in `src/hosts/<host>/index.ts`:
 
 - install flow
   - write/update host config atomically
@@ -51,14 +51,14 @@ then wire CLI + exports:
 - `src/index.ts`
   - runtime/install/doctor exports
   - result/report type exports
-- `src/core/hook-doctor.ts`
+- `src/hosts/shared/hook-doctor.ts`
   - add the host to aggregate doctor report
 
 ## test strategy (required)
 
 add host-specific tests and aggregate tests:
 
-- `test/<host>.test.ts`
+- `test/hosts/<host>.test.ts`
   - install idempotency
   - preserve unrelated config fields
   - doctor status matrix (`disabled`, `warn`, `broken`, `ok`)
@@ -83,7 +83,7 @@ minimum gate for a new host adapter:
 
 ```bash
 pnpm typecheck
-pnpm vitest run test/<host>.test.ts
+pnpm vitest run test/hosts/<host>.test.ts
 pnpm vitest run test/hosts/codex.test.ts test/hosts/claude-code.test.ts test/hosts/pi.test.ts
 ```
 

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -60,7 +60,10 @@ const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
 const TOKENJUICE_CLAUDE_CODE_FIX_COMMAND = "tokenjuice install claude-code";
 
 function getClaudeCodeHome(): string {
-  return process.env.CLAUDE_HOME || join(homedir(), ".claude");
+  // Claude Code itself reads CLAUDE_CONFIG_DIR for its config directory, so
+  // honor it first to stay aligned with the host. CLAUDE_HOME is kept as a
+  // fallback for backwards compatibility with existing tokenjuice installs.
+  return process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), ".claude");
 }
 
 function getDefaultSettingsPath(): string {

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -60,9 +60,9 @@ const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
 const TOKENJUICE_CLAUDE_CODE_FIX_COMMAND = "tokenjuice install claude-code";
 
 function getClaudeCodeHome(): string {
-  // Claude Code itself reads CLAUDE_CONFIG_DIR for its config directory, so
-  // honor it first to stay aligned with the host. CLAUDE_HOME is kept as a
-  // fallback for backwards compatibility with existing tokenjuice installs.
+  // Claude Code resolves its config directory from CLAUDE_CONFIG_DIR, so honor
+  // it first to stay aligned with the host. CLAUDE_HOME is kept as a fallback
+  // for backwards compatibility with existing tokenjuice installs.
   return process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), ".claude");
 }
 

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -693,4 +693,14 @@ describe("claude code config directory discovery", () => {
     const debug = JSON.parse(await readFile(debugPath, "utf8")) as { skipped?: string };
     expect(debug.skipped).toBe("empty-tool-response");
   });
+
+  it("doctor reads settings.json from CLAUDE_CONFIG_DIR when no path is provided", async () => {
+    const configDir = await createTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    await installClaudeCodeHook();
+
+    const report = await doctorClaudeCodeHook();
+
+    expect(report.settingsPath).toBe(join(configDir, "settings.json"));
+  });
 });

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -10,6 +10,7 @@ const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
 
 afterEach(async () => {
+  delete process.env.CLAUDE_CONFIG_DIR;
   delete process.env.CLAUDE_HOME;
   delete process.env.CODEX_HOME;
   delete process.env.CURSOR_HOME;
@@ -639,6 +640,57 @@ describe("runClaudeCodePostToolUseHook", () => {
     expect(code).toBe(0);
     expect(output).toBe("");
     expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("empty-tool-response");
+  });
+});
+
+describe("claude code config directory discovery", () => {
+  it("prefers CLAUDE_CONFIG_DIR over CLAUDE_HOME when both are set", async () => {
+    const configDir = await createTempDir();
+    const legacyHome = await createTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.env.CLAUDE_HOME = legacyHome;
+
+    const result = await installClaudeCodeHook();
+
+    expect(result.settingsPath).toBe(join(configDir, "settings.json"));
+  });
+
+  it("uses CLAUDE_CONFIG_DIR when CLAUDE_HOME is unset", async () => {
+    const configDir = await createTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    const result = await installClaudeCodeHook();
+
+    expect(result.settingsPath).toBe(join(configDir, "settings.json"));
+  });
+
+  it("falls back to CLAUDE_HOME when CLAUDE_CONFIG_DIR is unset", async () => {
+    const legacyHome = await createTempDir();
+    process.env.CLAUDE_HOME = legacyHome;
+
+    const result = await installClaudeCodeHook();
+
+    expect(result.settingsPath).toBe(join(legacyHome, "settings.json"));
+  });
+
+  it("writes hook debug log under CLAUDE_CONFIG_DIR when set", async () => {
+    const configDir = await createTempDir();
+    const legacyHome = await createTempDir();
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.env.CLAUDE_HOME = legacyHome;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+      tool_response: "",
+    });
+
+    await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+
+    const debugPath = join(configDir, "tokenjuice-hook.last.json");
+    const debug = JSON.parse(await readFile(debugPath, "utf8")) as { skipped?: string };
     expect(debug.skipped).toBe("empty-tool-response");
   });
 });


### PR DESCRIPTION
## Summary

`tokenjuice install claude-code` currently writes `settings.json` to a directory Claude Code does not read when the user sets `CLAUDE_CONFIG_DIR`, so the PostToolUse hook is never invoked.

## The bug

Claude Code reads `CLAUDE_CONFIG_DIR` for its config directory. The var is listed in the binary's official env var table (alongside the other `CLAUDE_CODE_*` vars). `CLAUDE_HOME` is not present in that list and Claude Code does not honor it.

The claude-code host adapter only checked `process.env.CLAUDE_HOME`. When a user sets `CLAUDE_CONFIG_DIR` (for example to isolate Claude Code configs across projects or during tests), `tokenjuice install claude-code` lands the hook in `$CLAUDE_HOME/settings.json` but Claude Code reads from `$CLAUDE_CONFIG_DIR/settings.json`, so the hook never fires.

## Reproducing

```bash
export CLAUDE_CONFIG_DIR=/tmp/cc-test
mkdir -p /tmp/cc-test
tokenjuice install claude-code        # writes to ~/.claude/settings.json
ls /tmp/cc-test/settings.json         # ENOENT, but this is where Claude Code reads
```

With the fix, `install claude-code` writes to `/tmp/cc-test/settings.json` and Claude Code honors the hook.

## The fix

Preference order in `getClaudeCodeHome()`:

1. `CLAUDE_CONFIG_DIR` (what Claude Code itself reads)
2. `CLAUDE_HOME` (kept for backwards compatibility with existing installs)
3. `~/.claude` (default)

## Test coverage

Five new tests in a `claude code config directory discovery` block:

- `CLAUDE_CONFIG_DIR` takes priority when both env vars are set
- `CLAUDE_CONFIG_DIR` alone resolves correctly
- `CLAUDE_HOME` alone still resolves (backwards compat)
- hook debug log lands under `CLAUDE_CONFIG_DIR` when set
- `doctorClaudeCodeHook()` with no explicit path resolves through `CLAUDE_CONFIG_DIR`

Also:
- `afterEach` clears `CLAUDE_CONFIG_DIR` alongside the other host envs
- `docs/integration-playbook.md` test isolation list adds `CLAUDE_CONFIG_DIR`

## Verified

- `pnpm test` 364/364 pass (23 in `test/hosts/claude-code.test.ts`, up from 18)
- `pnpm typecheck` clean
- `pnpm build` clean
- End-to-end smoke on local Claude Code 2.1.116: hook installs under `$CLAUDE_CONFIG_DIR/settings.json` and fires correctly on `find`-class commands (20507 -> 489 char reduction, `rewrote: true`)
- Clean-room validation in an isolated Ubuntu 24.04 container: identical test results

## Backwards compatibility

Existing users who set `CLAUDE_HOME` but not `CLAUDE_CONFIG_DIR` are unaffected. Users who set both will shift to `CLAUDE_CONFIG_DIR` (which is what Claude Code itself reads, so this aligns behavior with the host).

## Potential follow-up

A `CLAUDE_HOME`-only user today still gets a non-functional install because Claude Code itself does not read that env var. This PR preserves that existing behavior for backwards compatibility. A future PR could emit a warning from `install claude-code` / `doctor` when `CLAUDE_HOME` is set without `CLAUDE_CONFIG_DIR`, or deprecate `CLAUDE_HOME` entirely. Happy to open a follow-up if desired; kept out of this PR to keep the scope tight.
