### PR TITLE
fix(hosts): shorten compaction footer

### DIFF
--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { stripLeadingCdPrefix } from "../../core/command.js";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
+import { buildCompactionHint } from "../shared/hook-output.js";
 
 type ClaudeCodeHook = Record<string, unknown>;
 
@@ -395,18 +396,8 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
   return optionArgs.includes("--raw") || optionArgs.includes("--full");
 }
 
-function buildClaudeCodeHint(rawRefId?: string): string {
-  const hints = [
-    "if this compaction looks wrong, rerun with `tokenjuice wrap --raw -- <command>` or `tokenjuice wrap --full -- <command>`.",
-  ];
-  if (rawRefId) {
-    hints.unshift(`tokenjuice stored raw bash output as artifact ${rawRefId}. use \`tokenjuice cat ${rawRefId}\` only if the compacted output is insufficient.`);
-  }
-  return hints.join(" ");
-}
-
 function buildClaudeCodeAdditionalContext(inlineText: string, rawRefId?: string): string {
-  return `${inlineText}\n\n${buildClaudeCodeHint(rawRefId)}`;
+  return `${inlineText}\n\n${buildCompactionHint(rawRefId)}`;
 }
 
 async function writeHookDebug(record: Record<string, unknown>): Promise<void> {

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -10,6 +10,7 @@ import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../cor
 import { classifyOnly } from "../../core/reduce.js";
 import { countTextChars, stripAnsi } from "../../core/text.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
+import { buildCompactionHint } from "../shared/hook-output.js";
 
 import type { ToolExecutionInput } from "../../types.js";
 
@@ -612,18 +613,8 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
   return optionArgs.includes("--raw") || optionArgs.includes("--full");
 }
 
-function buildCodexHint(rawRefId?: string): string {
-  const hints = [
-    "if this compaction looks wrong, rerun with `tokenjuice wrap --raw -- <command>`.",
-  ];
-  if (rawRefId) {
-    hints.unshift(`tokenjuice stored raw bash output as artifact ${rawRefId}. use \`tokenjuice cat ${rawRefId}\` only if the compacted output is insufficient.`);
-  }
-  return hints.join(" ");
-}
-
 function buildCodexFeedback(inlineText: string, rawRefId?: string): string {
-  return `${inlineText}\n\n${buildCodexHint(rawRefId)}`;
+  return `${inlineText}\n\n${buildCompactionHint(rawRefId)}`;
 }
 
 function buildCodexReplacementOutput(inlineText: string, rawRefId?: string): Record<string, unknown> {

--- a/src/hosts/shared/hook-output.ts
+++ b/src/hosts/shared/hook-output.ts
@@ -1,3 +1,10 @@
+export function buildCompactionHint(rawRefId?: string): string {
+  if (rawRefId) {
+    return `raw saved: \`tokenjuice cat ${rawRefId}\`.`;
+  }
+  return "need raw? `tokenjuice wrap --raw -- <command>`.";
+}
+
 export function buildCompactedOutputContext(inlineText: string): string {
-  return `${inlineText}\n\ncompacted. if output looks incomplete, rerun with \`tokenjuice wrap --raw -- <command>\`.`;
+  return `${inlineText}\n\n${buildCompactionHint()}`;
 }

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -611,8 +611,9 @@ describe("runClaudeCodePostToolUseHook", () => {
     expect(response.hookSpecificOutput?.additionalContext).toContain("Changes not staged:");
     expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
     expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("need raw?");
     expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --full -- <command>");
+    expect(response.hookSpecificOutput?.additionalContext).not.toContain("tokenjuice wrap --full -- <command>");
     expect(debug.rewrote).toBe(true);
     expect(debug.matchedReducer).toBe("git/status");
   });


### PR DESCRIPTION
## Summary
- replace the verbose host compaction footer with `need raw? tokenjuice wrap --raw -- <command>`
- share the footer builder across Codex, Claude Code, and shared hook integrations
- remove Claude Code's lingering `--full` suggestion from compacted hook output

## Test plan
- pnpm exec vitest run test/hosts/codex.test.ts test/hosts/claude-code.test.ts test/hosts/openhands.test.ts test/hosts/cline.test.ts test/hosts/gemini-cli.test.ts
- pnpm typecheck
- pnpm lint