### PR TITLE
fix(stats): improve timezone validation errors

### DIFF
--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -14,8 +14,56 @@ function formatUtcDay(date: Date): string {
   return `${date.getUTCFullYear()}-${padTwo(date.getUTCMonth() + 1)}-${padTwo(date.getUTCDate())}`;
 }
 
+let supportedTimeZoneByLowerCase: Map<string, string> | undefined;
+
+function canonicalizeTimeZone(timeZone: string): string | undefined {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone }).resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+function getSupportedTimeZoneByLowerCase(): Map<string, string> {
+  if (supportedTimeZoneByLowerCase) {
+    return supportedTimeZoneByLowerCase;
+  }
+
+  const zones = typeof Intl.supportedValuesOf === "function"
+    ? Intl.supportedValuesOf("timeZone")
+    : [];
+  supportedTimeZoneByLowerCase = new Map(zones.map((zone) => [zone.toLowerCase(), zone]));
+  return supportedTimeZoneByLowerCase;
+}
+
+export function normalizeTimeZone(timeZone = "utc"): string {
+  const trimmed = timeZone.trim();
+  if (!trimmed) {
+    return "utc";
+  }
+
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "local" || normalized === "utc") {
+    return normalized;
+  }
+
+  const canonical = canonicalizeTimeZone(trimmed);
+  if (canonical) {
+    return canonical;
+  }
+
+  const supported = getSupportedTimeZoneByLowerCase().get(normalized);
+  if (supported) {
+    return supported;
+  }
+
+  throw new Error(
+    `invalid timezone: ${timeZone}. Expected "local", "utc", or an IANA time zone such as "Asia/Shanghai" or "America/New_York".`,
+  );
+}
+
 export function buildCalendarDayFormatter(timeZone = "utc"): (createdAt: string) => string {
-  const normalizedTimeZone = timeZone.toLowerCase();
+  const normalizedTimeZone = normalizeTimeZone(timeZone);
 
   if (normalizedTimeZone === "local") {
     return (createdAt) => {
@@ -32,7 +80,7 @@ export function buildCalendarDayFormatter(timeZone = "utc"): (createdAt: string)
   }
 
   const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
+    timeZone: normalizedTimeZone,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",

--- a/test/core/time.test.ts
+++ b/test/core/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCalendarDayFormatter } from "../../src/core/time.js";
+import { buildCalendarDayFormatter, normalizeTimeZone } from "../../src/core/time.js";
 
 describe("time helpers", () => {
   it("formats calendar days in utc and explicit timezones", () => {
@@ -9,6 +9,19 @@ describe("time helpers", () => {
     expect(buildCalendarDayFormatter("utc")(createdAt)).toBe("2026-04-20");
     expect(buildCalendarDayFormatter("UTC")(createdAt)).toBe("2026-04-20");
     expect(buildCalendarDayFormatter("America/New_York")(createdAt)).toBe("2026-04-19");
+    expect(buildCalendarDayFormatter("america/new_york")(createdAt)).toBe("2026-04-19");
+  });
+
+  it("normalizes valid timezones before formatting", () => {
+    expect(normalizeTimeZone("america/new_york")).toBe("America/New_York");
+    expect(normalizeTimeZone("US/Eastern")).toBe("America/New_York");
+    expect(normalizeTimeZone("  ")).toBe("utc");
+  });
+
+  it("reports invalid timezones with an actionable message", () => {
+    expect(() => buildCalendarDayFormatter("Asia/Beijing")).toThrow(
+      'invalid timezone: Asia/Beijing. Expected "local", "utc", or an IANA time zone such as "Asia/Shanghai" or "America/New_York".',
+    );
   });
 
   it("preserves the stored iso day when timestamps are malformed", () => {


### PR DESCRIPTION
## Summary

This came up while debugging why today's `tokenjuice stats` output did not make a recent CodeBuddy + `gh api` run obvious. During that check, I tried to make the daily stats bucket explicit with:

```bash
tokenjuice stats --timezone Asia/Beijing
```

That failed with Node's raw Intl error:

```text
Invalid time zone specified: Asia/Beijing
```

The command was doing the right thing internally: `stats` accepts `local`, `utc`, or an IANA time zone, and `Asia/Beijing` is not a valid IANA identifier. The valid IANA zone for this use case is `Asia/Shanghai`. The problem was that the error did not explain the accepted input shape or give a useful example, so both humans and agents were left to infer how to fix the command.

This PR keeps the parameter contract strict, but makes timezone handling clearer:

- normalizes valid time zones through Node Intl before daily stats bucketing
- preserves `local` and `utc` handling
- accepts case-insensitive IANA IDs when the runtime supports them, such as `america/new_york`
- replaces the raw Intl `RangeError` with an actionable message that points users to `local`, `utc`, and valid IANA examples

## Why this helps

When a user or agent passes a non-IANA value such as `Asia/Beijing`, the error now explains what went wrong and how to improve the command. That makes the failure self-correcting instead of looking like an opaque Node runtime exception.

## Test plan

- `pnpm exec vitest run test/core/time.test.ts`
- `pnpm typecheck`

## Issue Links
- Refs #35 because this was found while debugging stats output for the truncation/accounting issue. This PR only improves timezone validation errors and does not close #35.
