### PR TITLE
refactor(zed): harden rules integration

### DIFF
--- a/src/hosts/shared/marker-instructions.ts
+++ b/src/hosts/shared/marker-instructions.ts
@@ -1,0 +1,110 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type MarkerDelimitedBlockConfig = {
+  beginMarker: string;
+  endMarker: string;
+  block: string;
+};
+
+export type InstructionFileSnapshot = {
+  text: string;
+  exists: boolean;
+};
+
+export type MarkerDelimitedBlockState = {
+  hasBegin: boolean;
+  hasEnd: boolean;
+  completeBlockCount: number;
+};
+
+export type InstallMarkerDelimitedBlockResult = {
+  filePath: string;
+  backupPath?: string;
+};
+
+export type UninstallMarkerDelimitedBlockResult = {
+  filePath: string;
+  removed: boolean;
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function buildBlockPattern(config: MarkerDelimitedBlockConfig): RegExp {
+  return new RegExp(`\\n?${escapeRegExp(config.beginMarker)}[\\s\\S]*?${escapeRegExp(config.endMarker)}\\n?`, "gu");
+}
+
+export async function readInstructionFile(filePath: string): Promise<InstructionFileSnapshot> {
+  try {
+    return { text: await readFile(filePath, "utf8"), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { text: "", exists: false };
+    }
+    throw error;
+  }
+}
+
+export function inspectMarkerDelimitedBlock(text: string, config: MarkerDelimitedBlockConfig): MarkerDelimitedBlockState {
+  return {
+    hasBegin: text.includes(config.beginMarker),
+    hasEnd: text.includes(config.endMarker),
+    completeBlockCount: [...text.matchAll(buildBlockPattern(config))].length,
+  };
+}
+
+export function removeMarkerDelimitedBlock(text: string, config: MarkerDelimitedBlockConfig): { text: string; removed: boolean } {
+  const pattern = buildBlockPattern(config);
+  if (!pattern.test(text)) {
+    return { text, removed: false };
+  }
+  return {
+    text: text.replace(buildBlockPattern(config), "\n").replace(/\n{3,}/gu, "\n\n").trim(),
+    removed: true,
+  };
+}
+
+export function upsertMarkerDelimitedBlock(text: string, config: MarkerDelimitedBlockConfig): string {
+  const withoutBlock = removeMarkerDelimitedBlock(text, config).text.trim();
+  if (!withoutBlock) {
+    return `${config.block}\n`;
+  }
+  return `${withoutBlock}\n\n${config.block}\n`;
+}
+
+export async function installMarkerDelimitedBlock(filePath: string, config: MarkerDelimitedBlockConfig): Promise<InstallMarkerDelimitedBlockResult> {
+  const existing = await readInstructionFile(filePath);
+  let backupPath: string | undefined;
+  if (existing.exists) {
+    backupPath = `${filePath}.bak`;
+    await writeFile(backupPath, existing.text, "utf8");
+  }
+
+  await mkdir(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp`;
+  await writeFile(tempPath, upsertMarkerDelimitedBlock(existing.text, config), "utf8");
+  await rename(tempPath, filePath);
+  return {
+    filePath,
+    ...(backupPath ? { backupPath } : {}),
+  };
+}
+
+export async function uninstallMarkerDelimitedBlock(filePath: string, config: MarkerDelimitedBlockConfig): Promise<UninstallMarkerDelimitedBlockResult> {
+  const existing = await readInstructionFile(filePath);
+  if (!existing.exists) {
+    return { filePath, removed: false };
+  }
+  const removed = removeMarkerDelimitedBlock(existing.text, config);
+  if (!removed.removed) {
+    return { filePath, removed: false };
+  }
+  if (removed.text.trim()) {
+    await writeFile(filePath, `${removed.text.trim()}\n`, "utf8");
+  } else {
+    await rm(filePath, { force: true });
+  }
+  return { filePath, removed: true };
+}

--- a/src/hosts/zed/index.ts
+++ b/src/hosts/zed/index.ts
@@ -1,5 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+
+import {
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  readInstructionFile,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
 
 export type ZedInstructionsOptions = {
   projectDir?: string;
@@ -28,6 +34,7 @@ export type ZedDoctorReport = {
 const TOKENJUICE_ZED_FIX_COMMAND = "tokenjuice install zed";
 const TOKENJUICE_ZED_BEGIN = "<!-- tokenjuice:begin -->";
 const TOKENJUICE_ZED_END = "<!-- tokenjuice:end -->";
+const TOKENJUICE_ZED_ADVISORY = "Zed support is beta and rule-based; it guides command usage but does not intercept tool output.";
 
 function getProjectDir(options: ZedInstructionsOptions = {}): string {
   return options.projectDir || process.env.ZED_PROJECT_DIR || process.cwd();
@@ -37,86 +44,38 @@ function getDefaultInstructionsPath(options: ZedInstructionsOptions = {}): strin
   return join(getProjectDir(options), ".rules");
 }
 
-function buildZedBlock(): string {
-  return [
-    TOKENJUICE_ZED_BEGIN,
-    "## tokenjuice terminal output compaction",
-    "",
-    "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-    "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-    "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-    "- Do not suggest both raw and full reruns; use the raw escape hatch.",
-    TOKENJUICE_ZED_END,
-  ].join("\n");
-}
+const TOKENJUICE_ZED_BLOCK = [
+  TOKENJUICE_ZED_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
+  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
+  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
+  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  TOKENJUICE_ZED_END,
+].join("\n");
 
-async function readInstructions(instructionsPath: string): Promise<{ text: string; exists: boolean }> {
-  try {
-    return { text: await readFile(instructionsPath, "utf8"), exists: true };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { text: "", exists: false };
-    }
-    throw error;
-  }
-}
-
-function removeTokenjuiceBlock(text: string): { text: string; removed: boolean } {
-  const pattern = new RegExp(`\\n?${TOKENJUICE_ZED_BEGIN}[\\s\\S]*?${TOKENJUICE_ZED_END}\\n?`, "u");
-  if (!pattern.test(text)) {
-    return { text, removed: false };
-  }
-  return {
-    text: text.replace(pattern, "\n").replace(/\n{3,}/gu, "\n\n").trim(),
-    removed: true,
-  };
-}
-
-function upsertTokenjuiceBlock(text: string): string {
-  const withoutBlock = removeTokenjuiceBlock(text).text.trim();
-  if (!withoutBlock) {
-    return `${buildZedBlock()}\n`;
-  }
-  return `${withoutBlock}\n\n${buildZedBlock()}\n`;
-}
+const TOKENJUICE_ZED_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_ZED_BEGIN,
+  endMarker: TOKENJUICE_ZED_END,
+  block: TOKENJUICE_ZED_BLOCK,
+};
 
 export async function installZedInstructions(
   instructionsPath?: string,
   options: ZedInstructionsOptions = {},
 ): Promise<InstallZedInstructionsResult> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  let backupPath: string | undefined;
-  if (existing.exists) {
-    backupPath = `${resolvedInstructionsPath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
-  }
-
-  await mkdir(dirname(resolvedInstructionsPath), { recursive: true });
-  const tempPath = `${resolvedInstructionsPath}.tmp`;
-  await writeFile(tempPath, upsertTokenjuiceBlock(existing.text), "utf8");
-  await rename(tempPath, resolvedInstructionsPath);
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_ZED_BLOCK_CONFIG);
   return {
-    instructionsPath: resolvedInstructionsPath,
-    ...(backupPath ? { backupPath } : {}),
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
   };
 }
 
 export async function uninstallZedInstructions(instructionsPath = getDefaultInstructionsPath()): Promise<UninstallZedInstructionsResult> {
-  const existing = await readInstructions(instructionsPath);
-  if (!existing.exists) {
-    return { instructionsPath, removed: false };
-  }
-  const removed = removeTokenjuiceBlock(existing.text);
-  if (!removed.removed) {
-    return { instructionsPath, removed: false };
-  }
-  if (removed.text.trim()) {
-    await writeFile(instructionsPath, `${removed.text.trim()}\n`, "utf8");
-  } else {
-    await rm(instructionsPath, { force: true });
-  }
-  return { instructionsPath, removed: true };
+  const result = await uninstallMarkerDelimitedBlock(instructionsPath, TOKENJUICE_ZED_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
 }
 
 export async function doctorZedInstructions(
@@ -124,28 +83,34 @@ export async function doctorZedInstructions(
   options: ZedInstructionsOptions = {},
 ): Promise<ZedDoctorReport> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  if (!existing.exists || !existing.text.includes(TOKENJUICE_ZED_BEGIN)) {
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_ZED_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
       status: "disabled",
       issues: ["tokenjuice Zed rules are not installed"],
-      advisories: ["Zed support is beta and rule-based; it guides command usage but does not intercept tool output."],
+      advisories: [TOKENJUICE_ZED_ADVISORY],
       fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
       checkedPaths: [],
       missingPaths: [],
     };
   }
 
-  const issues = existing.text.includes(TOKENJUICE_ZED_END)
-    ? []
-    : ["configured Zed rules have a tokenjuice start marker without an end marker"];
+  const issues: string[] = [];
+  if (markerState.hasBegin && !markerState.hasEnd) {
+    issues.push("configured Zed rules have a tokenjuice start marker without an end marker");
+  } else if (!markerState.hasBegin && markerState.hasEnd) {
+    issues.push("configured Zed rules have a tokenjuice end marker without a start marker");
+  } else if (markerState.completeBlockCount !== 1) {
+    issues.push("configured Zed rules have multiple tokenjuice blocks; run tokenjuice install zed to repair");
+  }
 
   return {
     instructionsPath: resolvedInstructionsPath,
     status: issues.length > 0 ? "broken" : "ok",
     issues,
-    advisories: ["Zed support is beta and rule-based; it guides command usage but does not intercept tool output."],
+    advisories: [TOKENJUICE_ZED_ADVISORY],
     fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
     checkedPaths: [],
     missingPaths: [],

--- a/test/hosts/zed.test.ts
+++ b/test/hosts/zed.test.ts
@@ -29,6 +29,10 @@ async function createTempDir(): Promise<string> {
 }
 
 describe("zed rules", () => {
+  function countTokenjuiceBlocks(text: string): number {
+    return text.match(/<!-- tokenjuice:begin -->/gu)?.length ?? 0;
+  }
+
   it("installs a marker-delimited rule block", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, ".rules");
@@ -60,6 +64,35 @@ describe("zed rules", () => {
     expect(instructions).toContain("<!-- tokenjuice:begin -->");
   });
 
+  it("replaces stale tokenjuice rules without duplicating the block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".rules");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project rules",
+        "",
+        "- keep this",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "another stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installZedInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("- keep this");
+    expect(instructions).not.toContain("stale tokenjuice block");
+    expect(countTokenjuiceBlocks(instructions)).toBe(1);
+  });
+
   it("reports installed and uninstalled rule health", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, ".rules");
@@ -75,6 +108,29 @@ describe("zed rules", () => {
 
     expect(removed.removed).toBe(true);
     expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken rules with unmatched tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".rules");
+    await writeFile(instructionsPath, "<!-- tokenjuice:begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorZedInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+  });
+
+  it("leaves unrelated rules untouched when uninstall finds no tokenjuice block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".rules");
+    await writeFile(instructionsPath, "# project rules\n\n- keep this\n", "utf8");
+
+    const removed = await uninstallZedInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(removed.removed).toBe(false);
+    expect(instructions).toBe("# project rules\n\n- keep this\n");
   });
 
   it("uses ZED_PROJECT_DIR for the default rules file", async () => {


### PR DESCRIPTION
## Summary
- move marker-delimited rule file mechanics into a shared host helper
- refactor the Zed beta integration onto that helper without changing the install surface
- harden Zed doctor/install behavior for duplicate and malformed tokenjuice marker blocks
- add tests for stale block replacement, unmatched markers, and uninstall no-op preservation

## Test plan
- pnpm exec vitest run test/hosts/zed.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify