### PR TITLE
fix(ci): keep auto assign nonblocking

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:
@@ -32,9 +32,15 @@ jobs:
               return;
             }
 
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              assignees: [assignee],
-            });
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                assignees: [assignee],
+              });
+            } catch (error) {
+              const status = typeof error?.status === "number" ? `status ${error.status}: ` : "";
+              const message = error?.message ?? String(error);
+              core.warning(`Could not assign ${assignee}: ${status}${message}`);
+            }


### PR DESCRIPTION
## Summary
- grant the auto-assign workflow pull request write permission for PR assignment
- downgrade assignment API failures to workflow warnings so assignment never blocks CI

## Test plan
- inspected failing Auto Assign run 24925303722 logs
- git diff --check