### PR TITLE
docs: clarify truncation model and debugging guidance

### DIFF
--- a/docs/integration-playbook.md
+++ b/docs/integration-playbook.md
@@ -119,6 +119,12 @@ verify:
 node dist/cli/main.js wrap --format json --trace --raw -- <command>
 ```
 
+for truncation-related debugging, verify both boundaries explicitly:
+
+- reducer truncation: if output includes `... omitted ...` / `... lines omitted ...`, rerun with `--raw` first.
+- capture truncation: if output includes `[tokenjuice: output truncated]`, rerun with a larger capture ceiling (for example `--max-capture-bytes 52428800`).
+- do not treat these as the same failure mode; reducer bypass and capture-size tuning solve different problems.
+
 ## docs updates required in same PR
 
 when adding a host integration, update:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -122,6 +122,14 @@ that checks:
 - preserve failure detail more than success noise
 - use project overrides for local weirdness, not built-ins
 
+## fallback expectations
+
+`generic/fallback` is intentionally deterministic and lossy. it is a safety net, not a high-quality summarizer.
+
+- omitted middle sections are expected behavior under fallback head/tail retention.
+- if a command family regularly needs middle-body details, add a specific reducer instead of complicating fallback.
+- use `tokenjuice wrap --raw -- <command>` when a one-off run needs full reducer bypass.
+
 ## repository inventory reducers
 
 built-in filesystem inventory reducers cover:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -26,6 +26,21 @@ the package reduces observed output after execution, can store raw output as a l
 - becoming a shell framework
 - trying to solve every tool class in one release
 
+## truncation model
+
+tokenjuice intentionally uses deterministic truncation as a default strategy for prompt-facing output. this is a cost/clarity tradeoff, not an error path.
+
+there are two independent boundaries:
+
+- reducer boundary: rule summaries (especially `generic/fallback`) keep head/tail slices and may omit middle sections.
+- capture boundary: `tokenjuice wrap` enforces `--max-capture-bytes` (default `4mb`) to avoid unbounded memory growth while collecting tool output.
+
+important implications:
+
+- `--raw` is the explicit escape hatch for reducer compaction.
+- `--raw` does not bypass capture limits; increase `--max-capture-bytes` when full capture is required.
+- frequent `generic/fallback` matches on a command family are a reducer-coverage signal, not a reason to make fallback "smarter".
+
 ## architecture
 
 ### core package


### PR DESCRIPTION
## Summary
Document tokenjuice truncation behavior more explicitly for maintainers.

## What changed
- `docs/spec.md`: add a dedicated truncation model section.
- `docs/rules.md`: clarify `generic/fallback` is intentionally deterministic/lossy.
- `docs/integration-playbook.md`: add truncation debugging guidance (`omitted` vs capture truncation).

## Out of Scope
- host behavior changes
- stats accounting changes
