### PR TITLE
fix(codex): preserve code inspection output and hook history

### DIFF
--- a/src/core/command-identity.ts
+++ b/src/core/command-identity.ts
@@ -3,7 +3,7 @@ import { basename } from "node:path";
 import type { ToolExecutionInput } from "../types.js";
 
 import { deriveCommandMatchCandidates, getSourcePriority, type CommandMatchCandidate } from "./command-match.js";
-import { tokenizeCommand } from "./command-shell.js";
+import { stripLeadingCdPrefix, tokenizeCommand } from "./command-shell.js";
 
 const FILE_CONTENT_INSPECTION_COMMANDS = new Set(["cat", "sed", "head", "tail", "nl", "bat", "batcat", "jq", "yq"]);
 const REPO_INVENTORY_COMMANDS = new Set(["find", "fd", "fdfind", "ls", "tree"]);
@@ -76,12 +76,71 @@ export function getGitSubcommand(argv: string[]): string | null {
   return null;
 }
 
+function getGitSubcommandIndex(argv: string[]): number | null {
+  if (getCommandName(argv) !== "git") {
+    return null;
+  }
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (gitGlobalOptionTakesValue(arg)) {
+      index += 1;
+      continue;
+    }
+
+    if (isGitGlobalOptionWithInlineValue(arg)) {
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      continue;
+    }
+
+    return index;
+  }
+
+  return null;
+}
+
+function isGitBlobSpecifier(arg: string): boolean {
+  return /^[^:]+:.+/u.test(arg);
+}
+
+function isGitShowFileContentArgv(argv: string[]): boolean {
+  const subcommandIndex = getGitSubcommandIndex(argv);
+  if (subcommandIndex === null || argv[subcommandIndex] !== "show") {
+    return false;
+  }
+
+  for (let index = subcommandIndex + 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+    if (arg === "--") {
+      return false;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    if (isGitBlobSpecifier(arg)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function isFileContentInspectionArgv(argv: string[]): boolean {
   const argv0 = getCommandName(argv);
   if (!argv0) {
     return false;
   }
-  return FILE_CONTENT_INSPECTION_COMMANDS.has(argv0);
+  return FILE_CONTENT_INSPECTION_COMMANDS.has(argv0) || isGitShowFileContentArgv(argv);
 }
 
 export function isRepositoryInspectionArgv(argv: string[]): boolean {
@@ -110,8 +169,65 @@ function getMostDerivedCandidate(input: Pick<ToolExecutionInput, "argv" | "comma
   ));
 }
 
+function extractPipelineSourceCommand(command: string): string {
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      current += char;
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      current += char;
+      quote = char;
+      continue;
+    }
+
+    if (char === "|" && command[index + 1] !== "|") {
+      break;
+    }
+
+    current += char;
+  }
+
+  return current.trim();
+}
+
+function getInspectionArgv(input: Pick<ToolExecutionInput, "argv" | "command">): string[] {
+  const candidate = getMostDerivedCandidate(input);
+  if (candidate.argv.length > 0) {
+    return candidate.argv;
+  }
+  if (typeof input.command !== "string") {
+    return [];
+  }
+
+  const sourceCommand = extractPipelineSourceCommand(stripLeadingCdPrefix(input.command));
+  return sourceCommand ? tokenizeCommand(sourceCommand) : [];
+}
+
 export function isFileContentInspectionCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {
-  return isFileContentInspectionArgv(getMostDerivedCandidate(input).argv);
+  return isFileContentInspectionArgv(getInspectionArgv(input));
 }
 
 export function isRepositoryInspectionCommand(input: Pick<ToolExecutionInput, "argv" | "command">): boolean {

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { access, mkdir, readFile, readdir, realpath, rename, stat, writeFile } from "node:fs/promises";
+import { access, appendFile, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
@@ -47,6 +47,9 @@ const HOOK_REWRITE_MIN_SAVED_CHARS = 8;
 const CODEX_HOOK_LAST_LOG = "tokenjuice-hook.last.json";
 const CODEX_HOOK_HISTORY_LOG = "tokenjuice-hook.history.jsonl";
 const CODEX_HOOK_HISTORY_LIMIT = 200;
+const CODEX_HOOK_HISTORY_LOCK_STALE_MS = 30_000;
+const CODEX_HOOK_HISTORY_LOCK_RETRY_MS = 25;
+const CODEX_HOOK_HISTORY_LOCK_RETRIES = 8;
 const LOW_NON_TOKENJUICE_TIMEOUT_SECONDS = 2;
 const RECOMMENDED_NON_TOKENJUICE_TIMEOUT_SECONDS = 6;
 
@@ -801,24 +804,96 @@ async function writeHookDebug(record: Record<string, unknown>): Promise<void> {
   await mkdir(dirname(debugPath), { recursive: true });
   await writeFile(debugPath, `${JSON.stringify(enrichedRecord, null, 2)}\n`, "utf8");
 
-  let historyLines: string[] = [];
-  try {
-    const currentHistory = await readFile(historyPath, "utf8");
-    historyLines = currentHistory
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
-  } catch (error) {
-    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
-      throw error;
+  await writeHookHistoryEntry(historyPath, JSON.stringify(enrichedRecord));
+}
+
+function sanitizeHookHistoryLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => {
+      try {
+        JSON.parse(line);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, ms);
+  });
+}
+
+async function acquireHistoryLock(lockPath: string): Promise<boolean> {
+  for (let attempt = 0; attempt <= CODEX_HOOK_HISTORY_LOCK_RETRIES; attempt += 1) {
+    try {
+      await mkdir(lockPath);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        throw error;
+      }
+
+      try {
+        const details = await stat(lockPath);
+        if (Date.now() - details.mtimeMs > CODEX_HOOK_HISTORY_LOCK_STALE_MS) {
+          await rm(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statError) {
+        const statCode = (statError as NodeJS.ErrnoException).code;
+        if (statCode !== "ENOENT") {
+          throw statError;
+        }
+        continue;
+      }
+
+      if (attempt < CODEX_HOOK_HISTORY_LOCK_RETRIES) {
+        await wait(CODEX_HOOK_HISTORY_LOCK_RETRY_MS);
+      }
     }
   }
 
-  historyLines.push(JSON.stringify(enrichedRecord));
-  if (historyLines.length > CODEX_HOOK_HISTORY_LIMIT) {
-    historyLines = historyLines.slice(-CODEX_HOOK_HISTORY_LIMIT);
+  return false;
+}
+
+async function writeHookHistoryEntry(historyPath: string, line: string): Promise<void> {
+  const lockPath = `${historyPath}.lock`;
+  const tempPath = `${historyPath}.${process.pid}.tmp`;
+  const hasLock = await acquireHistoryLock(lockPath);
+
+  if (!hasLock) {
+    await appendFile(historyPath, `${line}\n`, "utf8");
+    return;
   }
-  await writeFile(historyPath, `${historyLines.join("\n")}\n`, "utf8");
+
+  try {
+    let historyLines: string[] = [];
+    try {
+      historyLines = sanitizeHookHistoryLines(await readFile(historyPath, "utf8"));
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    historyLines.push(line);
+    if (historyLines.length > CODEX_HOOK_HISTORY_LIMIT) {
+      historyLines = historyLines.slice(-CODEX_HOOK_HISTORY_LIMIT);
+    }
+
+    await writeFile(tempPath, `${historyLines.join("\n")}\n`, "utf8");
+    await rename(tempPath, historyPath);
+  } finally {
+    await rm(tempPath, { force: true }).catch(() => {});
+    await rm(lockPath, { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 function buildImmediateSkipStats(text: string): {

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -253,6 +253,8 @@ describe("isFileContentInspectionCommand", () => {
     { label: "bat", command: "bat README.md" },
     { label: "jq", command: "jq '.version' package.json" },
     { label: "yq", command: "yq '.name' pnpm-workspace.yaml" },
+    { label: "git show blob", command: "git show HEAD:README.md" },
+    { label: "git show blob piped to sed", command: "git show HEAD:README.md | sed -n '1,40p'" },
     { label: "wrapped cat", command: "cd repo && cat README.md" },
     { label: "clustered shell wrapper", command: "bash -ec 'cat README.md'" },
   ])("detects $label as file inspection from command text", ({ command }) => {
@@ -265,6 +267,10 @@ describe("isFileContentInspectionCommand", () => {
 
   it("returns false for normal search commands", () => {
     expect(isFileContentInspectionCommand({ command: "rg AssertionError src" })).toBe(false);
+  });
+
+  it("does not treat git show commit summaries as file inspection", () => {
+    expect(isFileContentInspectionCommand({ command: "git show HEAD --stat" })).toBe(false);
   });
 });
 

--- a/test/core/inventory-safety.test.ts
+++ b/test/core/inventory-safety.test.ts
@@ -126,6 +126,7 @@ describe("getInspectionCommandSkipReason", () => {
   it.each([
     { command: "cat README.md", reason: "file-content-inspection-command" },
     { command: "cd /repo && cat README.md", reason: "file-content-inspection-command" },
+    { command: "git show HEAD:README.md | sed -n '1,40p'", reason: "file-content-inspection-command" },
     { command: "tree src", reason: "inspection-command" },
     { command: "ls src && rg TODO src", reason: "sequential-inventory-command" },
     { command: "git -C repo ls-files | jq -R .", reason: "unsafe-inventory-pipeline" },

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -658,6 +658,43 @@ describe("runCodexPostToolUseHook", () => {
     expect(debug.ratio).toBe(1);
   });
 
+  it("skips auto-rewrite for git blob inspections piped through line filters", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git show HEAD:src/core/reduce.ts | sed -n '1,40p'",
+      },
+      tool_response: [
+        "import { loadRules } from \"./rules.js\";",
+        "throw new AssertionError();",
+        "export function reduceExecution() {}",
+      ].join("\n"),
+    });
+
+    const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+      matchedReducer?: string;
+      rawChars?: number;
+      reducedChars?: number;
+    };
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("file-content-inspection-command");
+    expect(debug.matchedReducer).toBeUndefined();
+    expect(debug.rawChars).toBeGreaterThan(0);
+    expect(debug.reducedChars).toBe(debug.rawChars);
+    expect(debug.savedChars).toBe(0);
+    expect(debug.ratio).toBe(1);
+  });
+
   it("keeps unsafe inventory pipelines unmodified", async () => {
     const home = await createTempDir();
     process.env.CODEX_HOME = home;
@@ -861,5 +898,49 @@ describe("runCodexPostToolUseHook", () => {
     expect(history[1]?.rewrote).toBe(false);
     expect(history[1]?.skipped).toBe("low-savings-compaction");
     expect(history[1]?.savedChars).toBe(1);
+  });
+
+  it("repairs malformed hook history lines before appending a new entry", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const validHistoryLine = JSON.stringify({
+      timestamp: "2026-04-23T00:00:00.000Z",
+      command: "git status --short",
+      rewrote: false,
+    });
+    await writeFile(
+      join(home, "tokenjuice-hook.history.jsonl"),
+      `${validHistoryLine}\nnot-json\n{"truncated":true\n`,
+      "utf8",
+    );
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "sed -n '1,40p' src/hosts/codex/index.ts",
+      },
+      tool_response: [
+        "function example() {",
+        "  throw new AssertionError();",
+        "}",
+      ].join("\n"),
+    });
+
+    await captureStdout(() => runCodexPostToolUseHook(payload));
+
+    const historyLines = (await readFile(join(home, "tokenjuice-hook.history.jsonl"), "utf8"))
+      .trim()
+      .split("\n");
+    const history = historyLines.map((line) => JSON.parse(line) as {
+      command?: string;
+      skipped?: string;
+    });
+
+    expect(history).toHaveLength(2);
+    expect(history[0]?.command).toBe("git status --short");
+    expect(history[1]?.command).toBe("sed -n '1,40p' src/hosts/codex/index.ts");
+    expect(history[1]?.skipped).toBe("file-content-inspection-command");
   });
 });


### PR DESCRIPTION
## Summary
- treat `git show <ref>:<path>` and piped line-filter variants as file-content inspection so the Codex hook leaves code reads alone
- make the Codex hook history writer resilient to concurrent hook writes and clean up malformed existing JSONL lines
- add regression coverage for the new inspection path and history repair behavior

## Test Plan
- `node node_modules/.pnpm/vitest@3.2.4_@types+node@24.12.2/node_modules/vitest/vitest.mjs run test/core/command.test.ts test/core/inventory-safety.test.ts test/hosts/codex.test.ts --reporter=dot`
- `node scripts/generate-builtin-rules.mjs`
- `node node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/tsc.js -p tsconfig.json --noEmit`