### PR TITLE
fix(dev): repair broken local pnpm bin shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "bench:verify": "node scripts/bench.mjs verify",
     "contracts": "publint run --strict --pack pnpm",
     "generate:builtin-rules": "node scripts/generate-builtin-rules.mjs",
+    "prepare": "pnpm repair:pnpm-bin-shims",
+    "repair:pnpm-bin-shims": "node scripts/repair-pnpm-bin-shims.mjs",
     "build": "rm -rf dist && pnpm generate:builtin-rules && tsc -p tsconfig.json && node scripts/build-pi-runtime.mjs && mkdir -p dist/rules && cp -R src/rules/. dist/rules/",
     "lint": "oxlint --deny-warnings src test scripts",
     "lint:circular": "madge --circular --extensions ts,mjs --ts-config tsconfig.json src",

--- a/scripts/repair-pnpm-bin-shims.mjs
+++ b/scripts/repair-pnpm-bin-shims.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const POSIX_SHIM_SUFFIX_PATTERN = /node_modules\/\.pnpm\/[^"\n]+/u;
+const POSIX_BASEDIR_TARGET_PATTERN = /\$basedir\/([^"\n]*node_modules\/\.pnpm\/[^"\n]+)"/gu;
+
+function normalizeRelativePath(path) {
+  return path.split(sep).join("/");
+}
+
+export function repairPosixShimText({ text, shimPath, projectRoot, targetExists }) {
+  const basedir = dirname(shimPath);
+  let nextText = text;
+  let changed = false;
+  const seenTargets = new Set();
+
+  for (const match of text.matchAll(POSIX_BASEDIR_TARGET_PATTERN)) {
+    const brokenRelativeTarget = match[1];
+    if (!brokenRelativeTarget || seenTargets.has(brokenRelativeTarget)) {
+      continue;
+    }
+    seenTargets.add(brokenRelativeTarget);
+
+    const resolvedBrokenTarget = resolve(basedir, brokenRelativeTarget);
+    if (targetExists(resolvedBrokenTarget)) {
+      continue;
+    }
+
+    const suffixMatch = brokenRelativeTarget.match(POSIX_SHIM_SUFFIX_PATTERN);
+    if (!suffixMatch) {
+      continue;
+    }
+
+    const fixedTarget = resolve(projectRoot, suffixMatch[0]);
+    if (!targetExists(fixedTarget)) {
+      continue;
+    }
+
+    const fixedRelativeTarget = normalizeRelativePath(relative(basedir, fixedTarget));
+    nextText = nextText.replaceAll(`$basedir/${brokenRelativeTarget}`, `$basedir/${fixedRelativeTarget}`);
+    changed = true;
+  }
+
+  return {
+    changed,
+    text: nextText,
+  };
+}
+
+export async function repairPnpmBinShims({
+  projectRoot = fileURLToPath(new URL("..", import.meta.url)),
+} = {}) {
+  const binDir = join(projectRoot, "node_modules", ".bin");
+  let entries;
+  try {
+    entries = await readdir(binDir, { withFileTypes: true });
+  } catch (error) {
+    const code = error?.code;
+    if (code === "ENOENT") {
+      return { repaired: [] };
+    }
+    throw error;
+  }
+
+  const repaired = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (entry.name.endsWith(".cmd") || entry.name.endsWith(".ps1")) {
+      continue;
+    }
+
+    const shimPath = join(binDir, entry.name);
+    const text = await readFile(shimPath, "utf8");
+    const result = repairPosixShimText({
+      text,
+      shimPath,
+      projectRoot,
+      targetExists: (path) => existsSync(path),
+    });
+
+    if (!result.changed) {
+      continue;
+    }
+
+    await writeFile(shimPath, result.text, "utf8");
+    repaired.push(entry.name);
+  }
+
+  return { repaired };
+}
+
+async function main() {
+  const result = await repairPnpmBinShims();
+  if (result.repaired.length > 0) {
+    console.log(`repaired broken pnpm .bin shims: ${result.repaired.join(", ")}`);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/test/scripts/repair-pnpm-bin-shims.test.ts
+++ b/test/scripts/repair-pnpm-bin-shims.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { repairPosixShimText } from "../../scripts/repair-pnpm-bin-shims.mjs";
+
+describe("repairPosixShimText", () => {
+  it("repairs broken pnpm relative targets back to the local virtual store", () => {
+    const shimPath = "/Users/vincentkoc/GIT/_Perso/tokenjuice/node_modules/.bin/vitest";
+    const projectRoot = "/Users/vincentkoc/GIT/_Perso/tokenjuice";
+    const brokenText = `#!/bin/sh
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../../../../../../GIT/_Perso/tokenjuice/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs" "$@"
+else
+  exec node  "$basedir/../../../../../../GIT/_Perso/tokenjuice/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs" "$@"
+fi
+`;
+
+    const result = repairPosixShimText({
+      text: brokenText,
+      shimPath,
+      projectRoot,
+      targetExists: (path) => path === "/Users/vincentkoc/GIT/_Perso/tokenjuice/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain(`"$basedir/../.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs"`);
+    expect(result.text).not.toContain("../../../../../../GIT/_Perso/tokenjuice");
+  });
+
+  it("leaves healthy pnpm shims untouched", () => {
+    const shimPath = "/Users/vincentkoc/GIT/_Perso/tokenjuice/node_modules/.bin/vitest";
+    const projectRoot = "/Users/vincentkoc/GIT/_Perso/tokenjuice";
+    const healthyText = `#!/bin/sh
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs" "$@"
+else
+  exec node  "$basedir/../.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs" "$@"
+fi
+`;
+
+    const result = repairPosixShimText({
+      text: healthyText,
+      shimPath,
+      projectRoot,
+      targetExists: (path) => path === "/Users/vincentkoc/GIT/_Perso/tokenjuice/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest/vitest.mjs",
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe(healthyText);
+  });
+
+  it("ignores shims when the target cannot be mapped back into the local virtual store", () => {
+    const shimPath = "/Users/vincentkoc/GIT/_Perso/tokenjuice/node_modules/.bin/custom";
+    const projectRoot = "/Users/vincentkoc/GIT/_Perso/tokenjuice";
+    const brokenText = `#!/bin/sh
+exec node "$basedir/../../../../../../GIT/_Perso/tokenjuice/node_modules/.pnpm/custom@1.0.0/node_modules/custom/bin.js" "$@"
+`;
+
+    const result = repairPosixShimText({
+      text: brokenText,
+      shimPath,
+      projectRoot,
+      targetExists: () => false,
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe(brokenText);
+  });
+});


### PR DESCRIPTION
## Summary
- add a small repair script that fixes broken local `node_modules/.bin` pnpm shims when they resolve outside the repo
- run that repair automatically from `prepare`, and expose it as `pnpm repair:pnpm-bin-shims`
- cover the repair logic with focused tests

## Test Plan
- `pnpm exec vitest --version`
- `pnpm typecheck`
- `pnpm exec vitest run test/scripts/repair-pnpm-bin-shims.test.ts test/core/command.test.ts test/core/inventory-safety.test.ts test/hosts/codex.test.ts --reporter=dot`
- `pnpm repair:pnpm-bin-shims`
- `pnpm prepare`