### PR TITLE
feat(rules): add npm ci compaction

### DIFF
--- a/src/core/builtin-rules.generated.ts
+++ b/src/core/builtin-rules.generated.ts
@@ -47,64 +47,65 @@ import rule42 from "../rules/git/show.json" with { type: "json" };
 import rule43 from "../rules/git/stash-list.json" with { type: "json" };
 import rule44 from "../rules/git/status.json" with { type: "json" };
 import rule45 from "../rules/install/bun-install.json" with { type: "json" };
-import rule46 from "../rules/install/npm-install.json" with { type: "json" };
-import rule47 from "../rules/install/pnpm-install.json" with { type: "json" };
-import rule48 from "../rules/install/yarn-install.json" with { type: "json" };
-import rule49 from "../rules/lint/biome.json" with { type: "json" };
-import rule50 from "../rules/lint/eslint.json" with { type: "json" };
-import rule51 from "../rules/lint/oxlint.json" with { type: "json" };
-import rule52 from "../rules/lint/prettier-check.json" with { type: "json" };
-import rule53 from "../rules/media/ffmpeg.json" with { type: "json" };
-import rule54 from "../rules/media/mediainfo.json" with { type: "json" };
-import rule55 from "../rules/network/curl.json" with { type: "json" };
-import rule56 from "../rules/network/dig.json" with { type: "json" };
-import rule57 from "../rules/network/nslookup.json" with { type: "json" };
-import rule58 from "../rules/network/ping.json" with { type: "json" };
-import rule59 from "../rules/network/ssh.json" with { type: "json" };
-import rule60 from "../rules/network/traceroute.json" with { type: "json" };
-import rule61 from "../rules/network/wget.json" with { type: "json" };
-import rule62 from "../rules/observability/free.json" with { type: "json" };
-import rule63 from "../rules/observability/htop.json" with { type: "json" };
-import rule64 from "../rules/observability/iostat.json" with { type: "json" };
-import rule65 from "../rules/observability/top.json" with { type: "json" };
-import rule66 from "../rules/observability/vmstat.json" with { type: "json" };
-import rule67 from "../rules/openclaw/sessions-history.json" with { type: "json" };
-import rule68 from "../rules/package/apt-install.json" with { type: "json" };
-import rule69 from "../rules/package/apt-upgrade.json" with { type: "json" };
-import rule70 from "../rules/package/brew-install.json" with { type: "json" };
-import rule71 from "../rules/package/brew-upgrade.json" with { type: "json" };
-import rule72 from "../rules/package/dnf-install.json" with { type: "json" };
-import rule73 from "../rules/package/yum-install.json" with { type: "json" };
-import rule74 from "../rules/search/git-grep.json" with { type: "json" };
-import rule75 from "../rules/search/grep.json" with { type: "json" };
-import rule76 from "../rules/search/rg.json" with { type: "json" };
-import rule77 from "../rules/service/journalctl.json" with { type: "json" };
-import rule78 from "../rules/service/launchctl.json" with { type: "json" };
-import rule79 from "../rules/service/lsof.json" with { type: "json" };
-import rule80 from "../rules/service/netstat.json" with { type: "json" };
-import rule81 from "../rules/service/service.json" with { type: "json" };
-import rule82 from "../rules/service/ss.json" with { type: "json" };
-import rule83 from "../rules/service/systemctl-status.json" with { type: "json" };
-import rule84 from "../rules/system/df.json" with { type: "json" };
-import rule85 from "../rules/system/du.json" with { type: "json" };
-import rule86 from "../rules/system/file.json" with { type: "json" };
-import rule87 from "../rules/system/ps.json" with { type: "json" };
-import rule88 from "../rules/task/just.json" with { type: "json" };
-import rule89 from "../rules/task/make.json" with { type: "json" };
-import rule90 from "../rules/tests/bun-test.json" with { type: "json" };
-import rule91 from "../rules/tests/cargo-test.json" with { type: "json" };
-import rule92 from "../rules/tests/go-test.json" with { type: "json" };
-import rule93 from "../rules/tests/jest.json" with { type: "json" };
-import rule94 from "../rules/tests/mocha.json" with { type: "json" };
-import rule95 from "../rules/tests/npm-test.json" with { type: "json" };
-import rule96 from "../rules/tests/playwright.json" with { type: "json" };
-import rule97 from "../rules/tests/pnpm-test.json" with { type: "json" };
-import rule98 from "../rules/tests/pytest.json" with { type: "json" };
-import rule99 from "../rules/tests/swift-test.json" with { type: "json" };
-import rule100 from "../rules/tests/vitest.json" with { type: "json" };
-import rule101 from "../rules/tests/yarn-test.json" with { type: "json" };
-import rule102 from "../rules/transfer/rsync.json" with { type: "json" };
-import rule103 from "../rules/transfer/scp.json" with { type: "json" };
+import rule46 from "../rules/install/npm-ci.json" with { type: "json" };
+import rule47 from "../rules/install/npm-install.json" with { type: "json" };
+import rule48 from "../rules/install/pnpm-install.json" with { type: "json" };
+import rule49 from "../rules/install/yarn-install.json" with { type: "json" };
+import rule50 from "../rules/lint/biome.json" with { type: "json" };
+import rule51 from "../rules/lint/eslint.json" with { type: "json" };
+import rule52 from "../rules/lint/oxlint.json" with { type: "json" };
+import rule53 from "../rules/lint/prettier-check.json" with { type: "json" };
+import rule54 from "../rules/media/ffmpeg.json" with { type: "json" };
+import rule55 from "../rules/media/mediainfo.json" with { type: "json" };
+import rule56 from "../rules/network/curl.json" with { type: "json" };
+import rule57 from "../rules/network/dig.json" with { type: "json" };
+import rule58 from "../rules/network/nslookup.json" with { type: "json" };
+import rule59 from "../rules/network/ping.json" with { type: "json" };
+import rule60 from "../rules/network/ssh.json" with { type: "json" };
+import rule61 from "../rules/network/traceroute.json" with { type: "json" };
+import rule62 from "../rules/network/wget.json" with { type: "json" };
+import rule63 from "../rules/observability/free.json" with { type: "json" };
+import rule64 from "../rules/observability/htop.json" with { type: "json" };
+import rule65 from "../rules/observability/iostat.json" with { type: "json" };
+import rule66 from "../rules/observability/top.json" with { type: "json" };
+import rule67 from "../rules/observability/vmstat.json" with { type: "json" };
+import rule68 from "../rules/openclaw/sessions-history.json" with { type: "json" };
+import rule69 from "../rules/package/apt-install.json" with { type: "json" };
+import rule70 from "../rules/package/apt-upgrade.json" with { type: "json" };
+import rule71 from "../rules/package/brew-install.json" with { type: "json" };
+import rule72 from "../rules/package/brew-upgrade.json" with { type: "json" };
+import rule73 from "../rules/package/dnf-install.json" with { type: "json" };
+import rule74 from "../rules/package/yum-install.json" with { type: "json" };
+import rule75 from "../rules/search/git-grep.json" with { type: "json" };
+import rule76 from "../rules/search/grep.json" with { type: "json" };
+import rule77 from "../rules/search/rg.json" with { type: "json" };
+import rule78 from "../rules/service/journalctl.json" with { type: "json" };
+import rule79 from "../rules/service/launchctl.json" with { type: "json" };
+import rule80 from "../rules/service/lsof.json" with { type: "json" };
+import rule81 from "../rules/service/netstat.json" with { type: "json" };
+import rule82 from "../rules/service/service.json" with { type: "json" };
+import rule83 from "../rules/service/ss.json" with { type: "json" };
+import rule84 from "../rules/service/systemctl-status.json" with { type: "json" };
+import rule85 from "../rules/system/df.json" with { type: "json" };
+import rule86 from "../rules/system/du.json" with { type: "json" };
+import rule87 from "../rules/system/file.json" with { type: "json" };
+import rule88 from "../rules/system/ps.json" with { type: "json" };
+import rule89 from "../rules/task/just.json" with { type: "json" };
+import rule90 from "../rules/task/make.json" with { type: "json" };
+import rule91 from "../rules/tests/bun-test.json" with { type: "json" };
+import rule92 from "../rules/tests/cargo-test.json" with { type: "json" };
+import rule93 from "../rules/tests/go-test.json" with { type: "json" };
+import rule94 from "../rules/tests/jest.json" with { type: "json" };
+import rule95 from "../rules/tests/mocha.json" with { type: "json" };
+import rule96 from "../rules/tests/npm-test.json" with { type: "json" };
+import rule97 from "../rules/tests/playwright.json" with { type: "json" };
+import rule98 from "../rules/tests/pnpm-test.json" with { type: "json" };
+import rule99 from "../rules/tests/pytest.json" with { type: "json" };
+import rule100 from "../rules/tests/swift-test.json" with { type: "json" };
+import rule101 from "../rules/tests/vitest.json" with { type: "json" };
+import rule102 from "../rules/tests/yarn-test.json" with { type: "json" };
+import rule103 from "../rules/transfer/rsync.json" with { type: "json" };
+import rule104 from "../rules/transfer/scp.json" with { type: "json" };
 
 export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule0 as JsonRule, // rules/archive/tar.json
@@ -153,62 +154,63 @@ export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule43 as JsonRule, // rules/git/stash-list.json
   rule44 as JsonRule, // rules/git/status.json
   rule45 as JsonRule, // rules/install/bun-install.json
-  rule46 as JsonRule, // rules/install/npm-install.json
-  rule47 as JsonRule, // rules/install/pnpm-install.json
-  rule48 as JsonRule, // rules/install/yarn-install.json
-  rule49 as JsonRule, // rules/lint/biome.json
-  rule50 as JsonRule, // rules/lint/eslint.json
-  rule51 as JsonRule, // rules/lint/oxlint.json
-  rule52 as JsonRule, // rules/lint/prettier-check.json
-  rule53 as JsonRule, // rules/media/ffmpeg.json
-  rule54 as JsonRule, // rules/media/mediainfo.json
-  rule55 as JsonRule, // rules/network/curl.json
-  rule56 as JsonRule, // rules/network/dig.json
-  rule57 as JsonRule, // rules/network/nslookup.json
-  rule58 as JsonRule, // rules/network/ping.json
-  rule59 as JsonRule, // rules/network/ssh.json
-  rule60 as JsonRule, // rules/network/traceroute.json
-  rule61 as JsonRule, // rules/network/wget.json
-  rule62 as JsonRule, // rules/observability/free.json
-  rule63 as JsonRule, // rules/observability/htop.json
-  rule64 as JsonRule, // rules/observability/iostat.json
-  rule65 as JsonRule, // rules/observability/top.json
-  rule66 as JsonRule, // rules/observability/vmstat.json
-  rule67 as JsonRule, // rules/openclaw/sessions-history.json
-  rule68 as JsonRule, // rules/package/apt-install.json
-  rule69 as JsonRule, // rules/package/apt-upgrade.json
-  rule70 as JsonRule, // rules/package/brew-install.json
-  rule71 as JsonRule, // rules/package/brew-upgrade.json
-  rule72 as JsonRule, // rules/package/dnf-install.json
-  rule73 as JsonRule, // rules/package/yum-install.json
-  rule74 as JsonRule, // rules/search/git-grep.json
-  rule75 as JsonRule, // rules/search/grep.json
-  rule76 as JsonRule, // rules/search/rg.json
-  rule77 as JsonRule, // rules/service/journalctl.json
-  rule78 as JsonRule, // rules/service/launchctl.json
-  rule79 as JsonRule, // rules/service/lsof.json
-  rule80 as JsonRule, // rules/service/netstat.json
-  rule81 as JsonRule, // rules/service/service.json
-  rule82 as JsonRule, // rules/service/ss.json
-  rule83 as JsonRule, // rules/service/systemctl-status.json
-  rule84 as JsonRule, // rules/system/df.json
-  rule85 as JsonRule, // rules/system/du.json
-  rule86 as JsonRule, // rules/system/file.json
-  rule87 as JsonRule, // rules/system/ps.json
-  rule88 as JsonRule, // rules/task/just.json
-  rule89 as JsonRule, // rules/task/make.json
-  rule90 as JsonRule, // rules/tests/bun-test.json
-  rule91 as JsonRule, // rules/tests/cargo-test.json
-  rule92 as JsonRule, // rules/tests/go-test.json
-  rule93 as JsonRule, // rules/tests/jest.json
-  rule94 as JsonRule, // rules/tests/mocha.json
-  rule95 as JsonRule, // rules/tests/npm-test.json
-  rule96 as JsonRule, // rules/tests/playwright.json
-  rule97 as JsonRule, // rules/tests/pnpm-test.json
-  rule98 as JsonRule, // rules/tests/pytest.json
-  rule99 as JsonRule, // rules/tests/swift-test.json
-  rule100 as JsonRule, // rules/tests/vitest.json
-  rule101 as JsonRule, // rules/tests/yarn-test.json
-  rule102 as JsonRule, // rules/transfer/rsync.json
-  rule103 as JsonRule, // rules/transfer/scp.json
+  rule46 as JsonRule, // rules/install/npm-ci.json
+  rule47 as JsonRule, // rules/install/npm-install.json
+  rule48 as JsonRule, // rules/install/pnpm-install.json
+  rule49 as JsonRule, // rules/install/yarn-install.json
+  rule50 as JsonRule, // rules/lint/biome.json
+  rule51 as JsonRule, // rules/lint/eslint.json
+  rule52 as JsonRule, // rules/lint/oxlint.json
+  rule53 as JsonRule, // rules/lint/prettier-check.json
+  rule54 as JsonRule, // rules/media/ffmpeg.json
+  rule55 as JsonRule, // rules/media/mediainfo.json
+  rule56 as JsonRule, // rules/network/curl.json
+  rule57 as JsonRule, // rules/network/dig.json
+  rule58 as JsonRule, // rules/network/nslookup.json
+  rule59 as JsonRule, // rules/network/ping.json
+  rule60 as JsonRule, // rules/network/ssh.json
+  rule61 as JsonRule, // rules/network/traceroute.json
+  rule62 as JsonRule, // rules/network/wget.json
+  rule63 as JsonRule, // rules/observability/free.json
+  rule64 as JsonRule, // rules/observability/htop.json
+  rule65 as JsonRule, // rules/observability/iostat.json
+  rule66 as JsonRule, // rules/observability/top.json
+  rule67 as JsonRule, // rules/observability/vmstat.json
+  rule68 as JsonRule, // rules/openclaw/sessions-history.json
+  rule69 as JsonRule, // rules/package/apt-install.json
+  rule70 as JsonRule, // rules/package/apt-upgrade.json
+  rule71 as JsonRule, // rules/package/brew-install.json
+  rule72 as JsonRule, // rules/package/brew-upgrade.json
+  rule73 as JsonRule, // rules/package/dnf-install.json
+  rule74 as JsonRule, // rules/package/yum-install.json
+  rule75 as JsonRule, // rules/search/git-grep.json
+  rule76 as JsonRule, // rules/search/grep.json
+  rule77 as JsonRule, // rules/search/rg.json
+  rule78 as JsonRule, // rules/service/journalctl.json
+  rule79 as JsonRule, // rules/service/launchctl.json
+  rule80 as JsonRule, // rules/service/lsof.json
+  rule81 as JsonRule, // rules/service/netstat.json
+  rule82 as JsonRule, // rules/service/service.json
+  rule83 as JsonRule, // rules/service/ss.json
+  rule84 as JsonRule, // rules/service/systemctl-status.json
+  rule85 as JsonRule, // rules/system/df.json
+  rule86 as JsonRule, // rules/system/du.json
+  rule87 as JsonRule, // rules/system/file.json
+  rule88 as JsonRule, // rules/system/ps.json
+  rule89 as JsonRule, // rules/task/just.json
+  rule90 as JsonRule, // rules/task/make.json
+  rule91 as JsonRule, // rules/tests/bun-test.json
+  rule92 as JsonRule, // rules/tests/cargo-test.json
+  rule93 as JsonRule, // rules/tests/go-test.json
+  rule94 as JsonRule, // rules/tests/jest.json
+  rule95 as JsonRule, // rules/tests/mocha.json
+  rule96 as JsonRule, // rules/tests/npm-test.json
+  rule97 as JsonRule, // rules/tests/playwright.json
+  rule98 as JsonRule, // rules/tests/pnpm-test.json
+  rule99 as JsonRule, // rules/tests/pytest.json
+  rule100 as JsonRule, // rules/tests/swift-test.json
+  rule101 as JsonRule, // rules/tests/vitest.json
+  rule102 as JsonRule, // rules/tests/yarn-test.json
+  rule103 as JsonRule, // rules/transfer/rsync.json
+  rule104 as JsonRule, // rules/transfer/scp.json
 ];

--- a/src/rules/fixtures/install/npm-ci-up-to-date.fixture.json
+++ b/src/rules/fixtures/install/npm-ci-up-to-date.fixture.json
@@ -1,0 +1,19 @@
+{
+  "id": "install-npm-ci-up-to-date",
+  "ruleId": "install/npm-ci",
+  "input": {
+    "toolName": "exec",
+    "argv": ["npm", "ci"],
+    "command": "npm ci",
+    "combinedText": "up to date, audited 42 packages in 614ms\nfound 0 vulnerabilities\n",
+    "exitCode": 0
+  },
+  "expect": {
+    "matchedReducer": "install/npm-ci",
+    "family": "dependency-install",
+    "inlineText": "npm ci: up to date",
+    "previewText": "npm ci: up to date",
+    "contains": ["npm ci: up to date"],
+    "excludes": ["found 0 vulnerabilities"]
+  }
+}

--- a/src/rules/fixtures/install/npm-ci.fixture.json
+++ b/src/rules/fixtures/install/npm-ci.fixture.json
@@ -1,0 +1,16 @@
+{
+  "id": "install-npm-ci-basic",
+  "ruleId": "install/npm-ci",
+  "input": {
+    "toolName": "exec",
+    "argv": ["npm", "ci"],
+    "command": "npm ci",
+    "combinedText": "added 42 packages, and audited 43 packages in 2s\nfound 0 vulnerabilities\n",
+    "exitCode": 0
+  },
+  "expect": {
+    "matchedReducer": "install/npm-ci",
+    "family": "dependency-install",
+    "contains": ["vulnerability", "audited 43 packages"]
+  }
+}

--- a/src/rules/install/npm-ci.json
+++ b/src/rules/install/npm-ci.json
@@ -1,0 +1,49 @@
+{
+  "id": "install/npm-ci",
+  "family": "dependency-install",
+  "description": "Compact npm ci output while preserving warnings and audit summaries.",
+  "onEmpty": "npm ci: ok",
+  "matchOutput": [
+    {
+      "pattern": "up to date, audited \\d+ package",
+      "message": "npm ci: up to date",
+      "flags": "i"
+    }
+  ],
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["npm"],
+    "argvIncludes": [["ci"]]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "filters": {
+    "skipPatterns": [
+      "^npm notice .+"
+    ]
+  },
+  "summarize": {
+    "head": 10,
+    "tail": 8
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 14,
+    "tail": 14
+  },
+  "counters": [
+    {
+      "name": "warning",
+      "pattern": "warn",
+      "flags": "i"
+    },
+    {
+      "name": "vulnerability",
+      "pattern": "vulnerabilit",
+      "flags": "i"
+    }
+  ]
+}

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -644,6 +644,19 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toBe("npm install: up to date");
   });
 
+  it("uses builtin matchOutput for up-to-date npm ci output", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "npm ci",
+      argv: ["npm", "ci"],
+      combinedText: "up to date, audited 42 packages in 612ms\n",
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("install/npm-ci");
+    expect(result.inlineText).toBe("npm ci: up to date");
+  });
+
   it.each([
     {
       label: "pnpm up to date",

--- a/test/core/rules.test.ts
+++ b/test/core/rules.test.ts
@@ -87,6 +87,7 @@ describe("rules", () => {
       "git/stash-list",
       "git/status",
       "install/bun-install",
+      "install/npm-ci",
       "install/npm-install",
       "install/pnpm-install",
       "install/yarn-install",
@@ -160,7 +161,7 @@ describe("rules", () => {
 
   it("loads builtin fixtures successfully", async () => {
     const fixtures = await loadBuiltinFixtures();
-    expect(fixtures).toHaveLength(108);
+    expect(fixtures).toHaveLength(110);
   });
 
   it("keeps builtin fixture inventory aligned with builtin rules", async () => {


### PR DESCRIPTION
## summary
- add a first-class `install/npm-ci` reducer
- add npm ci fixtures for normal and up-to-date output
- cover the new reducer in core rule tests

## validation
- `pnpm exec vitest run test/core/rules.test.ts test/core/reduce.test.ts`
- `pnpm typecheck`