### PR TITLE
fix(codex): warn when doctor sees stale Homebrew hook

### DIFF
--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { access, mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, realpath, rename, stat, writeFile } from "node:fs/promises";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
@@ -409,6 +409,42 @@ function truncateHookCommand(command: string, maxLength = 80): string {
   return `${trimmed.slice(0, maxLength - 3)}...`;
 }
 
+function extractHomebrewCellarVersion(path: string): string | undefined {
+  const normalized = path.replace(/\\/gu, "/");
+  const match = normalized.match(/\/Cellar\/tokenjuice\/([^/]+)\//u);
+  return match?.[1];
+}
+
+async function detectResolvedHomebrewVersionMismatch(
+  commandPaths: string[],
+): Promise<{ launcherPath: string; resolvedPath: string; resolvedVersion: string } | undefined> {
+  for (const path of commandPaths) {
+    if (!path.endsWith("/tokenjuice") && !path.endsWith("\\tokenjuice") && !path.endsWith("\\tokenjuice.exe")) {
+      continue;
+    }
+
+    let resolvedPath: string;
+    try {
+      resolvedPath = await realpath(path);
+    } catch {
+      continue;
+    }
+
+    const resolvedVersion = extractHomebrewCellarVersion(resolvedPath);
+    if (!resolvedVersion || resolvedVersion === packageJson.version) {
+      continue;
+    }
+
+    return {
+      launcherPath: path,
+      resolvedPath,
+      resolvedVersion,
+    };
+  }
+
+  return undefined;
+}
+
 function collectLowTimeoutWarnings(config: CodexHooksConfig): string[] {
   const issues: string[] = [];
 
@@ -706,6 +742,13 @@ export async function doctorCodexHook(
   }
   if (missingPaths.length > 0) {
     issues.push(`configured Codex hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
+  }
+  const resolvedVersionMismatch = await detectResolvedHomebrewVersionMismatch(checkedPaths);
+  if (resolvedVersionMismatch) {
+    issues.push(
+      `configured Codex hook launcher resolves to Homebrew tokenjuice ${resolvedVersionMismatch.resolvedVersion}, but this tokenjuice is ${packageJson.version}`,
+    );
+    fixCommand = "brew upgrade tokenjuice";
   }
   if (options.local && await detectStaleLocalBuild(checkedPaths)) {
     issues.push("local Codex hook target is older than the source tree");

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -198,6 +198,34 @@ describe("doctorCodexHook", () => {
     expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
     expect(report.issues).toEqual([]);
     expect(report.featureFlag.enabled).toBe(true);
+  });
+
+  it("warns when the stable launcher resolves to an older Homebrew tokenjuice version", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "opt", "homebrew", "bin");
+    const cellarBinDir = join(home, "opt", "homebrew", "Cellar", "tokenjuice", "0.0.1", "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const resolvedLauncherPath = join(cellarBinDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(cellarBinDir, { recursive: true });
+    await writeFile(resolvedLauncherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(resolvedLauncherPath, launcherPath);
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await installCodexHook(hooksPath, { featureFlagConfigPath });
+
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(report.fixCommand).toBe("brew upgrade tokenjuice");
+    expect(report.issues).toContain(
+      `configured Codex hook launcher resolves to Homebrew tokenjuice 0.0.1, but this tokenjuice is ${PACKAGE_VERSION}`,
+    );
+    expect(report.issues).not.toContain("configured Codex hook command does not match the current recommended command");
   });
 
   it("warns when codex_hooks feature flag is not enabled", async () => {


### PR DESCRIPTION
## Summary
- resolve stable `tokenjuice` launcher paths during Codex hook doctor checks
- warn when the live Codex hook resolves to a different Homebrew Cellar version than the running tokenjuice
- recommend `brew upgrade tokenjuice` for that stale-link case and cover it with a Codex host test

## Why
`doctor hooks` could report Codex as healthy when `~/.codex/hooks.json` used `/opt/homebrew/bin/tokenjuice`, even if that launcher still resolved to an older Homebrew Cellar keg. That hid the real issue during hook investigations.

## Test Plan
- `pnpm exec vitest run test/hosts/codex.test.ts`
- `pnpm test`
- `pnpm build`
- `node dist/cli/main.js doctor hooks --format json`
