### PR TITLE
fix(claude-code): avoid blocking compaction context

### DIFF
--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -404,6 +404,10 @@ function buildClaudeCodeHint(rawRefId?: string): string {
   return hints.join(" ");
 }
 
+function buildClaudeCodeAdditionalContext(inlineText: string, rawRefId?: string): string {
+  return `${inlineText}\n\n${buildClaudeCodeHint(rawRefId)}`;
+}
+
 async function writeHookDebug(record: Record<string, unknown>): Promise<void> {
   const debugPath = join(getClaudeCodeHome(), "tokenjuice-hook.last.json");
   await mkdir(dirname(debugPath), { recursive: true });
@@ -482,11 +486,13 @@ export async function runClaudeCodePostToolUseHook(rawText: string): Promise<num
     }
 
     const hookOutput: Record<string, unknown> = {
-      decision: "block",
-      reason: outcome.result.inlineText,
+      suppressOutput: true,
       hookSpecificOutput: {
         hookEventName: "PostToolUse",
-        additionalContext: buildClaudeCodeHint(outcome.result.rawRef?.id),
+        additionalContext: buildClaudeCodeAdditionalContext(
+          outcome.result.inlineText,
+          outcome.result.rawRef?.id,
+        ),
       },
     };
 

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -537,7 +537,7 @@ describe("doctorInstalledHooks", () => {
 });
 
 describe("runClaudeCodePostToolUseHook", () => {
-  it("writes a block/reason decision on compactable bash output", async () => {
+  it("adds compacted bash output as context without a block decision", async () => {
     const home = await createTempDir();
     process.env.CLAUDE_HOME = home;
 
@@ -562,8 +562,9 @@ describe("runClaudeCodePostToolUseHook", () => {
 
     const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
     const response = JSON.parse(output) as {
-      decision: string;
-      reason: string;
+      decision?: string;
+      reason?: string;
+      suppressOutput?: boolean;
       hookSpecificOutput?: { additionalContext?: string };
     };
     const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
@@ -572,10 +573,12 @@ describe("runClaudeCodePostToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.decision).toBe("block");
-    expect(response.reason).toContain("Changes not staged:");
-    expect(response.reason).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
-    expect(response.reason).not.toContain("and have 8 and 642");
+    expect(response).not.toHaveProperty("decision");
+    expect(response).not.toHaveProperty("reason");
+    expect(response.suppressOutput).toBe(true);
+    expect(response.hookSpecificOutput?.additionalContext).toContain("Changes not staged:");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
+    expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
     expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
     expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --full -- <command>");
     expect(debug.rewrote).toBe(true);
@@ -622,8 +625,9 @@ describe("runClaudeCodePostToolUseHook", () => {
 
     const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
     const response = JSON.parse(output) as {
-      decision: string;
-      reason: string;
+      decision?: string;
+      reason?: string;
+      hookSpecificOutput?: { additionalContext?: string };
     };
     const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
       rewrote: boolean;
@@ -631,8 +635,9 @@ describe("runClaudeCodePostToolUseHook", () => {
     };
 
     expect(code).toBe(0);
-    expect(response.decision).toBe("block");
-    expect(response.reason).toContain("30 paths");
+    expect(response).not.toHaveProperty("decision");
+    expect(response).not.toHaveProperty("reason");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("30 paths");
     expect(debug.rewrote).toBe(true);
     expect(debug.matchedReducer).toBe("filesystem/rg-files");
   });


### PR DESCRIPTION
## Summary
- send Claude Code compacted bash output through `PostToolUse.additionalContext` instead of `decision: "block"`
- keep the raw/full rerun hint attached to the same additional context payload
- update Claude Code host tests to assert no block decision is emitted

## Root cause
Claude Code records `decision: "block"` PostToolUse responses as `hook_blocking_error` entries. tokenjuice was using that channel for successful compaction, so normal summaries looked like hook errors in Claude logs.

## Validation
- `pnpm exec vitest run test/hosts/claude-code.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `git diff --check`