### PR TITLE
fix(hosts): honor raw/full bypass for cd-prefixed commands

### DIFF
--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -3,6 +3,7 @@ import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
+import { stripLeadingCdPrefix } from "../../core/command.js";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
 
@@ -365,7 +366,7 @@ function shouldStoreFromEnv(): boolean {
 }
 
 function commandRequestsTokenjuiceRawBypass(command: string): boolean {
-  const argv = parseShellWords(command);
+  const argv = parseShellWords(stripLeadingCdPrefix(command));
   if (argv.length < 3) {
     return false;
   }

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -4,6 +4,7 @@ import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
 
+import { stripLeadingCdPrefix } from "../../core/command.js";
 import { storeArtifactMetadata } from "../../core/artifacts.js";
 import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
@@ -582,7 +583,7 @@ function isTokenjuiceExecutableArg(value: string | undefined): boolean {
 }
 
 function commandRequestsTokenjuiceRawBypass(command: string): boolean {
-  const argv = parseShellWords(command);
+  const argv = parseShellWords(stripLeadingCdPrefix(command));
   if (argv.length < 3) {
     return false;
   }

--- a/src/hosts/cursor/index.ts
+++ b/src/hosts/cursor/index.ts
@@ -3,7 +3,7 @@ import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
-import { tokenizeCommand } from "../../core/command.js";
+import { stripLeadingCdPrefix, tokenizeCommand } from "../../core/command.js";
 
 type CursorHooksConfig = Record<string, unknown> & {
   version?: number;
@@ -283,7 +283,7 @@ function extractHookCommandPaths(command: string): string[] {
 }
 
 function commandAlreadyWrapped(command: string): boolean {
-  const argv = tokenizeCommand(command);
+  const argv = tokenizeCommand(stripLeadingCdPrefix(command));
   if (argv.length < 2) {
     return false;
   }

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -723,6 +723,31 @@ describe("runClaudeCodePostToolUseHook", () => {
     expect(debug.skipped).toBe("explicit-raw-bypass");
   });
 
+  it("honors tokenjuice raw bypass commands with leading cd prefixes", async () => {
+    const home = await createTempDir();
+    process.env.CLAUDE_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "cd /data/code/lighthouse/helper && tokenjuice wrap --raw -- python scripts/query_cls_log.py --limit 500",
+      },
+      tool_response: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("explicit-raw-bypass");
+  });
+
   it("honors tokenjuice full bypass commands without re-compacting them", async () => {
     const home = await createTempDir();
     process.env.CLAUDE_HOME = home;

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -875,6 +875,31 @@ describe("runCodexPostToolUseHook", () => {
     expect(debug.ratio).toBe(1);
   });
 
+  it("honors tokenjuice raw bypass commands with leading cd prefixes", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "cd /data/code/lighthouse/helper && tokenjuice wrap --raw -- python scripts/query_cls_log.py --limit 500",
+      },
+      tool_response: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("explicit-raw-bypass");
+  });
+
   it("records metadata-only stats for immediate skip paths", async () => {
     const home = await createTempDir();
     process.env.CODEX_HOME = home;

--- a/test/hosts/cursor.test.ts
+++ b/test/hosts/cursor.test.ts
@@ -305,6 +305,20 @@ describe("runCursorPreToolUseHook", () => {
     expect(output).toBe("");
   });
 
+  it("skips cd-prefixed commands that are already wrapped", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Shell",
+      tool_input: {
+        command: "cd /repo && tokenjuice wrap --raw -- git status",
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCursorPreToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
   it("falls back to SHELL when tool_input.shell is absent", async () => {
     const home = await createTempDir();
     const shellDir = join(home, "bin");


### PR DESCRIPTION
## Summary
Fix raw/full bypass detection for host-managed commands that are prefixed with `cd ... &&`.

Commands such as these are meant to be explicit escape hatches:

- `cd /repo && tokenjuice wrap --raw -- ...`
- `cd /repo && tokenjuice wrap --full -- ...`

Before this change, Codex/Claude/Cursor host hooks inspected the command before normalizing away the leading `cd` chain. That meant a user could intentionally request `--raw` or `--full`, but the host hook would fail to recognize the wrapped `tokenjuice` invocation and could compact the output again.

## Background
`tokenjuice wrap --raw` and `tokenjuice wrap --full` are important debugging and safety controls. They let a user bypass compaction when they need the exact command output, especially for large logs, query results, or cases where a reducer may hide important detail.

Agent hosts often execute shell commands from a target repository using a prefix like `cd /path/to/repo && ...`. The bypass detector needs to reason about the effective command after that prefix, not the literal shell string from the host payload.

## What changed
- Strip leading `cd ... &&` chains before checking for `tokenjuice wrap --raw` / `--full` in Codex and Claude post-tool hooks.
- Strip the same prefix before Cursor's "already wrapped" pre-tool check.
- Add regression tests for cd-prefixed wrapped commands across Codex, Claude Code, and Cursor.

## Why this matters
This keeps the raw/full escape hatch reliable in real host usage. Without it, a user may think they requested unmodified output while the hook silently re-compacts it, which makes truncation/debugging behavior much harder to reason about.

## Relationship to #40
This PR fixes host bypass recognition. #40 fixes stats accounting for capture-truncated artifacts. They are related because both improve truncation/debugging semantics, but they address separate root causes and touch separate behavior surfaces.

## Out of Scope
- Stats/truncation accounting changes; see #40.
- Truncation documentation updates.

## Test Plan
- `pnpm exec vitest run test/hosts/codex.test.ts test/hosts/claude-code.test.ts test/hosts/cursor.test.ts`

## Issue Links
- Refs #35 for the broader stats/truncation debugging context. This PR fixes the host raw/full bypass path, but does not close #35; #40 is the closing PR for that issue.
