### PR TITLE
fix(core): preserve content reads and summarize document-shaped output

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -529,6 +529,9 @@ async function loadDirectAnalysisEntry(args: ParsedArgs) {
   }
 
   const rawText = await readTextInput(file, args.maxInputBytes);
+  if (!file && rawText.length === 0) {
+    return null;
+  }
   const input = {
     toolName: args.toolName ?? "exec",
     command: args.sourceCommand ?? (file ? `analyze:${file}` : "stdin"),

--- a/src/core/command-identity.ts
+++ b/src/core/command-identity.ts
@@ -47,33 +47,8 @@ function isGitGlobalOptionWithInlineValue(option: string): boolean {
 }
 
 export function getGitSubcommand(argv: string[]): string | null {
-  if (getCommandName(argv) !== "git") {
-    return null;
-  }
-
-  for (let index = 1; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg) {
-      continue;
-    }
-
-    if (gitGlobalOptionTakesValue(arg)) {
-      index += 1;
-      continue;
-    }
-
-    if (isGitGlobalOptionWithInlineValue(arg)) {
-      continue;
-    }
-
-    if (arg.startsWith("-")) {
-      continue;
-    }
-
-    return arg;
-  }
-
-  return null;
+  const index = getGitSubcommandIndex(argv);
+  return index === null ? null : argv[index] ?? null;
 }
 
 function getGitSubcommandIndex(argv: string[]): number | null {
@@ -141,6 +116,16 @@ export function isFileContentInspectionArgv(argv: string[]): boolean {
     return false;
   }
   return FILE_CONTENT_INSPECTION_COMMANDS.has(argv0) || isGitShowFileContentArgv(argv);
+}
+
+function isGhApiContentsDecodeCommand(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  return /\bgh\s+api\b/u.test(command)
+    && /\/contents\//u.test(command)
+    && /--jq(?:=|\s+)['"]?\.content['"]?/u.test(command)
+    && /\|\s*base64\s+(?:-[dD]\b|--decode\b)/u.test(command);
 }
 
 export function isRepositoryInspectionArgv(argv: string[]): boolean {
@@ -227,7 +212,8 @@ function getInspectionArgv(input: Pick<ToolExecutionInput, "argv" | "command">):
 }
 
 export function isFileContentInspectionCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {
-  return isFileContentInspectionArgv(getInspectionArgv(input));
+  return isFileContentInspectionArgv(getInspectionArgv(input))
+    || deriveCommandMatchCandidates(input).some((candidate) => isGhApiContentsDecodeCommand(candidate.command));
 }
 
 export function isRepositoryInspectionCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -16,6 +16,8 @@ export type CommandMatchCandidate = {
 
 const SETUP_WRAPPER_COMMANDS = new Set(["cd", "pwd", "set", "source", ".", "export", "unset", "trap"]);
 const SHELL_COMMAND_LAUNCHERS = new Set(["bash", "sh", "zsh", "fish"]);
+const ENV_FLAGS_WITH_VALUES = new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]);
+const ENV_FLAGS = new Set(["-i", "--ignore-environment", "-0", "--null", "--debug"]);
 
 function getArgv0Name(argv: string[]): string | null {
   const first = argv[0];
@@ -168,6 +170,33 @@ export function stripLeadingEnvAssignments(argv: string[]): string[] {
   while (index < argv.length && ENV_ASSIGNMENT_PATTERN.test(argv[index] ?? "")) {
     index += 1;
   }
+
+  if (getArgv0Name(argv.slice(index)) !== "env") {
+    return argv.slice(index);
+  }
+
+  index += 1;
+  while (index < argv.length) {
+    const arg = argv[index] ?? "";
+    if (ENV_ASSIGNMENT_PATTERN.test(arg)) {
+      index += 1;
+      continue;
+    }
+    if (ENV_FLAGS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (ENV_FLAGS_WITH_VALUES.has(arg)) {
+      index += 2;
+      continue;
+    }
+    if (arg.startsWith("--unset=") || arg.startsWith("--chdir=") || arg.startsWith("--split-string=")) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
   return argv.slice(index);
 }
 
@@ -199,7 +228,7 @@ export function buildEffectiveCandidate(
   }
 
   return {
-    ...(command ? { command } : {}),
+    ...(command ? { command: strippedArgv.length === argv.length ? command : strippedArgv.join(" ") } : {}),
     argv: strippedArgv,
     source: "effective",
   };
@@ -235,6 +264,10 @@ export function resolveEffectiveCommand(input: Pick<ToolExecutionInput, "argv" |
   }
 
   return null;
+}
+
+export function getEffectiveCommandArgv(input: Pick<ToolExecutionInput, "argv" | "command">): string[] {
+  return resolveEffectiveCommand(input)?.argv ?? getCandidateArgv(input);
 }
 
 export function deriveCommandMatchCandidates(

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -178,6 +178,10 @@ export function stripLeadingEnvAssignments(argv: string[]): string[] {
   index += 1;
   while (index < argv.length) {
     const arg = argv[index] ?? "";
+    if (arg === "--") {
+      index += 1;
+      break;
+    }
     if (ENV_ASSIGNMENT_PATTERN.test(arg)) {
       index += 1;
       continue;

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -9,6 +9,7 @@ export {
 export type { CommandMatchCandidate } from "./command-match.js";
 export {
   deriveCommandMatchCandidates,
+  getEffectiveCommandArgv,
   isSetupWrapperSegment,
   resolveEffectiveCommand,
   stripLeadingEnvAssignments,

--- a/src/core/execution-input.ts
+++ b/src/core/execution-input.ts
@@ -1,6 +1,6 @@
 import type { ToolExecutionInput } from "../types.js";
 
-import { unwrapShellRunner } from "./command-match.js";
+import { resolveEffectiveCommand, unwrapShellRunner } from "./command-match.js";
 import { isCompoundShellCommand, stripLeadingCdPrefix, tokenizeCommand } from "./command-shell.js";
 
 export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutionInput {
@@ -15,7 +15,7 @@ export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutio
       };
     }
 
-    const argv = tokenizeCommand(effectiveCommand);
+    const argv = resolveEffectiveCommand({ command: effectiveCommand })?.argv ?? tokenizeCommand(effectiveCommand);
     if (argv.length === 0) {
       return {
         ...input,
@@ -25,8 +25,17 @@ export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutio
 
     return {
       ...input,
-      command: effectiveCommand,
+      command: argv.join(" "),
       argv,
+    };
+  }
+
+  const effective = resolveEffectiveCommand(input);
+  if (effective?.argv.length) {
+    return {
+      ...input,
+      ...(effective.command ? { command: effective.command } : {}),
+      argv: effective.argv,
     };
   }
 
@@ -46,6 +55,7 @@ export function normalizeExecutionInput(input: ToolExecutionInput): ToolExecutio
 
   return {
     ...input,
+    command: argv.join(" "),
     argv,
   };
 }

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -1,4 +1,5 @@
 import { getInspectionCommandSkipReason, getSafeRepositoryInventorySourceArgv } from "../inventory-safety.js";
+import { buildInspectionSummary } from "../reduce-inspection-summary.js";
 import { reduceExecution } from "../reduce.js";
 import { getCompactionSkipReason, type RewritePolicyOptions } from "./rewrite-policy.js";
 
@@ -51,6 +52,22 @@ function resolveInspectionPolicy(input: CompactBashResultInput): InspectionComma
   return input.skipInspectionCommands ? "skip-all" : "compact-all";
 }
 
+export function getOutputAwareInspectionSkipReason(
+  policy: InspectionCommandPolicy,
+  executionInput: ToolExecutionInput,
+): InspectionCommandSkipReason | null {
+  const command = executionInput.command ?? "";
+  const rawText = executionInput.combinedText ?? "";
+  const inspectionSkipReason = getInspectionCommandSkipReason(command, policy);
+  if (
+    inspectionSkipReason === "file-content-inspection-command"
+    && buildInspectionSummary(executionInput, rawText)
+  ) {
+    return null;
+  }
+  return inspectionSkipReason;
+}
+
 export async function compactBashResult(input: CompactBashResultInput): Promise<CompactBashResultOutput> {
   const command = input.command.trim();
   if (!command) {
@@ -73,16 +90,6 @@ export async function compactBashResult(input: CompactBashResultInput): Promise<
     };
   }
 
-  const inspectionSkipReason = getInspectionCommandSkipReason(command, resolveInspectionPolicy(input));
-  if (inspectionSkipReason) {
-    return {
-      action: "keep",
-      reason: inspectionSkipReason,
-      rawText,
-      usedTrustedFullText,
-    };
-  }
-
   const safeInventoryArgv = getSafeRepositoryInventorySourceArgv(command);
   const executionInput: ToolExecutionInput = {
     toolName: "exec",
@@ -93,6 +100,17 @@ export async function compactBashResult(input: CompactBashResultInput): Promise<
     ...(typeof input.exitCode === "number" ? { exitCode: input.exitCode } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
   };
+
+  const inspectionSkipReason = getOutputAwareInspectionSkipReason(resolveInspectionPolicy(input), executionInput);
+  if (inspectionSkipReason) {
+    return {
+      action: "keep",
+      reason: inspectionSkipReason,
+      rawText,
+      usedTrustedFullText,
+    };
+  }
+
   const options: ReduceOptions = {
     ...(typeof input.cwd === "string" && input.cwd.trim() ? { cwd: input.cwd } : {}),
     ...(typeof input.maxInlineChars === "number" ? { maxInlineChars: input.maxInlineChars } : {}),

--- a/src/core/inventory-safety.ts
+++ b/src/core/inventory-safety.ts
@@ -3,6 +3,7 @@ import {
   getGitSubcommand,
   isFileContentInspectionCommand,
 } from "./command-identity.js";
+import { getEffectiveCommandArgv } from "./command-match.js";
 import {
   hasSequentialShellCommands,
   stripLeadingCdPrefix,
@@ -92,11 +93,15 @@ const UNIQ_FILTER: StdinFilterSpec = {
   inlineValuePrefixes: ["--skip-fields=", "--skip-chars=", "--check-chars=", "--all-repeated="],
   compactValueFlags: [/^-[fsw].+/u],
 };
+const WC_FILTER: StdinFilterSpec = {
+  flags: ["-l", "--lines"],
+};
 const REPO_INVENTORY_PIPE_FILTERS = new Map<string, StdinFilterSpec>([
   ["head", HEAD_FILTER],
   ["sort", SORT_FILTER],
   ["tail", TAIL_FILTER],
   ["uniq", UNIQ_FILTER],
+  ["wc", WC_FILTER],
 ]);
 
 export type RepositoryInventorySafety = "not-inventory" | "safe" | "sequential-command" | "unsafe-pipeline";
@@ -109,8 +114,53 @@ export type InspectionCommandSkipReason =
 
 function getRepositoryInventorySourceArgv(command: string): string[] {
   const effectiveCommand = stripLeadingCdPrefix(command);
-  const sourceCommand = splitUnquotedPipes(effectiveCommand)[0] ?? effectiveCommand;
-  return tokenizeCommand(sourceCommand);
+  const leadingCommand = getLeadingSequentialSegment(effectiveCommand);
+  const sourceCommand = splitUnquotedPipes(leadingCommand)[0] ?? leadingCommand;
+  return getEffectiveCommandArgv({ command: sourceCommand });
+}
+
+function getLeadingSequentialSegment(command: string): string {
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      current += char;
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      current += char;
+      quote = char;
+      continue;
+    }
+
+    if (char === ";" || char === "\n" || (char === "&" && command[index + 1] === "&") || (char === "|" && command[index + 1] === "|")) {
+      return current.trim();
+    }
+
+    current += char;
+  }
+
+  return current.trim();
 }
 
 function splitUnquotedPipes(command: string): string[] {
@@ -197,11 +247,51 @@ function isStdinOnlyFilter(argv: string[], spec: StdinFilterSpec): boolean {
 }
 
 function isSafeRepositoryInventoryPipeSegment(commandName: string, argv: string[]): boolean {
+  if (commandName === "sed") {
+    return isSafeSedInventoryFilter(argv);
+  }
+
   const spec = REPO_INVENTORY_PIPE_FILTERS.get(commandName);
   if (!spec) {
     return false;
   }
   return isStdinOnlyFilter(argv, spec);
+}
+
+function isSafeSedInventoryFilter(argv: string[]): boolean {
+  const scripts: string[] = [];
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "-") {
+      continue;
+    }
+    if (arg === "-n" || arg === "-E" || arg === "-r") {
+      continue;
+    }
+    if (arg === "-e") {
+      index += 1;
+      if (index >= argv.length) {
+        return false;
+      }
+      scripts.push(argv[index]!);
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      return false;
+    }
+    scripts.push(arg);
+  }
+
+  if (scripts.length === 0 || scripts.length > 2) {
+    return false;
+  }
+
+  return scripts.every((script) => {
+    if (/^(?:\d+|\$)?(?:,\s*(?:\d+|\$))?p$/u.test(script)) {
+      return true;
+    }
+    return /^s(.)(?:\^?[^\\\n]*)\1(?:[^\\\n]*)\1[gIp]*$/u.test(script);
+  });
 }
 
 function isSafeRepositoryInventorySource(argv: string[]): boolean {
@@ -216,7 +306,7 @@ function isSafeRepositoryInventorySource(argv: string[]): boolean {
 }
 
 export function isRepositoryInventoryCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {
-  const argv = input.argv?.length ? input.argv : getRepositoryInventorySourceArgv(input.command ?? "");
+  const argv = input.argv?.length ? getEffectiveCommandArgv(input) : getRepositoryInventorySourceArgv(input.command ?? "");
   const argv0 = getCommandName(argv);
   if (!argv0) {
     return false;
@@ -264,7 +354,7 @@ export function isSafeRepositoryInventoryPipeline(command: string): boolean {
 }
 
 export function isRepositoryInspectionCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {
-  const argv = input.argv?.length ? input.argv : getRepositoryInventorySourceArgv(input.command ?? "");
+  const argv = input.argv?.length ? getEffectiveCommandArgv(input) : getRepositoryInventorySourceArgv(input.command ?? "");
   const argv0 = getCommandName(argv);
   if (isFileContentInspectionCommand(input)) {
     return true;
@@ -276,6 +366,11 @@ export function isRepositoryInspectionCommand(input: Pick<ToolExecutionInput, "a
     return true;
   }
   return false;
+}
+
+export function hasCommandOnlyFileContentSummary(command: string): boolean {
+  const effectiveCommand = stripLeadingCdPrefix(command);
+  return /\bpackage-lock\.json\b/u.test(effectiveCommand);
 }
 
 export function getSafeRepositoryInventorySourceArgv(command: string): string[] | null {
@@ -296,7 +391,7 @@ export function getInspectionCommandSkipReason(
     return isRepositoryInspectionCommand({ command }) ? "inspection-command" : null;
   }
 
-  if (isFileContentInspectionCommand({ command })) {
+  if (isFileContentInspectionCommand({ command }) && !hasCommandOnlyFileContentSummary(command)) {
     return "file-content-inspection-command";
   }
 

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -1,0 +1,452 @@
+import { compactWhitespace, clipMiddleWithHash, parseJsonObjectLine, parseJsonValue } from "./reduce-utils.js";
+
+import type { ToolExecutionInput } from "../types.js";
+
+const LONG_SEARCH_LINE_MAX_CHARS = 420;
+const LONG_CHANGED_LINE_MAX_CHARS = 260;
+const GIT_DIFF_CHANGED_LINES_PER_HUNK = 8;
+
+function rewriteGitStatusLine(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (trimmed.startsWith("On branch ")) {
+    return null;
+  }
+  if (/^and have \d+ and \d+ different commits each/u.test(trimmed)) {
+    return null;
+  }
+  if (/^(?:no changes added to commit|nothing added to commit but untracked files present)/u.test(trimmed)) {
+    return null;
+  }
+  if (/^\(use "git .+"\)$/u.test(trimmed) || /^use "git .+" to .+/u.test(trimmed)) {
+    return null;
+  }
+  if (trimmed === "Changes not staged for commit:") {
+    return "Changes not staged:";
+  }
+  if (trimmed === "Changes to be committed:") {
+    return "Staged changes:";
+  }
+  if (trimmed === "Untracked files:") {
+    return "Untracked files:";
+  }
+  if (/^\s*modified:\s+/u.test(line)) {
+    return `M: ${line.replace(/^\s*modified:\s+/u, "").trim()}`;
+  }
+  if (/^\s*new file:\s+/u.test(line)) {
+    return `A: ${line.replace(/^\s*new file:\s+/u, "").trim()}`;
+  }
+  if (/^\s*deleted:\s+/u.test(line)) {
+    return `D: ${line.replace(/^\s*deleted:\s+/u, "").trim()}`;
+  }
+  if (/^\s*renamed:\s+/u.test(line)) {
+    return `R: ${line.replace(/^\s*renamed:\s+/u, "").trim()}`;
+  }
+  if (/^\?\?\s+/u.test(trimmed)) {
+    return `?? ${trimmed.replace(/^\?\?\s+/u, "").trim()}`;
+  }
+
+  const porcelainMatch = line.match(/^([ MADRCU?!]{2})\s+(.+)$/u);
+  if (porcelainMatch) {
+    const status = porcelainMatch[1]!.trim().replace(/\?/gu, "??");
+    const path = porcelainMatch[2]!.trim();
+    const code = status === "" ? "M" : status[0] === "?" ? "??" : status[0]!;
+    return `${code}: ${path}`;
+  }
+
+  return trimmed;
+}
+
+export function rewriteGitStatusLines(lines: string[]): string[] {
+  let section: "staged" | "unstaged" | "untracked" | null = null;
+  const rewritten = lines
+    .map((line) => {
+      const trimmed = line.trim();
+      if (trimmed === "Changes not staged for commit:") {
+        section = "unstaged";
+      } else if (trimmed === "Changes to be committed:") {
+        section = "staged";
+      } else if (trimmed === "Untracked files:") {
+        section = "untracked";
+      }
+
+      if (section === "untracked" && /^\s{2,}\S/u.test(line) && !/^\s*(?:modified:|new file:|deleted:|renamed:)/u.test(line)) {
+        return `?? ${trimmed}`;
+      }
+
+      return rewriteGitStatusLine(line);
+    })
+    .filter((line): line is string => line !== null);
+
+  const collapsed: string[] = [];
+  for (const line of rewritten) {
+    if (line === "" && collapsed[collapsed.length - 1] === "") {
+      continue;
+    }
+    collapsed.push(line);
+  }
+  return collapsed;
+}
+
+function extractGhLabelNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (typeof entry === "string") {
+      return entry ? [entry] : [];
+    }
+    if (typeof entry === "object" && entry !== null && "name" in entry && typeof entry.name === "string") {
+      return entry.name ? [entry.name] : [];
+    }
+    return [];
+  });
+}
+
+function extractGhCommentCount(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  if (typeof value === "object" && value !== null && "totalCount" in value && typeof value.totalCount === "number") {
+    return value.totalCount;
+  }
+  return null;
+}
+
+function parseIsoTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "";
+  }
+
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`;
+  }
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  if (hours > 0) {
+    return `${hours}h${String(minutes).padStart(2, "0")}m`;
+  }
+  return `${minutes}m${String(remainingSeconds).padStart(2, "0")}s`;
+}
+
+function extractGhDuration(record: Record<string, unknown>): string | null {
+  if (typeof record.durationSec === "number" && Number.isFinite(record.durationSec) && record.durationSec >= 0) {
+    return formatDuration(record.durationSec);
+  }
+  if (typeof record.durationSeconds === "number" && Number.isFinite(record.durationSeconds) && record.durationSeconds >= 0) {
+    return formatDuration(record.durationSeconds);
+  }
+
+  const startedAt = parseIsoTimestamp(record.startedAt);
+  const completedAt = parseIsoTimestamp(record.completedAt);
+  if (startedAt !== null && completedAt !== null && completedAt >= startedAt) {
+    return formatDuration((completedAt - startedAt) / 1000);
+  }
+
+  const createdAt = parseIsoTimestamp(record.createdAt);
+  const updatedAt = parseIsoTimestamp(record.updatedAt);
+  if (createdAt !== null && updatedAt !== null && updatedAt >= createdAt) {
+    return formatDuration((updatedAt - createdAt) / 1000);
+  }
+
+  return null;
+}
+
+function formatGhJsonRecord(record: Record<string, unknown>): string | null {
+  const comment = formatGhCommentJsonRecord(record);
+  if (comment) {
+    return comment;
+  }
+
+  const numericId = typeof record.number === "number" ? record.number
+    : typeof record.databaseId === "number" ? record.databaseId
+      : null;
+  const title = typeof record.title === "string" ? record.title
+    : typeof record.displayTitle === "string" ? record.displayTitle
+      : typeof record.name === "string" ? record.name
+        : typeof record.workflowName === "string" ? record.workflowName
+          : null;
+  if (!title) {
+    return null;
+  }
+
+  const labels = extractGhLabelNames(record.labels).slice(0, 3);
+  const comments = extractGhCommentCount(record.comments);
+  const branch = typeof record.headBranch === "string" ? record.headBranch
+    : typeof record.headRefName === "string" ? record.headRefName
+      : null;
+  const status = typeof record.state === "string" ? record.state
+    : typeof record.status === "string" ? record.status
+      : typeof record.conclusion === "string" ? record.conclusion
+      : null;
+  const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt.slice(0, 10) : null;
+  const duration = extractGhDuration(record);
+
+  const parts: string[] = [];
+  if (numericId !== null) {
+    parts.push(`#${numericId}`);
+  }
+  parts.push(compactWhitespace(title));
+  if (status) {
+    parts.push(`[${status}]`);
+  }
+  if (branch) {
+    parts.push(`(${compactWhitespace(branch)})`);
+  }
+  if (duration) {
+    parts.push(duration);
+  }
+  if (typeof comments === "number" && comments > 0) {
+    parts.push(`${comments}c`);
+  }
+  if (labels.length > 0) {
+    parts.push(`{${labels.join(", ")}}`);
+  }
+  if (updatedAt) {
+    parts.push(updatedAt);
+  }
+  return parts.join(" ");
+}
+
+function getNestedLogin(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "object" && value !== null && "login" in value && typeof value.login === "string") {
+    return value.login;
+  }
+  return null;
+}
+
+function formatGhCommentJsonRecord(record: Record<string, unknown>): string | null {
+  const body = typeof record.body === "string" ? record.body
+    : typeof record.bodyText === "string" ? record.bodyText
+      : null;
+  if (!body) {
+    return null;
+  }
+
+  const id = typeof record.id === "string" ? record.id
+    : typeof record.id === "number" ? String(record.id)
+    : typeof record.databaseId === "number" ? String(record.databaseId)
+      : typeof record.node_id === "string" ? record.node_id
+        : null;
+  const author = getNestedLogin(record.author)
+    ?? getNestedLogin(record.user)
+    ?? getNestedLogin(record.actor);
+  const path = typeof record.path === "string" ? record.path : null;
+  const line = typeof record.line === "number" ? record.line
+    : typeof record.originalLine === "number" ? record.originalLine
+      : typeof record.startLine === "number" ? record.startLine
+        : null;
+  const state = typeof record.state === "string" ? record.state : null;
+  const createdAt = typeof record.createdAt === "string" ? record.createdAt.slice(0, 10)
+    : typeof record.created_at === "string" ? record.created_at.slice(0, 10)
+      : null;
+
+  const location = path ? `${path}${line !== null ? `:${line}` : ""}` : null;
+  const parts = [
+    "comment",
+    id ? `#${id}` : null,
+    author ? `@${author}` : null,
+    location,
+    state ? `[${state}]` : null,
+    createdAt,
+    `body=${clipMiddleWithHash(compactWhitespace(body), 180)}`,
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" ");
+}
+
+function getGhCollection(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "object" && value !== null && "nodes" in value && Array.isArray(value.nodes)) {
+    return value.nodes;
+  }
+  return [];
+}
+
+function formatGhJsonValue(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return [];
+      }
+      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
+      return formatted ? [formatted] : [];
+    });
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return [];
+  }
+
+  const record = value as Record<string, unknown>;
+  const lines: string[] = [];
+  const header = formatGhJsonRecord(record);
+  if (header) {
+    lines.push(header);
+  }
+
+  for (const collectionKey of ["jobs", "workflowRuns", "items", "artifacts", "comments", "reviews", "reviewThreads"]) {
+    const collection = getGhCollection(record[collectionKey]);
+    if (collection.length === 0) {
+      continue;
+    }
+
+    for (const entry of collection) {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        continue;
+      }
+      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
+      if (formatted) {
+        lines.push(formatted);
+      }
+    }
+  }
+
+  return lines;
+}
+
+export function rewriteSearchLines(lines: string[]): string[] {
+  return lines.map((line) => {
+    const match = /^(.+?:\d+(?::|-))(.*)$/u.exec(line);
+    if (!match) {
+      return clipMiddleWithHash(line, LONG_SEARCH_LINE_MAX_CHARS);
+    }
+    const [, prefix, rest] = match;
+    return `${prefix}${clipMiddleWithHash(rest ?? "", LONG_SEARCH_LINE_MAX_CHARS)}`;
+  });
+}
+
+export function rewriteGitDiffLines(lines: string[]): string[] {
+  const rewritten: string[] = [];
+  let emittedChangedLinesInHunk = 0;
+  let omittedAdded = 0;
+  let omittedRemoved = 0;
+
+  const flushOmitted = () => {
+    if (omittedAdded > 0 || omittedRemoved > 0) {
+      rewritten.push(`... hunk clipped: ${omittedAdded} added, ${omittedRemoved} removed lines omitted`);
+      omittedAdded = 0;
+      omittedRemoved = 0;
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("@@ ")) {
+      flushOmitted();
+      emittedChangedLinesInHunk = 0;
+      rewritten.push(line);
+      continue;
+    }
+    if (line.startsWith("diff --git ")) {
+      flushOmitted();
+      emittedChangedLinesInHunk = 0;
+      rewritten.push(line);
+      continue;
+    }
+
+    const isChangedLine = line.startsWith("+") || line.startsWith("-");
+    if (!isChangedLine || line.startsWith("+++") || line.startsWith("---")) {
+      rewritten.push(line);
+      continue;
+    }
+
+    if (emittedChangedLinesInHunk < GIT_DIFF_CHANGED_LINES_PER_HUNK) {
+      emittedChangedLinesInHunk += 1;
+      rewritten.push(clipMiddleWithHash(line, LONG_CHANGED_LINE_MAX_CHARS));
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      omittedAdded += 1;
+    } else {
+      omittedRemoved += 1;
+    }
+  }
+
+  flushOmitted();
+  return rewritten;
+}
+
+function formatGhTableLine(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const tabColumns = line.split("\t").map((part) => compactWhitespace(part)).filter(Boolean);
+  if (tabColumns.length >= 4 && /^\d{4}-\d{2}-\d{2}T/u.test(tabColumns[2] ?? "")) {
+    const [job, step, , ...rest] = tabColumns;
+    const parts = [job, step, compactWhitespace(rest.join(" "))].filter(Boolean);
+    return parts.join(" | ");
+  }
+
+  const columns = trimmed.split(/\s{2,}|\t+/u).map((part) => compactWhitespace(part)).filter(Boolean);
+  if (columns.length >= 2 && /^\d+$/u.test(columns[0] ?? "")) {
+    const number = columns[0]!;
+    const title = columns[1]!;
+    const state = columns.length >= 4 ? columns.at(-1) : null;
+    const context = columns.length >= 3 ? columns.slice(2, state ? -1 : undefined).join(" ") : null;
+    const parts = [`#${number}`, title];
+    if (state) {
+      parts.push(`[${state}]`);
+    }
+    if (context) {
+      parts.push(`(${context})`);
+    }
+    return parts.join(" ");
+  }
+
+  return compactWhitespace(trimmed);
+}
+
+export function rewriteGhLines(lines: string[], input: ToolExecutionInput): string[] {
+  const nonEmpty = lines.filter((line) => line.trim() !== "");
+  if (nonEmpty.length === 0) {
+    return [];
+  }
+
+  const parsedWholeJson = parseJsonValue(nonEmpty.join("\n"));
+  if (parsedWholeJson !== null) {
+    const rewrittenWholeJson = formatGhJsonValue(parsedWholeJson);
+    if (rewrittenWholeJson.length > 0) {
+      return rewrittenWholeJson;
+    }
+  }
+
+  const parsedJsonLines = nonEmpty.map(parseJsonObjectLine);
+  if (parsedJsonLines.every((entry) => entry !== null)) {
+    const rewritten = parsedJsonLines
+      .map((entry) => formatGhJsonRecord(entry!))
+      .filter((line): line is string => typeof line === "string" && line.length > 0);
+    if (rewritten.length > 0) {
+      return rewritten;
+    }
+  }
+
+  if ((input.argv ?? [])[0] === "gh") {
+    return lines.map(formatGhTableLine);
+  }
+
+  return lines;
+}

--- a/src/core/reduce-inspection-summary.ts
+++ b/src/core/reduce-inspection-summary.ts
@@ -1,0 +1,126 @@
+import { isFileContentInspectionCommand } from "./command-identity.js";
+import { clipMiddleWithHash, parseJsonValue } from "./reduce-utils.js";
+import { countTextChars, headTail, normalizeLines, stripAnsi, trimEmptyEdges } from "./text.js";
+
+import type { ToolExecutionInput } from "../types.js";
+
+const LARGE_INSPECTION_MIN_CHARS = 4_000;
+const LARGE_INSPECTION_MIN_LINES = 40;
+const PACKAGE_LOCK_RE = /\bpackage-lock\.json\b/u;
+
+export type InspectionSummaryReducerId = "generic/package-lock-summary" | "generic/large-document-summary";
+
+export type InspectionSummary = {
+  lines: string[];
+  matchedReducer: InspectionSummaryReducerId;
+};
+
+function buildPackageLockSummary(value: unknown): string[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const packages = typeof record.packages === "object" && record.packages !== null && !Array.isArray(record.packages)
+    ? Object.keys(record.packages as Record<string, unknown>)
+    : [];
+  const dependencies = typeof record.dependencies === "object" && record.dependencies !== null && !Array.isArray(record.dependencies)
+    ? Object.keys(record.dependencies as Record<string, unknown>)
+    : [];
+
+  const lines = [
+    "package-lock summary",
+    typeof record.name === "string" ? `name: ${record.name}` : null,
+    typeof record.version === "string" ? `version: ${record.version}` : null,
+    typeof record.lockfileVersion === "number" ? `lockfileVersion: ${record.lockfileVersion}` : null,
+    `packages: ${packages.length}`,
+    `dependencies: ${dependencies.length}`,
+  ].filter((line): line is string => line !== null);
+
+  const packageSamples = packages.filter(Boolean).slice(0, 12);
+  if (packageSamples.length > 0) {
+    lines.push(`sample packages: ${packageSamples.join(", ")}`);
+  }
+  return lines;
+}
+
+function buildLargeDocumentSummary(lines: string[], rawText: string): string[] {
+  const headings = lines
+    .map((line) => line.trim())
+    .filter((line) => /^#{1,6}\s+\S/u.test(line))
+    .slice(0, 24);
+  const excerpt = headTail(lines, 6, 6);
+  return [
+    `large document summary: ${lines.length} lines, ${countTextChars(rawText)} chars`,
+    ...(headings.length > 0 ? ["headings:", ...headings.map((line) => `- ${clipMiddleWithHash(line, 180)}`)] : []),
+    "excerpt:",
+    ...excerpt.map((line) => clipMiddleWithHash(line, 180)),
+  ];
+}
+
+function isLikelyDocumentLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < 50) {
+    return false;
+  }
+  if (/^(?:import|export|const|let|var|function|class|interface|type|return|if|for|while|switch|case|try|catch)\b/u.test(trimmed)) {
+    return false;
+  }
+  if (/^[{}()[\].,;:]/u.test(trimmed) || /[{};]$/u.test(trimmed)) {
+    return false;
+  }
+  return /\s/u.test(trimmed);
+}
+
+function isLikelyCodeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return /^(?:import|export|const|let|var|function|class|interface|type|return|if|for|while|switch|case|try|catch|\}|\{|\)|\])/u.test(trimmed)
+    || /[{};]$/u.test(trimmed);
+}
+
+function isLargeDocumentOutput(lines: string[], rawChars: number): boolean {
+  if (rawChars < LARGE_INSPECTION_MIN_CHARS) {
+    return false;
+  }
+
+  if (lines.length < LARGE_INSPECTION_MIN_LINES) {
+    return false;
+  }
+
+  const nonEmptyLines = lines.filter((line) => line.trim() !== "");
+  const headingCount = nonEmptyLines.filter((line) => /^#{1,6}\s+\S/u.test(line.trim())).length;
+  const hasFrontmatter = nonEmptyLines[0]?.trim() === "---"
+    && nonEmptyLines.slice(1, 20).some((line) => line.trim() === "---");
+  if (headingCount >= 2 || (hasFrontmatter && headingCount >= 1)) {
+    return true;
+  }
+
+  const documentLines = nonEmptyLines.filter(isLikelyDocumentLine).length;
+  const codeLines = nonEmptyLines.filter(isLikelyCodeLine).length;
+  return documentLines >= 20
+    && documentLines / nonEmptyLines.length >= 0.5
+    && codeLines / nonEmptyLines.length < 0.25;
+}
+
+export function buildInspectionSummary(input: ToolExecutionInput, rawText: string): InspectionSummary | null {
+  const command = input.command ?? "";
+  if (PACKAGE_LOCK_RE.test(command)) {
+    const lines = buildPackageLockSummary(parseJsonValue(rawText));
+    return lines.length > 0
+      ? { lines, matchedReducer: "generic/package-lock-summary" }
+      : null;
+  }
+
+  const rawChars = countTextChars(rawText);
+  const lines = trimEmptyEdges(normalizeLines(stripAnsi(rawText)));
+  if (!isFileContentInspectionCommand(input) || !isLargeDocumentOutput(lines, rawChars)) {
+    return null;
+  }
+
+  return {
+    lines: buildLargeDocumentSummary(lines, rawText),
+    matchedReducer: "generic/large-document-summary",
+  };
+}

--- a/src/core/reduce-utils.ts
+++ b/src/core/reduce-utils.ts
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+
+import { countTextChars } from "./text.js";
+
+export function compactWhitespace(text: string): string {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+function shortHash(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 12);
+}
+
+export function clipMiddleWithHash(text: string, maxChars: number): string {
+  if (countTextChars(text) <= maxChars) {
+    return text;
+  }
+  const omitted = countTextChars(text) - maxChars;
+  const headChars = Math.max(20, Math.floor(maxChars * 0.55));
+  const tailChars = Math.max(20, maxChars - headChars);
+  return `${text.slice(0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${text.slice(-tailChars)}`;
+}
+
+export function parseJsonObjectLine(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseJsonValue(text: string): unknown | null {
+  const trimmed = text.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/reduce-utils.ts
+++ b/src/core/reduce-utils.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { countTextChars } from "./text.js";
+import { countTextChars, sliceTextChars } from "./text.js";
 
 export function compactWhitespace(text: string): string {
   return text.replace(/\s+/gu, " ").trim();
@@ -17,7 +17,7 @@ export function clipMiddleWithHash(text: string, maxChars: number): string {
   const omitted = countTextChars(text) - maxChars;
   const headChars = Math.max(20, Math.floor(maxChars * 0.55));
   const tailChars = Math.max(20, maxChars - headChars);
-  return `${text.slice(0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${text.slice(-tailChars)}`;
+  return `${sliceTextChars(text, 0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${sliceTextChars(text, -tailChars)}`;
 }
 
 export function parseJsonObjectLine(line: string): Record<string, unknown> | null {

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -4,362 +4,12 @@ import { isFileContentInspectionCommand } from "./command-identity.js";
 import { normalizeExecutionInput } from "./execution-input.js";
 import { clampText, clampTextMiddle, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
 import { storeArtifact, storeArtifactMetadata } from "./artifacts.js";
+import { rewriteGhLines, rewriteGitDiffLines, rewriteGitStatusLines, rewriteSearchLines } from "./reduce-formatters.js";
+import { buildInspectionSummary } from "./reduce-inspection-summary.js";
 
 import type { CompactResult, CompiledRule, ReduceOptions, ToolExecutionInput } from "../types.js";
 
 const TINY_OUTPUT_MAX_CHARS = 240;
-
-function compactWhitespace(text: string): string {
-  return text.replace(/\s+/gu, " ").trim();
-}
-
-function rewriteGitStatusLine(line: string): string | null {
-  const trimmed = line.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  if (trimmed.startsWith("On branch ")) {
-    return null;
-  }
-  if (/^and have \d+ and \d+ different commits each/u.test(trimmed)) {
-    return null;
-  }
-  if (/^(?:no changes added to commit|nothing added to commit but untracked files present)/u.test(trimmed)) {
-    return null;
-  }
-  if (/^\(use "git .+"\)$/u.test(trimmed) || /^use "git .+" to .+/u.test(trimmed)) {
-    return null;
-  }
-  if (trimmed === "Changes not staged for commit:") {
-    return "Changes not staged:";
-  }
-  if (trimmed === "Changes to be committed:") {
-    return "Staged changes:";
-  }
-  if (trimmed === "Untracked files:") {
-    return "Untracked files:";
-  }
-  if (/^\s*modified:\s+/u.test(line)) {
-    return `M: ${line.replace(/^\s*modified:\s+/u, "").trim()}`;
-  }
-  if (/^\s*new file:\s+/u.test(line)) {
-    return `A: ${line.replace(/^\s*new file:\s+/u, "").trim()}`;
-  }
-  if (/^\s*deleted:\s+/u.test(line)) {
-    return `D: ${line.replace(/^\s*deleted:\s+/u, "").trim()}`;
-  }
-  if (/^\s*renamed:\s+/u.test(line)) {
-    return `R: ${line.replace(/^\s*renamed:\s+/u, "").trim()}`;
-  }
-  if (/^\?\?\s+/u.test(trimmed)) {
-    return `?? ${trimmed.replace(/^\?\?\s+/u, "").trim()}`;
-  }
-
-  const porcelainMatch = line.match(/^([ MADRCU?!]{2})\s+(.+)$/u);
-  if (porcelainMatch) {
-    const status = porcelainMatch[1]!.trim().replace(/\?/gu, "??");
-    const path = porcelainMatch[2]!.trim();
-    const code = status === "" ? "M" : status[0] === "?" ? "??" : status[0]!;
-    return `${code}: ${path}`;
-  }
-
-  return trimmed;
-}
-
-function rewriteGitStatusLines(lines: string[]): string[] {
-  let section: "staged" | "unstaged" | "untracked" | null = null;
-  const rewritten = lines
-    .map((line) => {
-      const trimmed = line.trim();
-      if (trimmed === "Changes not staged for commit:") {
-        section = "unstaged";
-      } else if (trimmed === "Changes to be committed:") {
-        section = "staged";
-      } else if (trimmed === "Untracked files:") {
-        section = "untracked";
-      }
-
-      if (section === "untracked" && /^\s{2,}\S/u.test(line) && !/^\s*(?:modified:|new file:|deleted:|renamed:)/u.test(line)) {
-        return `?? ${trimmed}`;
-      }
-
-      return rewriteGitStatusLine(line);
-    })
-    .filter((line): line is string => line !== null);
-
-  const collapsed: string[] = [];
-  for (const line of rewritten) {
-    if (line === "" && collapsed[collapsed.length - 1] === "") {
-      continue;
-    }
-    collapsed.push(line);
-  }
-  return collapsed;
-}
-
-function extractGhLabelNames(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((entry) => {
-    if (typeof entry === "string") {
-      return entry ? [entry] : [];
-    }
-    if (typeof entry === "object" && entry !== null && "name" in entry && typeof entry.name === "string") {
-      return entry.name ? [entry.name] : [];
-    }
-    return [];
-  });
-}
-
-function extractGhCommentCount(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.length;
-  }
-  if (typeof value === "object" && value !== null && "totalCount" in value && typeof value.totalCount === "number") {
-    return value.totalCount;
-  }
-  return null;
-}
-
-function parseJsonObjectLine(line: string): Record<string, unknown> | null {
-  const trimmed = line.trim();
-  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function parseJsonValue(text: string): unknown | null {
-  const trimmed = text.trim();
-  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(trimmed) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-function parseIsoTimestamp(value: unknown): number | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function formatDuration(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) {
-    return "";
-  }
-
-  if (seconds < 60) {
-    return `${Math.round(seconds)}s`;
-  }
-
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const remainingSeconds = Math.round(seconds % 60);
-  if (hours > 0) {
-    return `${hours}h${String(minutes).padStart(2, "0")}m`;
-  }
-  return `${minutes}m${String(remainingSeconds).padStart(2, "0")}s`;
-}
-
-function extractGhDuration(record: Record<string, unknown>): string | null {
-  if (typeof record.durationSec === "number" && Number.isFinite(record.durationSec) && record.durationSec >= 0) {
-    return formatDuration(record.durationSec);
-  }
-  if (typeof record.durationSeconds === "number" && Number.isFinite(record.durationSeconds) && record.durationSeconds >= 0) {
-    return formatDuration(record.durationSeconds);
-  }
-
-  const startedAt = parseIsoTimestamp(record.startedAt);
-  const completedAt = parseIsoTimestamp(record.completedAt);
-  if (startedAt !== null && completedAt !== null && completedAt >= startedAt) {
-    return formatDuration((completedAt - startedAt) / 1000);
-  }
-
-  const createdAt = parseIsoTimestamp(record.createdAt);
-  const updatedAt = parseIsoTimestamp(record.updatedAt);
-  if (createdAt !== null && updatedAt !== null && updatedAt >= createdAt) {
-    return formatDuration((updatedAt - createdAt) / 1000);
-  }
-
-  return null;
-}
-
-function formatGhJsonRecord(record: Record<string, unknown>): string | null {
-  const numericId = typeof record.number === "number" ? record.number
-    : typeof record.databaseId === "number" ? record.databaseId
-      : null;
-  const title = typeof record.title === "string" ? record.title
-    : typeof record.displayTitle === "string" ? record.displayTitle
-      : typeof record.name === "string" ? record.name
-        : typeof record.workflowName === "string" ? record.workflowName
-          : null;
-  if (!title) {
-    return null;
-  }
-
-  const labels = extractGhLabelNames(record.labels).slice(0, 3);
-  const comments = extractGhCommentCount(record.comments);
-  const branch = typeof record.headBranch === "string" ? record.headBranch
-    : typeof record.headRefName === "string" ? record.headRefName
-      : null;
-  const status = typeof record.state === "string" ? record.state
-    : typeof record.status === "string" ? record.status
-      : typeof record.conclusion === "string" ? record.conclusion
-      : null;
-  const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt.slice(0, 10) : null;
-  const duration = extractGhDuration(record);
-
-  const parts: string[] = [];
-  if (numericId !== null) {
-    parts.push(`#${numericId}`);
-  }
-  parts.push(compactWhitespace(title));
-  if (status) {
-    parts.push(`[${status}]`);
-  }
-  if (branch) {
-    parts.push(`(${compactWhitespace(branch)})`);
-  }
-  if (duration) {
-    parts.push(duration);
-  }
-  if (typeof comments === "number" && comments > 0) {
-    parts.push(`${comments}c`);
-  }
-  if (labels.length > 0) {
-    parts.push(`{${labels.join(", ")}}`);
-  }
-  if (updatedAt) {
-    parts.push(updatedAt);
-  }
-  return parts.join(" ");
-}
-
-function formatGhJsonValue(value: unknown): string[] {
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => {
-      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-        return [];
-      }
-      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
-      return formatted ? [formatted] : [];
-    });
-  }
-
-  if (typeof value !== "object" || value === null) {
-    return [];
-  }
-
-  const record = value as Record<string, unknown>;
-  const lines: string[] = [];
-  const header = formatGhJsonRecord(record);
-  if (header) {
-    lines.push(header);
-  }
-
-  for (const collectionKey of ["jobs", "workflowRuns", "items", "artifacts"]) {
-    const collection = record[collectionKey];
-    if (!Array.isArray(collection)) {
-      continue;
-    }
-
-    for (const entry of collection) {
-      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-        continue;
-      }
-      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
-      if (formatted) {
-        lines.push(formatted);
-      }
-    }
-  }
-
-  return lines;
-}
-
-function formatGhTableLine(line: string): string {
-  const trimmed = line.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const tabColumns = line.split("\t").map((part) => compactWhitespace(part)).filter(Boolean);
-  if (tabColumns.length >= 4 && /^\d{4}-\d{2}-\d{2}T/u.test(tabColumns[2] ?? "")) {
-    const [job, step, , ...rest] = tabColumns;
-    const parts = [job, step, compactWhitespace(rest.join(" "))].filter(Boolean);
-    return parts.join(" | ");
-  }
-
-  const columns = trimmed.split(/\s{2,}|\t+/u).map((part) => compactWhitespace(part)).filter(Boolean);
-  if (columns.length >= 2 && /^\d+$/u.test(columns[0] ?? "")) {
-    const number = columns[0]!;
-    const title = columns[1]!;
-    const state = columns.length >= 4 ? columns.at(-1) : null;
-    const context = columns.length >= 3 ? columns.slice(2, state ? -1 : undefined).join(" ") : null;
-    const parts = [`#${number}`, title];
-    if (state) {
-      parts.push(`[${state}]`);
-    }
-    if (context) {
-      parts.push(`(${context})`);
-    }
-    return parts.join(" ");
-  }
-
-  return compactWhitespace(trimmed);
-}
-
-function rewriteGhLines(lines: string[], input: ToolExecutionInput): string[] {
-  const nonEmpty = lines.filter((line) => line.trim() !== "");
-  if (nonEmpty.length === 0) {
-    return [];
-  }
-
-  const parsedWholeJson = parseJsonValue(nonEmpty.join("\n"));
-  if (parsedWholeJson !== null) {
-    const rewrittenWholeJson = formatGhJsonValue(parsedWholeJson);
-    if (rewrittenWholeJson.length > 0) {
-      return rewrittenWholeJson;
-    }
-  }
-
-  const parsedJsonLines = nonEmpty.map(parseJsonObjectLine);
-  if (parsedJsonLines.every((entry) => entry !== null)) {
-    const rewritten = parsedJsonLines
-      .map((entry) => formatGhJsonRecord(entry!))
-      .filter((line): line is string => typeof line === "string" && line.length > 0);
-    if (rewritten.length > 0) {
-      return rewritten;
-    }
-  }
-
-  if ((input.argv ?? [])[0] === "gh") {
-    return lines.map(formatGhTableLine);
-  }
-
-  return lines;
-}
 
 function buildRawText(input: ToolExecutionInput): string {
   if (input.combinedText) {
@@ -443,14 +93,25 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
     counterLines = rewriteGitStatusLines(counterLines);
     lines = rewriteGitStatusLines(lines);
   }
+  const preRewriteLines = [...lines];
   if (rule.id === "cloud/gh") {
     counterLines = rewriteGhLines(counterLines, input);
     lines = rewriteGhLines(lines, input);
   }
+  if (rule.id === "search/rg") {
+    lines = rewriteSearchLines(lines);
+  }
+  if (rule.id === "git/diff") {
+    lines = rewriteGitDiffLines(lines);
+  }
 
   for (const counter of compiledRule.compiled.counters) {
     const pattern = counter.pattern;
-    facts[counter.name] = (rule.counterSource === "preKeep" ? counterLines : lines).filter((line) => pattern.test(line)).length;
+    let factLines = rule.counterSource === "preKeep" ? counterLines : rule.id === "git/diff" ? preRewriteLines : lines;
+    if (rule.id === "git/diff" && (counter.name === "added line" || counter.name === "removed line")) {
+      factLines = factLines.filter((line) => !line.startsWith("+++") && !line.startsWith("---"));
+    }
+    facts[counter.name] = factLines.filter((line) => pattern.test(line)).length;
   }
 
   if (lines.length === 0 && rule.onEmpty) {
@@ -623,6 +284,55 @@ export async function reduceExecutionWithRules(
         ratio: 1,
       },
       classification,
+    };
+  }
+
+  const inspectionSummary = buildInspectionSummary(normalizedInput, rawText);
+  if (inspectionSummary) {
+    const summaryText = inspectionSummary.lines.join("\n").trim();
+    const selectedText = clampTextMiddle(summaryText, opts.maxInlineChars ?? 1200);
+    const reducedChars = countTextChars(selectedText);
+    const summaryClassification = {
+      family: "structured-summary",
+      confidence: 0.9,
+      matchedReducer: inspectionSummary.matchedReducer,
+    };
+    const stats = {
+      rawChars: measuredRawChars,
+      reducedChars,
+      ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
+    };
+    const rawRef = opts.store
+      ? await storeArtifact(
+          {
+            input: normalizedInput,
+            rawText,
+            classification: summaryClassification,
+            stats,
+          },
+          opts.storeDir,
+        )
+      : undefined;
+
+    if (!opts.store && opts.recordStats) {
+      await storeArtifactMetadata(
+        {
+          input: normalizedInput,
+          rawText,
+          classification: summaryClassification,
+          stats,
+        },
+        opts.storeDir,
+      );
+    }
+
+    return {
+      inlineText: selectedText,
+      previewText: summaryText,
+      ...(trace ? { trace } : {}),
+      ...(rawRef ? { rawRef } : {}),
+      stats,
+      classification: summaryClassification,
     };
   }
 

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -49,6 +49,10 @@ export function countTextChars(text: string): number {
   return graphemes(text).length;
 }
 
+export function sliceTextChars(text: string, start: number, end?: number): string {
+  return graphemes(text).slice(start, end).join("");
+}
+
 function codePointWidth(codePoint: number): number {
   if (
     codePoint === 0

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -5,8 +5,7 @@ import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
 
 import { storeArtifactMetadata } from "../../core/artifacts.js";
-import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
-import { getInspectionCommandSkipReason } from "../../core/inventory-safety.js";
+import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
 import { countTextChars, stripAnsi } from "../../core/text.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
@@ -995,7 +994,7 @@ export async function runCodexPostToolUseHook(rawText: string): Promise<number> 
     return 0;
   }
 
-  const inspectionSkipReason = getInspectionCommandSkipReason(command, "allow-safe-inventory");
+  const inspectionSkipReason = getOutputAwareInspectionSkipReason("allow-safe-inventory", executionInput);
   if (inspectionSkipReason) {
     await recordImmediateHookStats(executionInput, combinedText, storeRaw);
     const stats = buildImmediateSkipStats(combinedText);

--- a/src/hosts/openclaw/extension.ts
+++ b/src/hosts/openclaw/extension.ts
@@ -1,5 +1,4 @@
-import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
-import { getInspectionCommandSkipReason } from "../../core/inventory-safety.js";
+import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import {
   buildCompactionNotice,
   buildTokenjuiceDetails,
@@ -95,12 +94,16 @@ export function createTokenjuiceOpenClawEmbeddedExtension() {
       if (!command) {
         return undefined;
       }
-      if (getInspectionCommandSkipReason(command, "allow-safe-inventory")) {
-        return undefined;
-      }
-
       const outputText = readAggregatedText(event.details, event.content);
       if (!outputText.trim()) {
+        return undefined;
+      }
+      const executionInput = {
+        toolName: "exec",
+        command,
+        combinedText: outputText,
+      };
+      if (getOutputAwareInspectionSkipReason("allow-safe-inventory", executionInput)) {
         return undefined;
       }
 

--- a/src/hosts/pi/extension/runtime.ts
+++ b/src/hosts/pi/extension/runtime.ts
@@ -1,7 +1,6 @@
 import { readFile, stat } from "node:fs/promises";
 
-import { compactBashResult } from "../../../core/integrations/compact-bash-result.js";
-import { getInspectionCommandSkipReason } from "../../../core/inventory-safety.js";
+import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../../core/integrations/compact-bash-result.js";
 
 import type { Pi, PiContext, PiToolResultEvent } from "./pi-types.js";
 import { isRecord } from "./pi-types.js";
@@ -170,7 +169,15 @@ export function createTokenjuicePiExtension(config: PiExtensionRuntimeConfig) {
         };
       }
 
-      if (getInspectionCommandSkipReason(command, "allow-safe-inventory")) {
+      const exitCode = parseExitCode(outputText, Boolean(event.isError));
+      const visibleText = stripPiBashEpilogue(outputText);
+      const visibleExecutionInput = {
+        toolName: "exec",
+        command,
+        combinedText: visibleText,
+        exitCode,
+      };
+      if (getOutputAwareInspectionSkipReason("allow-safe-inventory", visibleExecutionInput)) {
         return undefined;
       }
 
@@ -179,15 +186,13 @@ export function createTokenjuicePiExtension(config: PiExtensionRuntimeConfig) {
         return undefined;
       }
 
-      const exitCode = parseExitCode(outputText, Boolean(event.isError));
-
       let outcome;
       try {
         outcome = await compactBashResult({
           source: "pi",
           command,
           cwd: ctx.cwd,
-          visibleText: stripPiBashEpilogue(outputText),
+          visibleText,
           ...(typeof trustedFullOutputText === "string" ? { trustedFullText: trustedFullOutputText } : {}),
           exitCode,
           maxInlineChars: DEFAULT_MAX_INLINE_CHARS,

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -209,6 +209,24 @@ describe("normalizeExecutionInput", () => {
     expect(normalized.command).toBe("rg --files | rg TODO src");
     expect(normalized.argv).toBeUndefined();
   });
+
+  it("unwraps env prefixes before deriving the effective argv", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "GIT_DIR=/repo/.git GIT_WORK_TREE=/repo git status --short",
+    });
+    expect(normalized.command).toBe("git status --short");
+    expect(normalized.argv).toEqual(["git", "status", "--short"]);
+  });
+
+  it("unwraps env launcher prefixes before deriving the effective argv", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "env GIT_DIR=/repo/.git GIT_WORK_TREE=/repo git ls-files src",
+    });
+    expect(normalized.command).toBe("git ls-files src");
+    expect(normalized.argv).toEqual(["git", "ls-files", "src"]);
+  });
 });
 
 describe("hasSequentialShellCommands", () => {
@@ -257,12 +275,18 @@ describe("isFileContentInspectionCommand", () => {
     { label: "git show blob piped to sed", command: "git show HEAD:README.md | sed -n '1,40p'" },
     { label: "wrapped cat", command: "cd repo && cat README.md" },
     { label: "clustered shell wrapper", command: "bash -ec 'cat README.md'" },
+    { label: "git show blob", command: "git show HEAD:src/core/reduce.ts" },
+    { label: "gh contents decode", command: "gh api repos/gumadeiras/tokenjuice/contents/src/core/reduce.ts --jq .content | base64 -d" },
   ])("detects $label as file inspection from command text", ({ command }) => {
     expect(isFileContentInspectionCommand({ command })).toBe(true);
   });
 
   it("detects file inspection after a safe cd prefix", () => {
     expect(isFileContentInspectionCommand({ command: "cd /repo && cat README.md" })).toBe(true);
+  });
+
+  it("detects file inspection after env prefixes", () => {
+    expect(isFileContentInspectionCommand({ command: "env GIT_DIR=/repo/.git git show HEAD:README.md" })).toBe(true);
   });
 
   it("returns false for normal search commands", () => {

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -227,6 +227,15 @@ describe("normalizeExecutionInput", () => {
     expect(normalized.command).toBe("git ls-files src");
     expect(normalized.argv).toEqual(["git", "ls-files", "src"]);
   });
+
+  it("unwraps env end-of-options markers before deriving the effective argv", () => {
+    const normalized = normalizeExecutionInput({
+      toolName: "exec",
+      command: "env -- git ls-files src",
+    });
+    expect(normalized.command).toBe("git ls-files src");
+    expect(normalized.argv).toEqual(["git", "ls-files", "src"]);
+  });
 });
 
 describe("hasSequentialShellCommands", () => {
@@ -287,6 +296,10 @@ describe("isFileContentInspectionCommand", () => {
 
   it("detects file inspection after env prefixes", () => {
     expect(isFileContentInspectionCommand({ command: "env GIT_DIR=/repo/.git git show HEAD:README.md" })).toBe(true);
+  });
+
+  it("detects file inspection after env end-of-options markers", () => {
+    expect(isFileContentInspectionCommand({ command: "env -- git show HEAD:README.md" })).toBe(true);
   });
 
   it("returns false for normal search commands", () => {

--- a/test/core/integrations/compact-bash-result.test.ts
+++ b/test/core/integrations/compact-bash-result.test.ts
@@ -118,6 +118,77 @@ describe("compactBashResult", () => {
     });
   });
 
+  it("treats git show blob reads as file content under the safe-inventory inspection policy", async () => {
+    const outcome = await compactBashResult({
+      source: "pi",
+      command: "git show HEAD:src/core/reduce.ts",
+      visibleText: "export function reduceExecution() {}\n",
+      inspectionPolicy: "allow-safe-inventory",
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    expect(outcome).toMatchObject({
+      action: "keep",
+      reason: "file-content-inspection-command",
+    });
+  });
+
+  it("allows package-lock inspection through the summary reducer", async () => {
+    const outcome = await compactBashResult({
+      source: "pi",
+      command: "jq . package-lock.json",
+      visibleText: JSON.stringify({
+        name: "tokenjuice",
+        lockfileVersion: 3,
+        packages: Object.fromEntries(Array.from({ length: 80 }, (_, index) => [`node_modules/pkg-${index}`, { version: "1.0.0" }])),
+      }, null, 2),
+      inspectionPolicy: "allow-safe-inventory",
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    expect(outcome).toMatchObject({
+      action: "rewrite",
+      result: {
+        classification: {
+          matchedReducer: "generic/package-lock-summary",
+        },
+        inlineText: expect.stringContaining("packages: 80"),
+      },
+    });
+  });
+
+  it("allows large document-shaped file inspections through the summary reducer", async () => {
+    const outcome = await compactBashResult({
+      source: "pi",
+      command: "sed -n '1,260p' notes.txt",
+      visibleText: [
+        "# Review",
+        "intro",
+        "## Evidence",
+        ...Array.from({ length: 260 }, (_, index) => `paragraph ${index} ${"x".repeat(40)}`),
+      ].join("\n"),
+      inspectionPolicy: "allow-safe-inventory",
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    expect(outcome).toMatchObject({
+      action: "rewrite",
+      result: {
+        classification: {
+          matchedReducer: "generic/large-document-summary",
+        },
+      },
+    });
+  });
+
   it("keeps tree output raw under the safe-inventory inspection policy", async () => {
     const outcome = await compactBashResult({
       source: "pi",

--- a/test/core/inventory-safety.test.ts
+++ b/test/core/inventory-safety.test.ts
@@ -19,6 +19,7 @@ describe("isRepositoryInventoryCommand", () => {
     "cd /repo && rg --files src/rules",
     "git -C repo ls-files src",
     "git --no-pager ls-files src",
+    "env -- git ls-files src",
   ])("detects `%s` as repository inventory", (command) => {
     expect(isRepositoryInventoryCommand({ command })).toBe(true);
   });
@@ -46,6 +47,7 @@ describe("isRepositoryInspectionCommand", () => {
     "git ls-files src",
     "git -C repo ls-files src",
     "git --no-pager ls-files src",
+    "env -- git ls-files src",
   ])("detects `%s` as repository inspection", (command) => {
     expect(isRepositoryInspectionCommand({ command })).toBe(true);
   });
@@ -76,6 +78,7 @@ describe("isSafeRepositoryInventoryPipeline", () => {
     "rg --files | sed 's#^src/##'",
     "find src -type f | wc -l",
     "env GIT_DIR=/repo/.git GIT_WORK_TREE=/repo git ls-files src | wc -l",
+    "env -- git ls-files src | wc -l",
   ])("allows `%s`", (command) => {
     expect(isSafeRepositoryInventoryPipeline(command)).toBe(true);
   });
@@ -125,6 +128,7 @@ describe("isSafeRepositoryInventoryPipeline", () => {
     { command: "fd --exec cat", safety: "unsafe-pipeline" },
     { command: "git ls-files | sed -n '1,20p'", safety: "safe" },
     { command: "git ls-files | wc -l", safety: "safe" },
+    { command: "env -- git ls-files src | wc -l", safety: "safe" },
   ])("classifies `%s` as $safety", ({ command, safety }) => {
     expect(getRepositoryInventorySafety(command)).toBe(safety);
   });

--- a/test/core/inventory-safety.test.ts
+++ b/test/core/inventory-safety.test.ts
@@ -72,6 +72,10 @@ describe("isSafeRepositoryInventoryPipeline", () => {
     "find src -type f | sort -k 1 | head -40",
     "find src -type f | sort --batch-size 4M --sort name | head -40",
     "find src -type f | uniq -c",
+    "git ls-files | sed -n '1,20p'",
+    "rg --files | sed 's#^src/##'",
+    "find src -type f | wc -l",
+    "env GIT_DIR=/repo/.git GIT_WORK_TREE=/repo git ls-files src | wc -l",
   ])("allows `%s`", (command) => {
     expect(isSafeRepositoryInventoryPipeline(command)).toBe(true);
   });
@@ -89,6 +93,8 @@ describe("isSafeRepositoryInventoryPipeline", () => {
     "git -C repo ls-files | jq -R .",
     "rg --files | rg TODO src",
     "find src -type f | sed -n '1,5p' src/core/reduce.ts",
+    "find src -type f | sed -f script.sed",
+    "find src -type f | wc -lm",
     "git ls-files | grep -R TODO src",
     "find src -type f | head -n 5 README.md",
     "git ls-files | tail -n 5 README.md",
@@ -117,6 +123,8 @@ describe("isSafeRepositoryInventoryPipeline", () => {
     { command: "find src -type f | xargs wc -l", safety: "unsafe-pipeline" },
     { command: "find src -type f -exec cat {} +", safety: "unsafe-pipeline" },
     { command: "fd --exec cat", safety: "unsafe-pipeline" },
+    { command: "git ls-files | sed -n '1,20p'", safety: "safe" },
+    { command: "git ls-files | wc -l", safety: "safe" },
   ])("classifies `%s` as $safety", ({ command, safety }) => {
     expect(getRepositoryInventorySafety(command)).toBe(safety);
   });
@@ -140,5 +148,8 @@ describe("getInspectionCommandSkipReason", () => {
   it("allows safe inventory with allow-safe-inventory", () => {
     expect(getInspectionCommandSkipReason("rg --files | sort | head -n 10", "allow-safe-inventory")).toBeNull();
     expect(getInspectionCommandSkipReason("cd /repo && rg --files src", "allow-safe-inventory")).toBeNull();
+    expect(getInspectionCommandSkipReason("git ls-files | sed -n '1,20p'", "allow-safe-inventory")).toBeNull();
+    expect(getInspectionCommandSkipReason("jq '.packages' package-lock.json", "allow-safe-inventory")).toBeNull();
+    expect(getInspectionCommandSkipReason("sed -n '1,260p' /tmp/paper.review.md", "allow-safe-inventory")).toBe("file-content-inspection-command");
   });
 });

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -5,12 +5,22 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { findMatchingRule, getArtifact, listArtifactMetadata, reduceExecution, statsArtifacts } from "../../src/index.js";
+import { clipMiddleWithHash } from "../../src/core/reduce-utils.js";
 import { countTextChars } from "../../src/core/text.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("clipMiddleWithHash", () => {
+  it("clips on grapheme boundaries instead of splitting surrogate pairs", () => {
+    const clipped = clipMiddleWithHash("😀".repeat(80), 42);
+    const hasUnpairedSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(clipped);
+
+    expect(hasUnpairedSurrogate).toBe(false);
+  });
 });
 
 async function createTempDir(): Promise<string> {

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1060,6 +1060,23 @@ describe("reduceExecution", () => {
     expect(result.stats.ratio).toBe(1);
   });
 
+  it("clips huge ripgrep match lines before selecting inline output", async () => {
+    const longPayload = "x".repeat(4_000);
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n payload fixtures",
+      argv: ["rg", "-n", "payload", "fixtures"],
+      combinedText: `fixtures/blob.json:1:${longPayload}`,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("search/rg");
+    expect(result.inlineText).toContain("fixtures/blob.json:1:");
+    expect(result.inlineText).toContain("chars omitted");
+    expect(result.inlineText).toContain("sha256:");
+    expect(result.inlineText.length).toBeLessThan(900);
+  });
+
   it("formats gh issue json-line output into compact issue summaries", async () => {
     const result = await reduceExecution({
       toolName: "exec",
@@ -1109,6 +1126,111 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("#67473");
     expect(result.inlineText).toContain("{bug, bug:behavior}");
     expect(result.inlineText).not.toContain("\"labels\"");
+  });
+
+  it("formats gh review comments into compact body hashes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh api repos/openclaw/openclaw/pulls/1/comments --paginate",
+      argv: ["gh", "api", "repos/openclaw/openclaw/pulls/1/comments", "--paginate"],
+      combinedText: JSON.stringify([
+        {
+          id: 123,
+          user: { login: "reviewer" },
+          path: "src/index.ts",
+          line: 42,
+          body: `Please fix this path. ${"details ".repeat(80)}`,
+          created_at: "2026-04-20T12:00:00Z",
+        },
+      ]),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("comment #123 @reviewer src/index.ts:42");
+    expect(result.inlineText).toContain("sha256:");
+    expect(result.inlineText).not.toContain("\"body\"");
+  });
+
+  it("clips large git diff hunks while keeping exact file and hunk headers", async () => {
+    const changedLines = Array.from({ length: 30 }, (_, index) => `+const value${index} = "${"x".repeat(80)}";`);
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git diff -- src/index.ts",
+      argv: ["git", "diff", "--", "src/index.ts"],
+      combinedText: [
+        "diff --git a/src/index.ts b/src/index.ts",
+        "index 1111111..2222222 100644",
+        "--- a/src/index.ts",
+        "+++ b/src/index.ts",
+        "@@ -1,3 +1,33 @@",
+        "-const old = true;",
+        ...changedLines,
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/diff");
+    expect(result.inlineText).toContain("diff --git a/src/index.ts b/src/index.ts");
+    expect(result.inlineText).toContain("@@ -1,3 +1,33 @@");
+    expect(result.inlineText).toContain("hunk clipped");
+    expect(result.inlineText).not.toContain("value29");
+    expect(result.facts?.["added line"]).toBe(30);
+  });
+
+  it("summarizes package-lock JSON file inspection instead of replaying the whole lockfile", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "jq . package-lock.json",
+      argv: ["jq", ".", "package-lock.json"],
+      combinedText: JSON.stringify({
+        name: "tokenjuice",
+        version: "0.6.0",
+        lockfileVersion: 3,
+        packages: Object.fromEntries(Array.from({ length: 80 }, (_, index) => [`node_modules/pkg-${index}`, { version: "1.0.0" }])),
+        dependencies: Object.fromEntries(Array.from({ length: 20 }, (_, index) => [`pkg-${index}`, { version: "1.0.0" }])),
+      }, null, 2),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/package-lock-summary");
+    expect(result.inlineText).toContain("package-lock summary");
+    expect(result.inlineText).toContain("packages: 80");
+    expect(result.inlineText).not.toContain("\"node_modules/pkg-79\"");
+  });
+
+  it("summarizes large document-shaped file inspections without path allowlists", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "sed -n '1,260p' notes.txt",
+      argv: ["sed", "-n", "1,260p", "notes.txt"],
+      combinedText: [
+        "# Review",
+        "intro",
+        "## Evidence",
+        ...Array.from({ length: 260 }, (_, index) => `paragraph ${index} ${"x".repeat(40)}`),
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/large-document-summary");
+    expect(result.inlineText).toContain("large document summary");
+    expect(result.inlineText).toContain("- # Review");
+    expect(result.inlineText).toContain("- ## Evidence");
+  });
+
+  it("keeps large code-shaped file inspections raw", async () => {
+    const code = Array.from({ length: 260 }, (_, index) => `export function value${index}() { return ${index}; }`).join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "cat src/generated.ts",
+      argv: ["cat", "src/generated.ts"],
+      combinedText: code,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toBe(code);
   });
 
   it("formats gh run json objects and nested jobs into compact summaries", async () => {

--- a/test/hosts/cursor.test.ts
+++ b/test/hosts/cursor.test.ts
@@ -287,7 +287,8 @@ describe("runCursorPreToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.updated_input.command).toContain(`${process.execPath} /repo/dist/cli/main.js wrap -- ${hostShellPath} -lc 'git status --short'`);
+    expect(response.updated_input.command).toContain(`/repo/dist/cli/main.js wrap -- ${hostShellPath} -lc 'git status --short'`);
+    expect(response.updated_input.command).toContain(process.execPath);
   });
 
   it("skips node-based local wrap commands to preserve raw bypass", async () => {


### PR DESCRIPTION
## Summary

This tightens Tokenjuice compaction around the main failure modes seen in recent Codex sessions:

- extend file-content inspection detection so remote/blob content reads stay raw instead of fallback-compacted
- normalize wrapped/effective commands before matching reducers and safety policy
- broaden safe repository inventory pipeline handling
- add deterministic summaries for large document-shaped output
- split reducer formatter and inspection-summary helpers out of `reduce.ts`

## Why

Replay showed that fallback compaction can produce the wrong interaction when a command is really asking for file contents: the agent receives a lossy/clamped view, then follows up with `--raw` / `--full`.

Main already preserved direct local file reads such as `cat`, `sed`, and `jq`. This PR extends that protection to additional content-read forms such as `git show HEAD:path` and `gh api .../contents | base64 -d`, while still allowing compaction when the output is explicitly structured (`package-lock.json`) or when the output itself looks like a large prose/document artifact rather than source code.

## Changes

- Fix empty stdin handling for direct analysis commands such as `doctor` / `discover`.
- Add effective command normalization for env prefixes, shell/setup wrappers, and wrapped command matching.
- Treat Git blobs and remote GitHub contents decode pipelines as file-content inspection.
- Broaden safe inventory handling for commands like `wc -l`, safe `sed -n`, simple `sed s///`, env-wrapped inventory commands, and safe inventory pipelines.
- Add deterministic reducers for:
  - long `rg` result lines
  - large git diff hunks
  - GitHub JSON/comment output
  - `package-lock.json`
  - large document-shaped file inspection output
- Detect large document summaries from output shape:
  - minimum size and line count
  - markdown headings or frontmatter
  - paragraph-heavy text
  - code-shaped output rejected
- Refactor reducer internals:
  - keep `src/core/reduce.ts` focused on orchestration
  - move output rewriting to `src/core/reduce-formatters.ts`
  - move inspection summaries to `src/core/reduce-inspection-summary.ts`
  - move shared clipping/JSON helpers to `src/core/reduce-utils.ts`
- Route Codex, OpenClaw, Pi, and shared bash compaction through the same output-aware inspection skip helper.

## Replay Results

Replayed local Codex exec outputs from the first real Tokenjuice hook session:

- Window: `2026-04-19T20:01:34.537Z` through current run
- Exec outputs: 10,457
- Raw chars: 34,881,336
- `origin/main` reduced chars: 20,554,000
- This branch reduced chars: 15,883,031
- Extra saved vs `origin/main`: 4,670,969 chars
- Savings rate: 41.08% -> 54.47%

Largest gain:

- `generic/large-document-summary`: 647 calls, +4,728,532 chars saved
- Zero negative replay cases for the document-summary reducer

Correctness tradeoff:

- Preserved local file reads: 2,435 calls, 0 extra cost vs baseline in replay
- `gh api .../contents | base64 -d` file reads now stay raw: 7 calls, -34,699 chars vs fallback compaction
- explicit `tokenjuice wrap --raw/--full` bypass behavior remains preserved
- explicit raw/full appeared immediately after content reads 35 times in the replay window

## Testing

- `pnpm verify`
- `pnpm build`
- `node dist/cli/main.js doctor`
