### PR TITLE
fix(codex): warn on brittle external hook timeouts

### DIFF
--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -47,6 +47,8 @@ const HOOK_REWRITE_MIN_SAVED_CHARS = 8;
 const CODEX_HOOK_LAST_LOG = "tokenjuice-hook.last.json";
 const CODEX_HOOK_HISTORY_LOG = "tokenjuice-hook.history.jsonl";
 const CODEX_HOOK_HISTORY_LIMIT = 200;
+const LOW_NON_TOKENJUICE_TIMEOUT_SECONDS = 2;
+const RECOMMENDED_NON_TOKENJUICE_TIMEOUT_SECONDS = 6;
 
 export type InstallCodexHookResult = {
   hooksPath: string;
@@ -399,6 +401,45 @@ function findTokenjuiceCodexHookCommand(config: CodexHooksConfig): string | unde
   return undefined;
 }
 
+function truncateHookCommand(command: string, maxLength = 80): string {
+  const trimmed = command.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 3)}...`;
+}
+
+function collectLowTimeoutWarnings(config: CodexHooksConfig): string[] {
+  const issues: string[] = [];
+
+  for (const [eventName, groups] of Object.entries(config.hooks)) {
+    groups.forEach((group, groupIndex) => {
+      const tokenjuiceGroup = eventName === "PostToolUse" && isTokenjuiceCodexHook(group);
+      if (tokenjuiceGroup) {
+        return;
+      }
+
+      group.hooks.forEach((hook, hookIndex) => {
+        if (
+          typeof hook.timeout !== "number"
+          || !Number.isFinite(hook.timeout)
+          || hook.timeout > LOW_NON_TOKENJUICE_TIMEOUT_SECONDS
+        ) {
+          return;
+        }
+
+        const location = `${eventName}[${groupIndex}].hooks[${hookIndex}]`;
+        const command = truncateHookCommand(hook.command);
+        issues.push(
+          `non-tokenjuice Codex hook ${location} uses a low ${hook.timeout}s timeout for "${command}" — consider ${RECOMMENDED_NON_TOKENJUICE_TIMEOUT_SECONDS}s or higher`,
+        );
+      });
+    });
+  }
+
+  return issues;
+}
+
 function sanitizeHooksConfig(raw: unknown): CodexHooksConfig {
   if (!isRecord(raw) || !isRecord(raw.hooks)) {
     return { hooks: {} };
@@ -675,6 +716,7 @@ export async function doctorCodexHook(
       "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
     );
   }
+  issues.push(...collectLowTimeoutWarnings(config));
 
   return {
     hooksPath,

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -282,6 +282,61 @@ describe("doctorCodexHook", () => {
     expect(report.fixCommand).toBe("tokenjuice install codex");
   });
 
+  it("warns about low timeouts on non-tokenjuice Codex hooks", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [{ type: "command", command: "$HOME/bin/agent-attn-set reset codex", timeout: 2 }],
+            },
+          ],
+          UserPromptSubmit: [
+            {
+              hooks: [{ type: "command", command: "$HOME/bin/agent-attn-set reset codex", timeout: 2 }],
+            },
+          ],
+          Stop: [
+            {
+              hooks: [{ type: "command", command: "$HOME/bin/agent-attn-set waiting codex", timeout: 2 }],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [{ type: "command", command: `${launcherPath} codex-post-tool-use`, statusMessage: "compacting bash output with tokenjuice" }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.issues).toContain(
+      'non-tokenjuice Codex hook SessionStart[0].hooks[0] uses a low 2s timeout for "$HOME/bin/agent-attn-set reset codex" — consider 6s or higher',
+    );
+    expect(report.issues).toContain(
+      'non-tokenjuice Codex hook UserPromptSubmit[0].hooks[0] uses a low 2s timeout for "$HOME/bin/agent-attn-set reset codex" — consider 6s or higher',
+    );
+    expect(report.issues).toContain(
+      'non-tokenjuice Codex hook Stop[0].hooks[0] uses a low 2s timeout for "$HOME/bin/agent-attn-set waiting codex" — consider 6s or higher',
+    );
+  });
+
   it("reports a healthy local codex hook when asked to check local mode", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");


### PR DESCRIPTION
## Summary
- warn in `tokenjuice doctor codex` when non-tokenjuice command hooks use brittle low timeouts
- include the hook location, timeout, and command preview in the warning text
- cover the case with a Codex doctor regression test modeled on local `agent-attn-set` hooks

## Why
Codex can surface generic hook errors even when the tokenjuice PostToolUse hook is healthy, because unrelated hooks in `~/.codex/hooks.json` can time out first. This makes the failure mode visible in the doctor output instead of leaving users to grep logs.

## Test Plan
- `pnpm exec vitest run test/hosts/codex.test.ts`
- `pnpm typecheck`