### PR TITLE
fix(codex): simplify rerun hint

### DIFF
--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -613,7 +613,7 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
 
 function buildCodexHint(rawRefId?: string): string {
   const hints = [
-    "if this compaction looks wrong, rerun with `tokenjuice wrap --raw -- <command>` or `tokenjuice wrap --full -- <command>`.",
+    "if this compaction looks wrong, rerun with `tokenjuice wrap --raw -- <command>`.",
   ];
   if (rawRefId) {
     hints.unshift(`tokenjuice stored raw bash output as artifact ${rawRefId}. use \`tokenjuice cat ${rawRefId}\` only if the compacted output is insufficient.`);

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -513,7 +513,7 @@ describe("runCodexPostToolUseHook", () => {
     expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
     expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
     expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --full -- <command>");
+    expect(response.hookSpecificOutput?.additionalContext).not.toContain("tokenjuice wrap --full -- <command>");
     expect(debug.rewrote).toBe(true);
     expect(debug.matchedReducer).toBe("git/status");
   });


### PR DESCRIPTION
## Summary
- shorten the Codex compaction rerun hint to only mention `tokenjuice wrap --raw -- <command>`
- update the Codex hook test to assert the `--full` option is no longer shown in the hint

## Validation
- `pnpm exec vitest run test/hosts/codex.test.ts`
- `pnpm typecheck`
