### PR TITLE
fix(stats): separate capture truncation from compaction metrics

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -843,6 +843,8 @@ async function runStats(args: ParsedArgs): Promise<number> {
   }
 
   process.stdout.write(`entries: ${formatMetric(report.totals.entries)}\n`);
+  process.stdout.write(`capture-truncated entries: ${formatMetric(report.totals.captureTruncatedEntries)}\n`);
+  process.stdout.write(`observed entries: ${formatMetric(report.totals.observedEntries)}\n`);
   process.stdout.write(`raw chars: ${formatMetric(report.totals.rawChars)}\n`);
   process.stdout.write(`reduced chars: ${formatMetric(report.totals.reducedChars)}\n`);
   process.stdout.write(`saved chars: ${formatMetric(report.totals.savedChars)}\n`);

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -35,6 +35,13 @@ export type DoctorReport = {
 
 export type StatsReport = {
   totals: {
+    observedEntries: number;
+    captureTruncatedEntries: number;
+    observedRawChars: number;
+    observedReducedChars: number;
+    observedSavedChars: number;
+    observedAvgRatio: number | null;
+    observedSavingsPercent: number | null;
     entries: number;
     rawChars: number;
     reducedChars: number;
@@ -104,6 +111,7 @@ function effectiveRatio(metadata: StoredArtifactMetadata): number | null {
 }
 
 export function buildAnalysisEntry(input: ToolExecutionInput, result: CompactResult): AnalysisEntry {
+  const captureTruncated = input.metadata?.tokenjuiceCaptureTruncated;
   return {
     metadata: {
       createdAt: new Date().toISOString(),
@@ -114,6 +122,7 @@ export function buildAnalysisEntry(input: ToolExecutionInput, result: CompactRes
       ...(input.toolName ? { toolName: input.toolName } : {}),
       ...(input.command ? { command: input.command } : {}),
       ...(typeof input.exitCode === "number" ? { exitCode: input.exitCode } : {}),
+      ...(typeof captureTruncated === "boolean" ? { captureTruncated } : {}),
     },
   };
 }
@@ -246,12 +255,11 @@ type StatsGroup = {
   ratioCount: number;
 };
 
-function addToStatsGroup(group: StatsGroup | undefined, entry: AnalysisEntry): StatsGroup {
-  const ratio = effectiveRatio(entry.metadata);
+function addToStatsGroup(group: StatsGroup | undefined, rawChars: number, reducedChars: number, ratio: number | null): StatsGroup {
   return {
     count: (group?.count ?? 0) + 1,
-    rawChars: (group?.rawChars ?? 0) + entry.metadata.rawChars,
-    reducedChars: (group?.reducedChars ?? 0) + effectiveReducedChars(entry.metadata),
+    rawChars: (group?.rawChars ?? 0) + rawChars,
+    reducedChars: (group?.reducedChars ?? 0) + reducedChars,
     ratioSum: (group?.ratioSum ?? 0) + (ratio ?? 0),
     ratioCount: (group?.ratioCount ?? 0) + (ratio !== null ? 1 : 0),
   };
@@ -267,17 +275,35 @@ export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions =
   const daily = new Map<string, StatsGroup>();
   const formatDay = buildCalendarDayFormatter(options.timeZone);
 
+  let observedRawChars = 0;
+  let observedReducedChars = 0;
+  let observedRatioSum = 0;
+  let observedRatioCount = 0;
+  let captureTruncatedEntries = 0;
+
   let rawChars = 0;
   let reducedChars = 0;
   let ratioSum = 0;
   let ratioCount = 0;
 
   for (const entry of entries) {
+    const reduced = effectiveReducedChars(entry.metadata);
+    const ratio = effectiveRatio(entry.metadata);
+    observedRawChars += entry.metadata.rawChars;
+    observedReducedChars += reduced;
+    if (ratio !== null) {
+      observedRatioSum += ratio;
+      observedRatioCount += 1;
+    }
+
+    if (entry.metadata.captureTruncated) {
+      captureTruncatedEntries += 1;
+      continue;
+    }
+
     const reducer = entry.metadata.classification.matchedReducer ?? "generic/fallback";
     const signature = normalizeCommandSignature(entry.metadata.command) ?? "(unknown)";
     const day = formatDay(entry.metadata.createdAt);
-    const reduced = effectiveReducedChars(entry.metadata);
-    const ratio = effectiveRatio(entry.metadata);
 
     rawChars += entry.metadata.rawChars;
     reducedChars += reduced;
@@ -286,18 +312,28 @@ export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions =
       ratioCount += 1;
     }
 
-    reducers.set(reducer, addToStatsGroup(reducers.get(reducer), entry));
-    commands.set(signature, addToStatsGroup(commands.get(signature), entry));
-    daily.set(day, addToStatsGroup(daily.get(day), entry));
+    reducers.set(reducer, addToStatsGroup(reducers.get(reducer), entry.metadata.rawChars, reduced, ratio));
+    commands.set(signature, addToStatsGroup(commands.get(signature), entry.metadata.rawChars, reduced, ratio));
+    daily.set(day, addToStatsGroup(daily.get(day), entry.metadata.rawChars, reduced, ratio));
   }
 
   const totalSavedChars = Math.max(rawChars - reducedChars, 0);
   const avgRatio = ratioCount > 0 ? ratioSum / ratioCount : null;
   const savingsPercent = rawChars > 0 ? totalSavedChars / rawChars : null;
+  const observedSavedChars = Math.max(observedRawChars - observedReducedChars, 0);
+  const observedAvgRatio = observedRatioCount > 0 ? observedRatioSum / observedRatioCount : null;
+  const observedSavingsPercent = observedRawChars > 0 ? observedSavedChars / observedRawChars : null;
 
   return {
     totals: {
-      entries: entries.length,
+      observedEntries: entries.length,
+      captureTruncatedEntries,
+      observedRawChars,
+      observedReducedChars,
+      observedSavedChars,
+      observedAvgRatio,
+      observedSavingsPercent,
+      entries: entries.length - captureTruncatedEntries,
       rawChars,
       reducedChars,
       savedChars: totalSavedChars,

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -5,7 +5,7 @@ import { randomUUID } from "node:crypto";
 
 import { countTextChars, stripAnsi } from "./text.js";
 
-import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef } from "../types.js";
+import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
 
@@ -35,6 +35,9 @@ function isStoredArtifactMetadata(value: unknown): value is StoredArtifactMetada
   if ("exitCode" in value && value.exitCode !== undefined && typeof value.exitCode !== "number") {
     return false;
   }
+  if ("captureTruncated" in value && value.captureTruncated !== undefined && typeof value.captureTruncated !== "boolean") {
+    return false;
+  }
   if ("reducedChars" in value && value.reducedChars !== undefined && typeof value.reducedChars !== "number") {
     return false;
   }
@@ -43,6 +46,11 @@ function isStoredArtifactMetadata(value: unknown): value is StoredArtifactMetada
   }
 
   return true;
+}
+
+function extractCaptureTruncatedFlag(input: ToolExecutionInput): boolean | undefined {
+  const value = input.metadata?.tokenjuiceCaptureTruncated;
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function artifactBaseDir(storeDir?: string): string {
@@ -78,6 +86,7 @@ export async function storeArtifact(input: StoredArtifactInput, storeDir?: strin
   const id = `tj_${randomUUID().slice(0, 12)}`;
   const ref = buildArtifactPaths(id, storeDir);
   await mkdir(artifactBaseDir(storeDir), { recursive: true, mode: 0o700 });
+  const captureTruncated = extractCaptureTruncatedFlag(input.input);
 
   const artifact: StoredArtifact = {
     id,
@@ -89,6 +98,7 @@ export async function storeArtifact(input: StoredArtifactInput, storeDir?: strin
       ...(input.input.toolName ? { toolName: input.input.toolName } : {}),
       ...(input.input.command ? { command: input.input.command } : {}),
       ...(typeof input.input.exitCode === "number" ? { exitCode: input.input.exitCode } : {}),
+      ...(captureTruncated !== undefined ? { captureTruncated } : {}),
       ...(input.stats ? { reducedChars: input.stats.reducedChars, ratio: input.stats.ratio } : {}),
     },
   };
@@ -104,6 +114,7 @@ export async function storeArtifact(input: StoredArtifactInput, storeDir?: strin
 export async function storeArtifactMetadata(input: StoredArtifactInput, storeDir?: string): Promise<ArtifactMetadataRef> {
   const id = `tj_${randomUUID().slice(0, 12)}`;
   const metadataPath = buildMetadataOnlyPath(id, storeDir);
+  const captureTruncated = extractCaptureTruncatedFlag(input.input);
   const metadata: StoredArtifactMetadata = {
     createdAt: new Date().toISOString(),
     classification: input.classification,
@@ -111,6 +122,7 @@ export async function storeArtifactMetadata(input: StoredArtifactInput, storeDir
     ...(input.input.toolName ? { toolName: input.input.toolName } : {}),
     ...(input.input.command ? { command: input.input.command } : {}),
     ...(typeof input.input.exitCode === "number" ? { exitCode: input.input.exitCode } : {}),
+    ...(captureTruncated !== undefined ? { captureTruncated } : {}),
     ...(input.stats ? { reducedChars: input.stats.reducedChars, ratio: input.stats.ratio } : {}),
   };
 

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -101,6 +101,9 @@ export async function runWrappedCommand(argv: string[], opts: WrapOptions = {}):
             stderr: stderr.text,
             combinedText: combined.text,
             exitCode: code ?? 1,
+            metadata: {
+              tokenjuiceCaptureTruncated: combined.truncated,
+            },
           },
           {
             raw: opts.raw ?? false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export type StoredArtifactMetadata = {
   toolName?: string;
   command?: string;
   exitCode?: number;
+  captureTruncated?: boolean;
   classification: ClassificationResult;
   rawChars: number;
   reducedChars?: number;

--- a/test/core/analysis.test.ts
+++ b/test/core/analysis.test.ts
@@ -131,6 +131,49 @@ describe("analysis", () => {
     expect(report.daily.length).toBe(1);
   });
 
+  it("excludes capture-truncated entries from compaction totals", () => {
+    const report = statsArtifacts([
+      {
+        metadata: {
+          createdAt: "2026-04-23T00:00:00.000Z",
+          command: "python query_cls_log.py",
+          classification: {
+            family: "generic",
+            confidence: 1,
+            matchedReducer: "generic/fallback",
+          },
+          rawChars: 1000,
+          reducedChars: 100,
+          ratio: 0.1,
+          captureTruncated: true,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-04-23T00:01:00.000Z",
+          command: "rg TODO src",
+          classification: {
+            family: "search",
+            confidence: 1,
+            matchedReducer: "search/rg",
+          },
+          rawChars: 200,
+          reducedChars: 50,
+          ratio: 0.25,
+        },
+      },
+    ]);
+
+    expect(report.totals.observedEntries).toBe(2);
+    expect(report.totals.captureTruncatedEntries).toBe(1);
+    expect(report.totals.entries).toBe(1);
+    expect(report.totals.rawChars).toBe(200);
+    expect(report.totals.reducedChars).toBe(50);
+    expect(report.totals.savedChars).toBe(150);
+    expect(report.commands[0]?.signature).toBe("rg");
+    expect(report.reducers.some((entry) => entry.reducer === "generic/fallback")).toBe(false);
+  });
+
   it("buckets daily stats by the requested timezone", () => {
     const entries = [
       {

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { listArtifacts, runWrappedCommand } from "../../src/index.js";
+import { listArtifactMetadata, listArtifacts, runWrappedCommand } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -58,6 +58,24 @@ describe("runWrappedCommand", () => {
     expect(wrapped.stdout.length).toBeLessThan(300);
     expect(wrapped.stdout).toContain("[tokenjuice: output truncated]");
     expect(wrapped.result.inlineText).toContain("[tokenjuice: output truncated]");
+  });
+
+  it("records capture truncation state in stored metadata", async () => {
+    const storeDir = await createTempDir();
+
+    await runWrappedCommand([
+      "node",
+      "-e",
+      "process.stdout.write('a'.repeat(2000));",
+    ], {
+      maxCaptureBytes: 128,
+      store: true,
+      storeDir,
+    });
+
+    const metadata = await listArtifactMetadata(storeDir);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.metadata.captureTruncated).toBe(true);
   });
 
   it("supports a raw bypass for wrapped commands", async () => {


### PR DESCRIPTION
Closes #35

## Summary
Separate wrap capture truncation from reducer compaction metrics so `tokenjuice stats` reflects real compression savings instead of capture ceilings.

## Background
`tokenjuice` can reduce command output in two very different ways:

1. **Reducer compaction**: tokenjuice analyzes the captured output and produces a shorter, more useful summary. This is the behavior `stats` should measure as compression savings.
2. **Capture truncation**: `tokenjuice wrap --max-capture-bytes` stops collecting output after a byte limit. This protects memory usage and keeps artifacts bounded, but it is not reducer compression.

Before this change, `stats` mixed those two effects together. If a large log query was cut off during capture, the resulting artifact could still be counted alongside normal reducer-compacted artifacts. That made saved-character totals, top reducers, and top commands look better or more important than they really were.

## Why this matters
For large log-search or log-query workflows, capture-truncated entries can dominate the totals. When that happens, `tokenjuice stats` no longer answers the question users care about: "How much are reducers actually helping?"

By separating capture-truncated entries from compaction-only aggregates, stats become useful for evaluating reducer effectiveness, spotting weak rules, and understanding real token savings without confusing them with capture limits.

## What changed
- Mark capture-truncated runs in artifact metadata with `captureTruncated`.
- Set that metadata from the `wrap` capture pipeline.
- Exclude capture-truncated entries from compaction-only totals in `statsArtifacts`.
- Keep observed totals alongside compaction-only totals so users can still see the full captured population.
- Show `capture-truncated entries` and `observed entries` in `tokenjuice stats` text output.
- Add regression tests for mixed truncated/non-truncated aggregation and metadata persistence.

## Relationship to #39
#39 fixes whether host integrations correctly honor explicit `tokenjuice wrap --raw` / `--full` bypass commands when they are prefixed with `cd ... &&`. This PR fixes how stored artifacts are counted once capture truncation has happened. They are related, but they address separate root causes.

## Out of Scope
- Host bypass behavior for `cd ... && tokenjuice wrap --raw`; see #39.
- Truncation documentation updates.

## Test Plan
- `pnpm exec vitest run test/core/analysis.test.ts test/core/wrap.test.ts`
- `pnpm typecheck`