### PR TITLE
fix(core): preserve small discovery outputs

### DIFF
--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -11,6 +11,8 @@ import { buildInspectionSummary } from "./reduce-inspection-summary.js";
 import type { CompactResult, CompiledRule, ReduceOptions, ToolExecutionInput } from "../types.js";
 
 const TINY_OUTPUT_MAX_CHARS = 240;
+const SMALL_OUTPUT_PASSTHROUGH_MIN_SAVED_CHARS = 120;
+const SMALL_OUTPUT_PASSTHROUGH_MAX_RATIO = 0.75;
 
 function buildRawText(input: ToolExecutionInput): string {
   if (input.combinedText) {
@@ -152,6 +154,53 @@ function buildPassthroughText(input: ToolExecutionInput, rawText: string): strin
   return normalized;
 }
 
+function buildLiteralPassthroughText(input: ToolExecutionInput, rawText: string): string {
+  const normalized = stripAnsi(rawText).trimEnd();
+  if (!normalized) {
+    return buildPassthroughText(input, rawText);
+  }
+
+  if (input.exitCode && input.exitCode !== 0) {
+    return `exit ${input.exitCode}\n${normalized}`;
+  }
+
+  return normalized;
+}
+
+function shouldKeepSmallOutput(
+  classification: { family: string },
+  input: ToolExecutionInput,
+  rawChars: number,
+  compactChars: number,
+  maxInlineChars: number,
+): boolean {
+  if (rawChars === 0 || rawChars > maxInlineChars || (input.exitCode ?? 0) !== 0) {
+    return false;
+  }
+  if (!isTerseDiscoveryCommand(classification, input)) {
+    return false;
+  }
+
+  const savedChars = rawChars - compactChars;
+  const ratio = rawChars === 0 ? 1 : compactChars / rawChars;
+  return savedChars < SMALL_OUTPUT_PASSTHROUGH_MIN_SAVED_CHARS
+    || ratio > SMALL_OUTPUT_PASSTHROUGH_MAX_RATIO;
+}
+
+function isTerseDiscoveryCommand(classification: { family: string }, input: ToolExecutionInput): boolean {
+  const argv = input.argv ?? [];
+  if (classification.family === "git-status") {
+    return argv.some((arg) => arg === "--short" || arg === "-s" || arg.startsWith("--porcelain"));
+  }
+  if (classification.family === "git-remote") {
+    return argv.includes("-v") || argv.includes("--verbose");
+  }
+  if (classification.family === "git-worktree") {
+    return argv.includes("--porcelain");
+  }
+  return false;
+}
+
 function formatInline(
   classification: { family: string },
   input: ToolExecutionInput,
@@ -189,13 +238,15 @@ function selectInlineText(
   compactText: string,
   maxInlineChars: number,
 ): string {
-  if (classification.family === "git-status") {
-    return compactText;
-  }
-
   const passthroughText = buildPassthroughText(input, rawText);
   const rawChars = countTextChars(stripAnsi(rawText));
   const compactChars = countTextChars(compactText);
+  if (shouldKeepSmallOutput(classification, input, rawChars, compactChars, maxInlineChars)) {
+    return buildLiteralPassthroughText(input, rawText);
+  }
+  if (classification.family === "git-status") {
+    return compactText;
+  }
   if (rawChars <= maxInlineChars && compactChars >= rawChars) {
     return passthroughText;
   }

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -131,6 +131,21 @@ describe("reduceExecution", () => {
     expect(result.stats.reducedChars).toBeLessThanOrEqual(result.stats.rawChars);
   });
 
+  it("passes through small terse status output instead of rewriting columns", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git status --short",
+      argv: ["git", "status", "--short"],
+      combinedText: " M src/index.ts\n?? test/new.test.ts\n",
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/status");
+    expect(result.inlineText).toBe(" M src/index.ts\n?? test/new.test.ts");
+    expect(result.inlineText).not.toContain("M:");
+    expect(result.stats.ratio).toBeGreaterThan(0.75);
+  });
+
   it("rewrites long git status output into compact branch and file summaries", async () => {
     const result = await reduceExecution({
       toolName: "exec",

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -593,7 +593,7 @@ describe("runCodexPostToolUseHook", () => {
     expect(stdout).toBe("");
     expect(stderr).toBe("");
     expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("low-savings-compaction");
+    expect(debug.skipped).toBe("no-compaction");
     expect(debug.matchedReducer).toBe("git/status");
     expect(debug.rawChars).toBe(28);
     expect(debug.reducedChars).toBe(27);
@@ -909,7 +909,7 @@ describe("runCodexPostToolUseHook", () => {
     expect(history[0]?.ratio).toBe(1);
     expect(history[0]?.matchedReducer).toBeUndefined();
     expect(history[1]?.rewrote).toBe(false);
-    expect(history[1]?.skipped).toBe("low-savings-compaction");
+    expect(history[1]?.skipped).toBe("no-compaction");
     expect(history[1]?.savedChars).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- preserve literal output for already-terse discovery commands when reducer savings are negligible
- keep `git status --short` status columns intact instead of rewriting them to long-form labels
- update Codex hook expectations for the new core no-compaction path

Fixes #50.

## Test plan
- `pnpm exec vitest run test/core/reduce.test.ts test/core/wrap.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `node dist/cli/main.js wrap -- git remote -v`
- `node dist/cli/main.js wrap -- git worktree list --porcelain`
- synthetic `node dist/cli/main.js reduce-json --format json` payload for `git status --short`
- `git diff --check`
- `tokenjuice wrap --raw -- pnpm verify`
