### PR TITLE
feat(hooks): support local routing for claude and cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
 tokenjuice install [codex|claude-code|cursor|pi]
-tokenjuice install [codex|pi] --local
+tokenjuice install [codex|claude-code|cursor|pi] --local
 tokenjuice uninstall codex
 tokenjuice ls
 tokenjuice cat <artifact-id>
@@ -98,7 +98,7 @@ shared behavior:
 - `tokenjuice doctor hooks` checks installed host hooks together instead of making you guess which integration drifted
 - `tokenjuice doctor pi` inspects the installed Pi extension directly when you only care about that surface
 - `tokenjuice uninstall codex` cleanly removes the Codex hook and `tokenjuice doctor hooks` reports that as `disabled`, not broken
-- `tokenjuice install codex --local` / `tokenjuice doctor hooks --local` are for testing the current repo build before release
+- `tokenjuice install [codex|claude-code|cursor] --local` / `tokenjuice doctor hooks --local` are for testing the current repo build before release
 - `tokenjuice install pi --local` forces the installed pi extension to be bundled from the current repo source, so local integration changes can be verified before release
 - Claude Code preserves unrelated settings keys while updating `hooks.PostToolUse`
 - Codex, Claude Code, Cursor, and pi keep exact file-content reads raw, but compact safe repository inventory commands such as `find`, `ls`, `rg --files`, `git ls-files`, and `fd`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -162,6 +162,8 @@ tokenjuice install pi
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice install codex --local
+tokenjuice install claude-code --local
+tokenjuice install cursor --local
 tokenjuice install pi --local
 tokenjuice doctor hooks --local
 ```
@@ -170,12 +172,12 @@ supported host hooks:
 
 | Client | Install | Hook file | Notes |
 | --- | --- | --- | --- |
-| Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Preserves unrelated settings keys while updating `hooks.PostToolUse` |
+| Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Preserves unrelated settings keys while updating `hooks.PostToolUse`; `tokenjuice install claude-code --local` is available for repo-local verification |
 | Codex CLI | `tokenjuice install codex` | `~/.codex/hooks.json` | `tokenjuice install codex --local` is available for repo-local verification |
-| Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
+| Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; `tokenjuice install cursor --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor pi` is the direct Pi-only check. the `--local` variant is for codex dev verification and expects that hook to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor pi` is the direct Pi-only check. the `--local` variant expects Codex, Claude Code, and Cursor hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -60,8 +60,8 @@ function printUsage(): void {
       "  tokenjuice wrap [--raw|--full] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
       "  tokenjuice <command> ... [--trace]",
       "  tokenjuice install codex [--local]",
-      "  tokenjuice install claude-code",
-      "  tokenjuice install cursor",
+      "  tokenjuice install claude-code [--local]",
+      "  tokenjuice install cursor [--local]",
       "  tokenjuice install pi [--local]",
       "  tokenjuice uninstall codex",
       "  tokenjuice ls",
@@ -373,7 +373,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
   }
 
   if (target === "claude-code") {
-    const result = await installClaudeCodeHook();
+    const result = await installClaudeCodeHook(undefined, { local: args.local });
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
       return 0;
@@ -384,12 +384,12 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     if (result.backupPath) {
       process.stdout.write(`backup: ${result.backupPath}\n`);
     }
-    process.stdout.write("doctor: tokenjuice doctor hooks\n");
+    process.stdout.write(`doctor: tokenjuice doctor hooks${args.local ? " --local" : ""}\n`);
     return 0;
   }
 
   if (target === "cursor") {
-    const result = await installCursorHook();
+    const result = await installCursorHook(undefined, { local: args.local });
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
       return 0;
@@ -400,7 +400,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     if (result.backupPath) {
       process.stdout.write(`backup: ${result.backupPath}\n`);
     }
-    process.stdout.write("doctor: tokenjuice doctor hooks\n");
+    process.stdout.write(`doctor: tokenjuice doctor hooks${args.local ? " --local" : ""}\n`);
     process.stdout.write("escape hatch: tokenjuice wrap --raw -- <command>\n");
     return 0;
   }
@@ -724,7 +724,7 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
   }
 
   if (args.positionals[0] === "cursor") {
-    const report = await doctorCursorHook();
+    const report = await doctorCursorHook(undefined, { local: args.local });
 
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -754,7 +754,7 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
   }
 
   if (args.positionals[0] === "claude-code") {
-    const report = await doctorClaudeCodeHook();
+    const report = await doctorClaudeCodeHook(undefined, { local: args.local });
 
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -1,6 +1,6 @@
 import { constants as fsConstants } from "node:fs";
 import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
@@ -56,6 +56,12 @@ export type ClaudeCodeDoctorReport = {
   missingPaths: string[];
 };
 
+export type ClaudeCodeHookCommandOptions = {
+  local?: boolean;
+  binaryPath?: string;
+  nodePath?: string;
+};
+
 const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
 const TOKENJUICE_CLAUDE_CODE_FIX_COMMAND = "tokenjuice install claude-code";
 
@@ -102,14 +108,19 @@ async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
   return undefined;
 }
 
-async function buildClaudeCodeHookCommand(binaryPath = process.argv[1], nodePath = process.execPath): Promise<string> {
+async function buildClaudeCodeHookCommand(options: ClaudeCodeHookCommandOptions = {}): Promise<string> {
+  const rawBinaryPath = options.binaryPath ?? process.argv[1];
+  const binaryPath = rawBinaryPath && !isAbsolute(rawBinaryPath) ? resolve(rawBinaryPath) : rawBinaryPath;
+  const nodePath = options.nodePath ?? process.execPath;
   if (!binaryPath) {
     throw new Error("unable to resolve tokenjuice binary path for claude code install");
   }
 
-  const installedBinaryPath = await resolveInstalledTokenjuicePath();
-  if (installedBinaryPath) {
-    return `${shellQuote(installedBinaryPath)} claude-code-post-tool-use`;
+  if (!options.local) {
+    const installedBinaryPath = await resolveInstalledTokenjuicePath();
+    if (installedBinaryPath) {
+      return `${shellQuote(installedBinaryPath)} claude-code-post-tool-use`;
+    }
   }
 
   if (binaryPath.endsWith(".js")) {
@@ -117,6 +128,10 @@ async function buildClaudeCodeHookCommand(binaryPath = process.argv[1], nodePath
   }
 
   return `${shellQuote(binaryPath)} claude-code-post-tool-use`;
+}
+
+function getClaudeCodeFixCommand(local = false): string {
+  return local ? "tokenjuice install claude-code --local" : TOKENJUICE_CLAUDE_CODE_FIX_COMMAND;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -251,9 +266,12 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-export async function installClaudeCodeHook(settingsPath = getDefaultSettingsPath()): Promise<InstallClaudeCodeHookResult> {
+export async function installClaudeCodeHook(
+  settingsPath = getDefaultSettingsPath(),
+  options: ClaudeCodeHookCommandOptions = {},
+): Promise<InstallClaudeCodeHookResult> {
   const { config, backupPath } = await loadClaudeCodeSettings(settingsPath);
-  const command = await buildClaudeCodeHookCommand();
+  const command = await buildClaudeCodeHookCommand(options);
   const postToolUse = Array.isArray(config.hooks.PostToolUse) ? config.hooks.PostToolUse : [];
   const retained = postToolUse.filter((group) =>
     !(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup)),
@@ -273,8 +291,12 @@ export async function installClaudeCodeHook(settingsPath = getDefaultSettingsPat
   };
 }
 
-export async function doctorClaudeCodeHook(settingsPath = getDefaultSettingsPath()): Promise<ClaudeCodeDoctorReport> {
-  const expectedCommand = await buildClaudeCodeHookCommand();
+export async function doctorClaudeCodeHook(
+  settingsPath = getDefaultSettingsPath(),
+  options: ClaudeCodeHookCommandOptions = {},
+): Promise<ClaudeCodeDoctorReport> {
+  const expectedCommand = await buildClaudeCodeHookCommand(options);
+  const fixCommand = getClaudeCodeFixCommand(options.local);
   const { config, exists } = await readClaudeCodeSettings(settingsPath);
   const detectedCommand = findTokenjuiceClaudeCodeHookCommand(config);
 
@@ -283,7 +305,7 @@ export async function doctorClaudeCodeHook(settingsPath = getDefaultSettingsPath
       settingsPath,
       status: "warn",
       issues: ["claude code settings.json is missing"],
-      fixCommand: TOKENJUICE_CLAUDE_CODE_FIX_COMMAND,
+      fixCommand,
       expectedCommand,
       checkedPaths: [],
       missingPaths: [],
@@ -295,7 +317,7 @@ export async function doctorClaudeCodeHook(settingsPath = getDefaultSettingsPath
       settingsPath,
       status: "warn",
       issues: ["tokenjuice PostToolUse hook is not installed for Claude Code"],
-      fixCommand: TOKENJUICE_CLAUDE_CODE_FIX_COMMAND,
+      fixCommand,
       expectedCommand,
       checkedPaths: [],
       missingPaths: [],
@@ -326,7 +348,7 @@ export async function doctorClaudeCodeHook(settingsPath = getDefaultSettingsPath
     settingsPath,
     status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
     issues,
-    fixCommand: TOKENJUICE_CLAUDE_CODE_FIX_COMMAND,
+    fixCommand,
     expectedCommand,
     detectedCommand,
     checkedPaths,

--- a/src/hosts/cursor/index.ts
+++ b/src/hosts/cursor/index.ts
@@ -11,6 +11,7 @@ type CursorHooksConfig = Record<string, unknown> & {
 };
 
 type CursorHookCommandOptions = {
+  local?: boolean;
   binaryPath?: string;
   nodePath?: string;
 };
@@ -152,13 +153,20 @@ async function buildCursorHookCommand(options: CursorHookCommandOptions = {}): P
     throw new Error("unable to resolve tokenjuice binary path for cursor install");
   }
 
-  const installedBinaryPath = await resolveInstalledTokenjuicePath();
-  const launcher = installedBinaryPath ?? binaryPath;
+  let launcher = binaryPath;
+  if (!options.local) {
+    const installedBinaryPath = await resolveInstalledTokenjuicePath();
+    launcher = installedBinaryPath ?? binaryPath;
+  }
   const launcherCommand = launcher.endsWith(".js")
     ? `${shellQuote(nodePath)} ${shellQuote(launcher)}`
     : shellQuote(launcher);
 
   return `${launcherCommand} cursor-pre-tool-use --wrap-launcher ${shellQuote(launcher)}`;
+}
+
+function getCursorFixCommand(local = false): string {
+  return local ? "tokenjuice install cursor --local" : TOKENJUICE_CURSOR_FIX_COMMAND;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -354,7 +362,7 @@ export async function doctorCursorHook(
       hooksPath,
       status: "disabled",
       issues: [],
-      fixCommand: TOKENJUICE_CURSOR_FIX_COMMAND,
+      fixCommand: getCursorFixCommand(options.local),
       expectedCommand,
       checkedPaths: [],
       missingPaths: [],
@@ -385,7 +393,7 @@ export async function doctorCursorHook(
     hooksPath,
     status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
     issues,
-    fixCommand: TOKENJUICE_CURSOR_FIX_COMMAND,
+    fixCommand: getCursorFixCommand(options.local),
     expectedCommand,
     detectedCommand,
     checkedPaths,

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -3,7 +3,7 @@ import { doctorCodexHook } from "../codex/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
 import { doctorPiExtension } from "../pi/index.js";
 
-import type { ClaudeCodeDoctorReport } from "../claude-code/index.js";
+import type { ClaudeCodeDoctorReport, ClaudeCodeHookCommandOptions } from "../claude-code/index.js";
 import type { CodexDoctorReport, CodexHookCommandOptions } from "../codex/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
 import type { PiDoctorReport } from "../pi/index.js";
@@ -22,6 +22,8 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
+export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions;
+
 function mergeStatus(left: HookHealthStatus, right: HookHealthStatus): HookHealthStatus {
   if (left === "broken" || right === "broken") {
     return "broken";
@@ -38,10 +40,15 @@ function mergeStatus(left: HookHealthStatus, right: HookHealthStatus): HookHealt
   return "ok";
 }
 
-export async function doctorInstalledHooks(codexOptions: CodexHookCommandOptions = {}): Promise<HookDoctorReport> {
-  const codex = await doctorCodexHook(undefined, codexOptions);
-  const claudeCode = await doctorClaudeCodeHook();
-  const cursor = await doctorCursorHook();
+export async function doctorInstalledHooks(options: HookDoctorCommandOptions = {}): Promise<HookDoctorReport> {
+  const codex = await doctorCodexHook(undefined, options);
+  const hookCommandOptions = {
+    ...(typeof options.local === "boolean" ? { local: options.local } : {}),
+    ...(typeof options.binaryPath === "string" ? { binaryPath: options.binaryPath } : {}),
+    ...(typeof options.nodePath === "string" ? { nodePath: options.nodePath } : {}),
+  };
+  const claudeCode = await doctorClaudeCodeHook(undefined, hookCommandOptions);
+  const cursor = await doctorCursorHook(undefined, hookCommandOptions);
   const pi = await doctorPiExtension();
 
   return {

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -1,10 +1,10 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { doctorClaudeCodeHook, doctorInstalledHooks, installClaudeCodeHook, installCodexHook, installPiExtension, runClaudeCodePostToolUseHook } from "../../src/index.js";
+import { doctorClaudeCodeHook, doctorInstalledHooks, installClaudeCodeHook, installCodexHook, installCursorHook, installPiExtension, runClaudeCodePostToolUseHook } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
@@ -216,6 +216,39 @@ describe("installClaudeCodeHook", () => {
     expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(`${launcherPath} claude-code-post-tool-use`);
   });
 
+  it("can force local repo routing instead of the PATH launcher", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const localCliPath = join(home, "dist", "cli", "main.js");
+    const localNodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(home, "dist", "cli"), { recursive: true });
+    await writeFile(
+      launcherPath,
+      "#!/usr/bin/env bash\nexit 0\n",
+      { encoding: "utf8", mode: 0o755 },
+    );
+    await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
+    await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const result = await installClaudeCodeHook(settingsPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    const expectedCommand = `${localNodePath} ${resolve(localCliPath)} claude-code-post-tool-use`;
+    expect(result.command).toBe(expectedCommand);
+    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(expectedCommand);
+  });
+
   it("is idempotent and replaces old tokenjuice entries", async () => {
     const home = await createTempDir();
     const settingsPath = join(home, "settings.json");
@@ -310,6 +343,38 @@ describe("doctorClaudeCodeHook", () => {
     expect(report.status).toBe("ok");
     expect(report.detectedCommand).toBe(`${launcherPath} claude-code-post-tool-use`);
     expect(report.issues).toEqual([]);
+  });
+
+  it("reports a healthy local hook when asked to check local mode", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const localCliPath = join(home, "dist", "cli", "main.js");
+    const localNodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(home, "dist", "cli"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
+    await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await installClaudeCodeHook(settingsPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+
+    const report = await doctorClaudeCodeHook(settingsPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+
+    expect(report.status).toBe("ok");
+    expect(report.expectedCommand).toBe(`${localNodePath} ${resolve(localCliPath)} claude-code-post-tool-use`);
+    expect(report.detectedCommand).toBe(report.expectedCommand);
+    expect(report.fixCommand).toBe("tokenjuice install claude-code --local");
   });
 
   it("flags stale Homebrew Cellar hook commands as broken", async () => {
@@ -407,6 +472,66 @@ describe("doctorInstalledHooks", () => {
     expect(report.integrations.codex.status).toBe("disabled");
     expect(report.integrations["claude-code"].status).toBe("ok");
     expect(report.integrations.pi.status).toBe("ok");
+  });
+
+  it("passes local hook expectations through to codex, claude-code, and cursor", async () => {
+    const home = await createTempDir();
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const codexHome = join(home, "codex");
+    const claudeHome = join(home, "claude");
+    const cursorHome = join(home, "cursor");
+    const piAgentDir = join(home, "pi-agent");
+    const localBinaryPath = join(home, "dist", "cli", "main.js");
+    const localNodePath = join(home, "node");
+    const expectedHookPrefix = `${localNodePath} ${resolve(localBinaryPath)}`;
+
+    process.env.PATH = binDir;
+    process.env.CODEX_HOME = codexHome;
+    process.env.CLAUDE_HOME = claudeHome;
+    process.env.CURSOR_HOME = cursorHome;
+    process.env.PI_CODING_AGENT_DIR = piAgentDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(home, "dist", "cli"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(localBinaryPath, "console.log('tokenjuice');\n", "utf8");
+    await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(join(codexHome, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
+
+    await installCodexHook(undefined, {
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+      featureFlagConfigPath: join(codexHome, "config.toml"),
+    });
+    await installClaudeCodeHook(undefined, {
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+    });
+    await installCursorHook(undefined, {
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+    });
+    await installPiExtension(undefined, { local: true });
+
+    const report = await doctorInstalledHooks({
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+      featureFlagConfigPath: join(codexHome, "config.toml"),
+    });
+
+    expect(report.status).toBe("ok");
+    expect(report.integrations.codex.status).toBe("ok");
+    expect(report.integrations["claude-code"].status).toBe("ok");
+    expect(report.integrations.cursor.status).toBe("ok");
+    expect(report.integrations.pi.status).toBe("ok");
+    expect(report.integrations.codex.expectedCommand).toContain(expectedHookPrefix);
+    expect(report.integrations["claude-code"].expectedCommand).toContain(expectedHookPrefix);
+    expect(report.integrations.cursor.expectedCommand).toContain(expectedHookPrefix);
   });
 });
 

--- a/test/hosts/cursor.test.ts
+++ b/test/hosts/cursor.test.ts
@@ -93,6 +93,36 @@ describe("installCursorHook", () => {
     expect(parsed.hooks.preToolUse[0]?.command).toContain(`${launcherPath} cursor-pre-tool-use`);
   });
 
+  it("can force local repo routing instead of the PATH launcher", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const localCliPath = join(home, "dist", "cli", "main.js");
+    const localNodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(home, "dist", "cli"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
+    await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const result = await installCursorHook(hooksPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ command: string }>>;
+    };
+
+    const resolvedBinaryPath = resolve(localCliPath);
+    const expectedCommand = `${localNodePath} ${resolvedBinaryPath} cursor-pre-tool-use --wrap-launcher ${resolvedBinaryPath}`;
+    expect(result.command).toBe(expectedCommand);
+    expect(parsed.hooks.preToolUse[0]?.command).toBe(expectedCommand);
+  });
+
   it("persists absolute launcher path when installing from relative binaryPath", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");
@@ -132,6 +162,39 @@ describe("doctorCursorHook", () => {
     expect(report.status).toBe("ok");
     expect(report.detectedCommand).toContain(`${launcherPath} cursor-pre-tool-use`);
     expect(report.issues).toEqual([]);
+  });
+
+  it("reports a healthy local hook when asked to check local mode", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const localCliPath = join(home, "dist", "cli", "main.js");
+    const localNodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(join(home, "dist", "cli"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
+    await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await installCursorHook(hooksPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+
+    const report = await doctorCursorHook(hooksPath, {
+      local: true,
+      binaryPath: localCliPath,
+      nodePath: localNodePath,
+    });
+
+    const resolvedBinaryPath = resolve(localCliPath);
+    expect(report.status).toBe("ok");
+    expect(report.expectedCommand).toBe(`${localNodePath} ${resolvedBinaryPath} cursor-pre-tool-use --wrap-launcher ${resolvedBinaryPath}`);
+    expect(report.detectedCommand).toBe(report.expectedCommand);
+    expect(report.fixCommand).toBe("tokenjuice install cursor --local");
   });
 
   it("flags a configured native Windows hook as broken", async () => {


### PR DESCRIPTION
## Summary
- add `--local` hook routing support for Claude Code and Cursor installs and doctor checks
- make `tokenjuice doctor hooks --local` pass local expectations through to Claude Code and Cursor, not just Codex
- document the expanded local-routing support and cover it with host tests

## Why
Codex already supported repo-local hook routing, but Claude Code and Cursor still preferred the installed launcher on `PATH`. That made local verification inconsistent and made `doctor hooks --local` only partially true.

## Test Plan
- `pnpm typecheck`
- `pnpm exec vitest run test/hosts/claude-code.test.ts test/hosts/cursor.test.ts test/hosts/codex.test.ts`
- `pnpm build`
