### PR TITLE
feat(cli): add source breakdown reporting

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -58,6 +58,8 @@ type ParsedArgs = {
   maxCaptureBytes: number | undefined;
   maxInputBytes: number | undefined;
   timeZone: string | undefined;
+  source: string | undefined;
+  bySource: boolean;
   wrapLauncher: string | undefined;
   trace: boolean;
   printInstructions: boolean;
@@ -80,7 +82,7 @@ function printUsage(): void {
       "  tokenjuice --version",
       "  tokenjuice reduce [file] [--format text|json] [--classifier <id>] [--store] [--raw|--full]",
       "  tokenjuice reduce-json [file]",
-      "  tokenjuice wrap [--raw|--full] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
+      "  tokenjuice wrap [--raw|--full] [--source <name>] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
       "  tokenjuice <command> ... [--trace]",
       "  tokenjuice install codex [--local]",
       "  tokenjuice install claude-code [--local]",
@@ -97,9 +99,9 @@ function printUsage(): void {
       "  tokenjuice ls",
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
-      "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
       "  tokenjuice doctor [file|hooks|codex|claude-code|codebuddy|cursor|pi|opencode|vscode-copilot|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
-      "  tokenjuice stats [--timezone local|utc|<iana-timezone>]",
+      "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
   process.stderr.write("\n");
@@ -124,6 +126,8 @@ function parseArgs(argv: string[]): ParsedArgs {
   let maxCaptureBytes: number | undefined;
   let maxInputBytes: number | undefined;
   let timeZone: string | undefined;
+  let source: string | undefined;
+  let bySource = false;
   let wrapLauncher: string | undefined;
   let trace = false;
   let printInstructions = false;
@@ -235,6 +239,17 @@ function parseArgs(argv: string[]): ParsedArgs {
         timeZone = next;
         index += 2;
         break;
+      case "--source":
+        if (!next) {
+          throw new Error("--source requires a value");
+        }
+        source = next;
+        index += 2;
+        break;
+      case "--by-source":
+        bySource = true;
+        index += 1;
+        break;
       case "--wrap-launcher":
         if (!next) {
           throw new Error("--wrap-launcher requires a value");
@@ -272,6 +287,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     maxCaptureBytes,
     maxInputBytes,
     timeZone,
+    source,
+    bySource,
     wrapLauncher,
     trace,
     printInstructions,
@@ -328,6 +345,7 @@ async function runReduce(args: ParsedArgs): Promise<number> {
       command: file ? `reduce:${file}` : "stdin",
       combinedText: rawText,
       exitCode: 0,
+      ...(args.source ? { metadata: { source: args.source } } : {}),
     },
     {
       ...(args.classifier ? { classifier: args.classifier } : {}),
@@ -351,7 +369,16 @@ async function runReduceJson(args: ParsedArgs): Promise<number> {
   }
 
   const request = parseReduceJsonRequest(JSON.parse(rawText) as unknown);
-  const result = await reduceExecution(request.input, {
+  const requestInput = args.source
+    ? {
+        ...request.input,
+        metadata: {
+          ...request.input.metadata,
+          source: args.source,
+        },
+      }
+    : request.input;
+  const result = await reduceExecution(requestInput, {
     ...request.options,
     ...(args.classifier ? { classifier: args.classifier } : {}),
     ...(args.raw ? { raw: true } : {}),
@@ -375,6 +402,7 @@ async function runWrap(args: ParsedArgs): Promise<number> {
     ...(args.storeDir ? { storeDir: args.storeDir } : {}),
     ...(typeof args.maxInlineChars === "number" ? { maxInlineChars: args.maxInlineChars } : {}),
     ...(typeof args.maxCaptureBytes === "number" ? { maxCaptureBytes: args.maxCaptureBytes } : {}),
+    ...(args.source ? { source: args.source } : {}),
   });
   const inlineText = decorateWrapInlineText(wrapped.result, args.raw);
   emit(args.format, wrapped, inlineText, args.raw);
@@ -722,6 +750,7 @@ async function loadDirectAnalysisEntry(args: ParsedArgs) {
     command: args.sourceCommand ?? (file ? `analyze:${file}` : "stdin"),
     combinedText: rawText,
     exitCode: args.exitCode ?? 0,
+    ...(args.source ? { metadata: { source: args.source } } : {}),
   } as const;
   const result = await reduceExecution(input, {
     ...(args.classifier ? { classifier: args.classifier } : {}),
@@ -755,7 +784,10 @@ function formatMetric(value: number): string {
 async function runDiscover(args: ParsedArgs): Promise<number> {
   const direct = await loadDirectAnalysisEntry(args);
   const entries = direct ? [direct.entry] : await listArtifactMetadata(args.storeDir);
-  const candidates = discoverCandidates(entries);
+  const candidates = discoverCandidates(entries, {
+    ...(args.source ? { source: args.source } : {}),
+    ...(args.bySource ? { bySource: true } : {}),
+  });
 
   if (args.format === "json") {
     process.stdout.write(`${JSON.stringify(direct ? { result: direct.result, candidates } : candidates, null, 2)}\n`);
@@ -776,6 +808,7 @@ async function runDiscover(args: ParsedArgs): Promise<number> {
     process.stdout.write(
       [
         candidate.kind,
+        candidate.source ? `source=${candidate.source}` : null,
         candidate.signature,
         `count=${formatMetric(candidate.count)}`,
         `raw=${formatMetric(candidate.totalRawChars)}`,
@@ -1153,7 +1186,11 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
 
 async function runStats(args: ParsedArgs): Promise<number> {
   const entries = await listArtifactMetadata(args.storeDir);
-  const report = statsArtifacts(entries, { timeZone: args.timeZone ?? "local" });
+  const report = statsArtifacts(entries, {
+    timeZone: args.timeZone ?? "local",
+    ...(args.source ? { source: args.source } : {}),
+    ...(args.bySource ? { bySource: true } : {}),
+  });
 
   if (args.format === "json") {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -1191,6 +1228,25 @@ async function runStats(args: ParsedArgs): Promise<number> {
     process.stdout.write("daily:\n");
     for (const day of report.daily.slice(-5)) {
       process.stdout.write(`- ${day.day} count=${formatMetric(day.count)} saved=${formatMetric(day.savedChars)}\n`);
+    }
+  }
+
+  if (report.sources && report.sources.length > 0) {
+    process.stdout.write("sources:\n");
+    for (const source of report.sources) {
+      process.stdout.write(
+        `source ${source.source}: entries=${formatMetric(source.totals.entries)} saved=${formatMetric(source.totals.savedChars)} avgRatio=${formatRatio(source.totals.avgRatio)}\n`,
+      );
+      if (source.reducers.length > 0) {
+        process.stdout.write(
+          `  reducers: ${source.reducers.slice(0, 3).map((reducer) => `${reducer.reducer}(${formatMetric(reducer.count)})`).join(", ")}\n`,
+        );
+      }
+      if (source.commands.length > 0) {
+        process.stdout.write(
+          `  commands: ${source.commands.slice(0, 3).map((command) => `${command.signature}(${formatMetric(command.count)})`).join(", ")}\n`,
+        );
+      }
     }
   }
 

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -1,5 +1,6 @@
 import type { CompactResult, StoredArtifactMetadata, ToolExecutionInput } from "../types.js";
 import { normalizeCommandSignature } from "./command-identity.js";
+import { readStoredArtifactSource, resolveArtifactSource } from "./source.js";
 import { buildCalendarDayFormatter } from "./time.js";
 
 export type AnalysisEntry = {
@@ -8,6 +9,7 @@ export type AnalysisEntry = {
 
 export type DiscoverCandidate = {
   kind: "missing-rule" | "weak-rule";
+  source?: string;
   signature: string;
   count: number;
   totalRawChars: number;
@@ -34,6 +36,7 @@ export type DoctorReport = {
 };
 
 export type StatsReport = {
+  source?: string;
   totals: {
     observedEntries: number;
     captureTruncatedEntries: number;
@@ -72,14 +75,27 @@ export type StatsReport = {
     reducedChars: number;
     savedChars: number;
   }>;
+  sources?: StatsSourceReport[];
 };
 
 export type StatsOptions = {
   timeZone?: string;
+  source?: string;
+  bySource?: boolean;
+};
+
+export type DiscoverOptions = {
+  source?: string;
+  bySource?: boolean;
+};
+
+export type StatsSourceReport = Omit<StatsReport, "sources"> & {
+  source: string;
 };
 
 type GroupState = {
   kind: DiscoverCandidate["kind"];
+  source?: string;
   signature: string;
   count: number;
   totalRawChars: number;
@@ -115,6 +131,7 @@ export function buildAnalysisEntry(input: ToolExecutionInput, result: CompactRes
   return {
     metadata: {
       createdAt: new Date().toISOString(),
+      source: resolveArtifactSource(input),
       classification: result.classification,
       rawChars: result.stats.rawChars,
       reducedChars: result.stats.reducedChars,
@@ -127,8 +144,25 @@ export function buildAnalysisEntry(input: ToolExecutionInput, result: CompactRes
   };
 }
 
-function groupCandidates(entries: Array<AnalysisEntry & { kind: DiscoverCandidate["kind"] }>): DiscoverCandidate[] {
+function entrySource(entry: AnalysisEntry): string {
+  return readStoredArtifactSource(entry.metadata.source);
+}
+
+function filterEntriesBySource(entries: AnalysisEntry[], source: string | undefined): AnalysisEntry[] {
+  const normalized = readStoredArtifactSource(source);
+  if (!source) {
+    return entries;
+  }
+
+  return entries.filter((entry) => entrySource(entry) === normalized);
+}
+
+function groupCandidates(
+  entries: Array<AnalysisEntry & { kind: DiscoverCandidate["kind"] }>,
+  options: DiscoverOptions = {},
+): DiscoverCandidate[] {
   const groups = new Map<string, GroupState>();
+  const includeSource = options.bySource || Boolean(options.source);
 
   for (const entry of entries) {
     const signature = normalizeCommandSignature(entry.metadata.command);
@@ -136,9 +170,16 @@ function groupCandidates(entries: Array<AnalysisEntry & { kind: DiscoverCandidat
       continue;
     }
 
-    const key = `${entry.kind}:${signature}:${entry.metadata.classification.matchedReducer ?? ""}`;
+    const source = entrySource(entry);
+    const key = [
+      entry.kind,
+      includeSource ? source : "",
+      signature,
+      entry.metadata.classification.matchedReducer ?? "",
+    ].join(":");
     const existing = groups.get(key) ?? {
       kind: entry.kind,
+      ...(includeSource ? { source } : {}),
       signature,
       count: 0,
       totalRawChars: 0,
@@ -162,6 +203,7 @@ function groupCandidates(entries: Array<AnalysisEntry & { kind: DiscoverCandidat
   return [...groups.values()]
     .map((group) => ({
       kind: group.kind,
+      ...(group.source ? { source: group.source } : {}),
       signature: group.signature,
       count: group.count,
       totalRawChars: group.totalRawChars,
@@ -178,8 +220,9 @@ function groupCandidates(entries: Array<AnalysisEntry & { kind: DiscoverCandidat
     });
 }
 
-export function discoverCandidates(entries: AnalysisEntry[]): DiscoverCandidate[] {
-  const missing = entries
+export function discoverCandidates(entries: AnalysisEntry[], options: DiscoverOptions = {}): DiscoverCandidate[] {
+  const filteredEntries = filterEntriesBySource(entries, options.source);
+  const missing = filteredEntries
     .filter((entry) => GENERIC_REDUCERS.has(entry.metadata.classification.matchedReducer))
     .filter((entry) => entry.metadata.rawChars >= MISSING_RAW_CHARS_THRESHOLD)
     .map((entry) => ({
@@ -187,7 +230,7 @@ export function discoverCandidates(entries: AnalysisEntry[]): DiscoverCandidate[
       kind: "missing-rule" as const,
     }));
 
-  const weak = entries
+  const weak = filteredEntries
     .filter((entry) => !GENERIC_REDUCERS.has(entry.metadata.classification.matchedReducer))
     .filter((entry) => typeof entry.metadata.ratio === "number" && entry.metadata.ratio >= WEAK_RATIO_THRESHOLD)
     .filter((entry) => entry.metadata.rawChars >= WEAK_RAW_CHARS_THRESHOLD)
@@ -197,8 +240,8 @@ export function discoverCandidates(entries: AnalysisEntry[]): DiscoverCandidate[
     }));
 
   return [
-    ...groupCandidates(missing),
-    ...groupCandidates(weak),
+    ...groupCandidates(missing, options),
+    ...groupCandidates(weak, options),
   ].sort((left, right) => {
     if (left.kind !== right.kind) {
       return left.kind.localeCompare(right.kind);
@@ -269,7 +312,7 @@ function avgRatioFromGroup(group: StatsGroup): number | null {
   return group.ratioCount > 0 ? group.ratioSum / group.ratioCount : null;
 }
 
-export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions = {}): StatsReport {
+function buildStatsReport(entries: AnalysisEntry[], options: StatsOptions, source?: string): StatsReport {
   const reducers = new Map<string, StatsGroup>();
   const commands = new Map<string, StatsGroup>();
   const daily = new Map<string, StatsGroup>();
@@ -325,6 +368,7 @@ export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions =
   const observedSavingsPercent = observedRawChars > 0 ? observedSavedChars / observedRawChars : null;
 
   return {
+    ...(source ? { source } : {}),
     totals: {
       observedEntries: entries.length,
       captureTruncatedEntries,
@@ -371,6 +415,32 @@ export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions =
         savedChars: Math.max(group.rawChars - group.reducedChars, 0),
       }))
       .sort((left, right) => left.day.localeCompare(right.day)),
+  };
+}
+
+export function statsArtifacts(entries: AnalysisEntry[], options: StatsOptions = {}): StatsReport {
+  const filteredEntries = filterEntriesBySource(entries, options.source);
+  const report = buildStatsReport(
+    filteredEntries,
+    options,
+    options.source ? readStoredArtifactSource(options.source) : undefined,
+  );
+
+  if (!options.bySource) {
+    return report;
+  }
+
+  const sources = [...new Set(filteredEntries.map((entry) => entrySource(entry)))]
+    .sort()
+    .map((source) => buildStatsReport(
+      filteredEntries.filter((entry) => entrySource(entry) === source),
+      options,
+      source,
+    ) as StatsSourceReport);
+
+  return {
+    ...report,
+    sources,
   };
 }
 

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { countTextChars, stripAnsi } from "./text.js";
+import { resolveArtifactSource } from "./source.js";
 
 import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
@@ -27,6 +28,9 @@ function isStoredArtifactMetadata(value: unknown): value is StoredArtifactMetada
   }
 
   if ("toolName" in value && value.toolName !== undefined && typeof value.toolName !== "string") {
+    return false;
+  }
+  if ("source" in value && value.source !== undefined && typeof value.source !== "string") {
     return false;
   }
   if ("command" in value && value.command !== undefined && typeof value.command !== "string") {
@@ -93,6 +97,7 @@ export async function storeArtifact(input: StoredArtifactInput, storeDir?: strin
     rawText: input.rawText,
     metadata: {
       createdAt: new Date().toISOString(),
+      source: resolveArtifactSource(input.input),
       classification: input.classification,
       rawChars: input.stats?.rawChars ?? countTextChars(stripAnsi(input.rawText)),
       ...(input.input.toolName ? { toolName: input.input.toolName } : {}),
@@ -117,6 +122,7 @@ export async function storeArtifactMetadata(input: StoredArtifactInput, storeDir
   const captureTruncated = extractCaptureTruncatedFlag(input.input);
   const metadata: StoredArtifactMetadata = {
     createdAt: new Date().toISOString(),
+    source: resolveArtifactSource(input.input),
     classification: input.classification,
     rawChars: input.stats?.rawChars ?? countTextChars(stripAnsi(input.rawText)),
     ...(input.input.toolName ? { toolName: input.input.toolName } : {}),

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -1,0 +1,53 @@
+import type { ToolExecutionInput } from "../types.js";
+
+export const UNKNOWN_ARTIFACT_SOURCE = "unknown";
+export const DEFAULT_CLI_ARTIFACT_SOURCE = "cli";
+
+export function normalizeArtifactSource(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const source = value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/gu, "-")
+    .replace(/[^a-z0-9.-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+
+  if (!source) {
+    return null;
+  }
+
+  if (source.startsWith("claude-code") || source === "claude") {
+    return "claude-code";
+  }
+  if (source.startsWith("codex")) {
+    return "codex";
+  }
+  if (source.startsWith("cursor")) {
+    return "cursor";
+  }
+  if (source.startsWith("openclaw")) {
+    return "openclaw";
+  }
+  if (source.startsWith("opencode") || source.startsWith("open-code")) {
+    return "opencode";
+  }
+  if (source.startsWith("pi")) {
+    return "pi";
+  }
+  if (source === "direct" || source === "tokenjuice" || source === "wrap") {
+    return DEFAULT_CLI_ARTIFACT_SOURCE;
+  }
+
+  return source;
+}
+
+export function resolveArtifactSource(input: ToolExecutionInput): string {
+  return normalizeArtifactSource(input.metadata?.source) ?? DEFAULT_CLI_ARTIFACT_SOURCE;
+}
+
+export function readStoredArtifactSource(source: string | undefined): string {
+  return normalizeArtifactSource(source) ?? UNKNOWN_ARTIFACT_SOURCE;
+}

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -102,6 +102,7 @@ export async function runWrappedCommand(argv: string[], opts: WrapOptions = {}):
             combinedText: combined.text,
             exitCode: code ?? 1,
             metadata: {
+              ...(opts.source ? { source: opts.source } : {}),
               tokenjuiceCaptureTruncated: combined.truncated,
             },
           },

--- a/src/hosts/codebuddy/index.ts
+++ b/src/hosts/codebuddy/index.ts
@@ -393,7 +393,7 @@ export async function runCodeBuddyPreToolUseHook(rawText: string, wrapLauncher =
     return 0;
   }
 
-  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command });
+  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "codebuddy" });
 
   const response = {
     hookSpecificOutput: {

--- a/src/hosts/cursor/index.ts
+++ b/src/hosts/cursor/index.ts
@@ -302,7 +302,7 @@ export async function runCursorPreToolUseHook(rawText: string, wrapLauncher = "t
     return 0;
   }
 
-  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command });
+  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "cursor" });
   const response = {
     permission: "allow",
     updated_input: {

--- a/src/hosts/shared/pre-tool-wrap.ts
+++ b/src/hosts/shared/pre-tool-wrap.ts
@@ -185,13 +185,15 @@ export function buildWrappedCommand(params: {
   wrapLauncher: string;
   shellPath: string;
   command: string;
+  source?: string;
   nodePath?: string;
 }): string {
   const nodePath = params.nodePath ?? process.execPath;
   const launcherCommand = params.wrapLauncher.endsWith(".js")
     ? `${shellQuote(nodePath)} ${shellQuote(params.wrapLauncher)}`
     : shellQuote(params.wrapLauncher);
-  return `${launcherCommand} wrap -- ${shellQuote(params.shellPath)} -lc ${shellQuote(params.command)}`;
+  const sourceArgs = params.source ? ` --source ${shellQuote(params.source)}` : "";
+  return `${launcherCommand} wrap${sourceArgs} -- ${shellQuote(params.shellPath)} -lc ${shellQuote(params.command)}`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export { clearFixtureCache, loadBuiltinFixtures, verifyBuiltinFixtures } from ".
 export { parseReduceJsonRequest } from "./core/json-protocol.js";
 export { classifyOnly, findMatchingRule, reduceExecution, reduceExecutionWithRules } from "./core/reduce.js";
 export { clearRuleCache, loadBuiltinRules, loadRules, verifyBuiltinRules, verifyRules } from "./core/rules.js";
+export { normalizeArtifactSource, readStoredArtifactSource, resolveArtifactSource } from "./core/source.js";
 export { clampText, countTerminalCells, countTextChars, stripAnsi } from "./core/text.js";
 export { runWrappedCommand } from "./core/wrap.js";
 export { assertValidRule, validateRule } from "./core/validate-rules.js";
@@ -81,4 +82,4 @@ export type {
   InstallCopilotCliHookResult,
   UninstallCopilotCliHookResult,
 } from "./hosts/copilot-cli/index.js";
-export type { StatsOptions, StatsReport } from "./core/analysis.js";
+export type { DiscoverOptions, StatsOptions, StatsReport, StatsSourceReport } from "./core/analysis.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,7 @@ export type StoredArtifactRef = {
 
 export type StoredArtifactMetadata = {
   createdAt: string;
+  source?: string;
   toolName?: string;
   command?: string;
   exitCode?: number;
@@ -214,6 +215,7 @@ export type RuleFixture = {
 
 export type WrapOptions = {
   cwd?: string;
+  source?: string;
   recordStats?: boolean;
   store?: boolean;
   storeDir?: string;

--- a/test/core/analysis.test.ts
+++ b/test/core/analysis.test.ts
@@ -88,6 +88,7 @@ describe("analysis", () => {
 
     expect(entry.metadata.classification.matchedReducer).toBe("tests/vitest");
     expect(entry.metadata.rawChars).toBeGreaterThan(0);
+    expect(entry.metadata.source).toBe("cli");
   });
 
   it("aggregates stats across stored artifacts", async () => {
@@ -136,6 +137,7 @@ describe("analysis", () => {
       {
         metadata: {
           createdAt: "2026-04-23T00:00:00.000Z",
+          source: "codex",
           command: "python query_cls_log.py",
           classification: {
             family: "generic",
@@ -151,6 +153,7 @@ describe("analysis", () => {
       {
         metadata: {
           createdAt: "2026-04-23T00:01:00.000Z",
+          source: "cursor",
           command: "rg TODO src",
           classification: {
             family: "search",
@@ -172,6 +175,116 @@ describe("analysis", () => {
     expect(report.totals.savedChars).toBe(150);
     expect(report.commands[0]?.signature).toBe("rg");
     expect(report.reducers.some((entry) => entry.reducer === "generic/fallback")).toBe(false);
+  });
+
+  it("segments stats by normalized artifact source", () => {
+    const entries = [
+      {
+        metadata: {
+          createdAt: "2026-04-20T00:00:00.000Z",
+          source: "codex",
+          command: "pnpm test",
+          classification: {
+            family: "tests",
+            confidence: 1,
+            matchedReducer: "tests/pnpm-test",
+          },
+          rawChars: 100,
+          reducedChars: 40,
+          ratio: 0.4,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-04-20T01:00:00.000Z",
+          source: "cursor",
+          command: "grep TODO src",
+          classification: {
+            family: "search",
+            confidence: 1,
+            matchedReducer: "search/grep",
+          },
+          rawChars: 200,
+          reducedChars: 100,
+          ratio: 0.5,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-04-20T02:00:00.000Z",
+          command: "custom-tool check",
+          classification: {
+            family: "generic",
+            confidence: 1,
+            matchedReducer: "generic/fallback",
+          },
+          rawChars: 50,
+          reducedChars: 50,
+          ratio: 1,
+        },
+      },
+    ];
+
+    const grouped = statsArtifacts(entries, { bySource: true });
+    expect(grouped.totals.entries).toBe(3);
+    expect(grouped.sources?.map((source) => source.source)).toEqual(["codex", "cursor", "unknown"]);
+    expect(grouped.sources?.find((source) => source.source === "cursor")?.commands[0]?.signature).toBe("grep");
+
+    const cursorOnly = statsArtifacts(entries, { source: "cursor" });
+    expect(cursorOnly.source).toBe("cursor");
+    expect(cursorOnly.totals.entries).toBe(1);
+    expect(cursorOnly.commands[0]?.signature).toBe("grep");
+  });
+
+  it("can segment and filter discover candidates by source", () => {
+    const entries = [
+      {
+        metadata: {
+          createdAt: "2026-04-20T00:00:00.000Z",
+          source: "codex",
+          command: "custom-tool check",
+          classification: {
+            family: "generic",
+            confidence: 1,
+            matchedReducer: "generic/fallback",
+          },
+          rawChars: 300,
+          reducedChars: 300,
+          ratio: 1,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-04-20T01:00:00.000Z",
+          source: "cursor",
+          command: "custom-tool check",
+          classification: {
+            family: "generic",
+            confidence: 1,
+            matchedReducer: "generic/fallback",
+          },
+          rawChars: 400,
+          reducedChars: 400,
+          ratio: 1,
+        },
+      },
+    ];
+
+    const defaultCandidates = discoverCandidates(entries);
+    expect(defaultCandidates).toHaveLength(1);
+    expect(defaultCandidates[0]?.count).toBe(2);
+    expect(defaultCandidates[0]?.source).toBeUndefined();
+
+    const grouped = discoverCandidates(entries, { bySource: true });
+    expect(grouped.map((candidate) => candidate.source).sort()).toEqual(["codex", "cursor"]);
+
+    const codexOnly = discoverCandidates(entries, { source: "codex", bySource: true });
+    expect(codexOnly).toHaveLength(1);
+    expect(codexOnly[0]?.source).toBe("codex");
+    expect(codexOnly[0]?.count).toBe(1);
+
+    const filtered = discoverCandidates(entries, { source: "cursor" });
+    expect(filtered[0]?.source).toBe("cursor");
   });
 
   it("buckets daily stats by the requested timezone", () => {

--- a/test/core/artifacts.test.ts
+++ b/test/core/artifacts.test.ts
@@ -98,5 +98,30 @@ describe("artifacts", () => {
     expect(metadata[0]?.id).toBe(metadataRef.id);
     expect(metadata[0]?.path).toBeUndefined();
     expect(metadata[0]?.metadata.command).toBe("pnpm test");
+    expect(metadata[0]?.metadata.source).toBe("cli");
+  });
+
+  it("persists normalized source metadata when provided", async () => {
+    const storeDir = await createTempDir();
+
+    const metadataRef = await storeArtifactMetadata(
+      {
+        input: {
+          toolName: "exec",
+          command: "pnpm test",
+          exitCode: 0,
+          metadata: { source: "codex-post-tool-use" },
+        },
+        rawText: "test output",
+        classification: { family: "test-results", confidence: 1, matchedReducer: "tests/pnpm-test" },
+        stats: { rawChars: 11, reducedChars: 5, ratio: 0.45 },
+      },
+      storeDir,
+    );
+
+    const metadata = await listArtifactMetadata(storeDir);
+
+    expect(metadata[0]?.id).toBe(metadataRef.id);
+    expect(metadata[0]?.metadata.source).toBe("codex");
   });
 });

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -91,4 +91,22 @@ describe("runWrappedCommand", () => {
     expect(wrapped.result.inlineText).toBe("usage: cmd\n\nflag\n");
     expect(wrapped.result.stats.ratio).toBe(1);
   });
+
+  it("records the requested source for wrapper stats", async () => {
+    const storeDir = await createTempDir();
+
+    await runWrappedCommand([
+      "node",
+      "-e",
+      "console.log('source tagged output');",
+    ], {
+      source: "cursor",
+      recordStats: true,
+      storeDir,
+    });
+
+    const metadata = await listArtifactMetadata(storeDir);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.metadata.source).toBe("cursor");
+  });
 });

--- a/test/hosts/codebuddy.test.ts
+++ b/test/hosts/codebuddy.test.ts
@@ -615,6 +615,7 @@ describe("runCodeBuddyPreToolUseHook", () => {
     const parsed = parseWrappedCommand(response.hookSpecificOutput.modifiedInput.command);
     expect(parsed.launcher).toEqual(["/usr/local/bin/tokenjuice"]);
     expect(parsed.subcommand).toBe("wrap");
+    expect(parsed.wrapArgs).toEqual(["--source", "codebuddy"]);
     expect(parsed.shellPath).toBe(hostShellPath);
     expect(parsed.inner).toBe("git status --short");
     expect(parsed.wrapDepth).toBe(1);
@@ -699,6 +700,7 @@ describe("runCodeBuddyPreToolUseHook", () => {
     const parsed = parseWrappedCommand(response.hookSpecificOutput.modifiedInput.command);
     expect(parsed.launcher[0]).toBe(process.execPath);
     expect(parsed.launcher[1]).toBe("/repo/dist/cli/main.js");
+    expect(parsed.wrapArgs).toEqual(["--source", "codebuddy"]);
     expect(parsed.shellPath).toBe(hostShellPath);
     expect(parsed.inner).toBe("git status --short");
     expect(parsed.wrapDepth).toBe(1);

--- a/test/hosts/cursor.test.ts
+++ b/test/hosts/cursor.test.ts
@@ -258,6 +258,7 @@ describe("runCursorPreToolUseHook", () => {
     const parsed = parseWrappedCommand(response.updated_input.command);
     expect(parsed.launcher).toEqual(["/usr/local/bin/tokenjuice"]);
     expect(parsed.subcommand).toBe("wrap");
+    expect(parsed.wrapArgs).toEqual(["--source", "cursor"]);
     expect(parsed.shellPath).toBe(hostShellPath);
     expect(parsed.inner).toBe("git status --short");
     expect(parsed.wrapDepth).toBe(1);
@@ -326,6 +327,7 @@ describe("runCursorPreToolUseHook", () => {
     // may or may not be absolute depending on how resolve() normalized it.
     expect(parsed.launcher[0]).toBe(process.execPath);
     expect(parsed.launcher[1]).toBe("/repo/dist/cli/main.js");
+    expect(parsed.wrapArgs).toEqual(["--source", "cursor"]);
     expect(parsed.shellPath).toBe(hostShellPath);
     expect(parsed.inner).toBe("git status --short");
     expect(parsed.wrapDepth).toBe(1);
@@ -381,6 +383,7 @@ describe("runCursorPreToolUseHook", () => {
 
     expect(code).toBe(0);
     const parsed = parseWrappedCommand(response.updated_input.command);
+    expect(parsed.wrapArgs).toEqual(["--source", "cursor"]);
     expect(parsed.shellPath).toBe(hostShellPath);
     expect(parsed.inner).toBe("git status --short");
     expect(parsed.wrapDepth).toBe(1);

--- a/test/hosts/shared/pre-tool-wrap.test.ts
+++ b/test/hosts/shared/pre-tool-wrap.test.ts
@@ -240,6 +240,16 @@ describe("buildWrappedCommand", () => {
     expect(wrapped).toBe("/usr/bin/node /repo/dist/cli/main.js wrap -- /bin/bash -lc 'echo hi'");
   });
 
+  it("adds a source tag before the wrapped shell command", () => {
+    const wrapped = buildWrappedCommand({
+      wrapLauncher: "/usr/local/bin/tokenjuice",
+      shellPath: "/bin/bash",
+      command: "git status --short",
+      source: "cursor",
+    });
+    expect(wrapped).toBe("/usr/local/bin/tokenjuice wrap --source cursor -- /bin/bash -lc 'git status --short'");
+  });
+
   it("escapes commands containing single quotes through POSIX shellQuote", () => {
     const wrapped = buildWrappedCommand({
       wrapLauncher: "/usr/local/bin/tokenjuice",


### PR DESCRIPTION
## Summary
- persist normalized artifact source metadata for new records while keeping old artifacts readable as unknown
- add source filtering and grouping to stats and discover
- tag Cursor wrapped commands as cursor so wrapper-generated stats preserve channel context

Closes #26

## Test plan
- pnpm exec vitest run test/core/analysis.test.ts test/core/artifacts.test.ts test/core/wrap.test.ts test/hosts/cursor.test.ts
- pnpm typecheck
- tokenjuice wrap --raw -- pnpm verify
