### PR TITLE
refactor(avante): harden instructions integration

### DIFF
--- a/src/hosts/avante/index.ts
+++ b/src/hosts/avante/index.ts
@@ -1,5 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+
+import {
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  readInstructionFile,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
 
 export type AvanteInstructionsOptions = {
   projectDir?: string;
@@ -28,6 +34,7 @@ export type AvanteDoctorReport = {
 const TOKENJUICE_AVANTE_FIX_COMMAND = "tokenjuice install avante";
 const TOKENJUICE_AVANTE_BEGIN = "<!-- tokenjuice:begin -->";
 const TOKENJUICE_AVANTE_END = "<!-- tokenjuice:end -->";
+const TOKENJUICE_AVANTE_ADVISORY = "Avante support is beta and instruction-based; it guides command usage but does not intercept tool output.";
 
 function getProjectDir(options: AvanteInstructionsOptions = {}): string {
   return options.projectDir || process.env.AVANTE_PROJECT_DIR || process.cwd();
@@ -37,86 +44,38 @@ function getDefaultInstructionsPath(options: AvanteInstructionsOptions = {}): st
   return join(getProjectDir(options), "avante.md");
 }
 
-function buildAvanteBlock(): string {
-  return [
-    TOKENJUICE_AVANTE_BEGIN,
-    "## tokenjuice terminal output compaction",
-    "",
-    "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-    "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-    "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-    "- Do not suggest both raw and full reruns; use the raw escape hatch.",
-    TOKENJUICE_AVANTE_END,
-  ].join("\n");
-}
+const TOKENJUICE_AVANTE_BLOCK = [
+  TOKENJUICE_AVANTE_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
+  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
+  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
+  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  TOKENJUICE_AVANTE_END,
+].join("\n");
 
-async function readInstructions(instructionsPath: string): Promise<{ text: string; exists: boolean }> {
-  try {
-    return { text: await readFile(instructionsPath, "utf8"), exists: true };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { text: "", exists: false };
-    }
-    throw error;
-  }
-}
-
-function removeTokenjuiceBlock(text: string): { text: string; removed: boolean } {
-  const pattern = new RegExp(`\\n?${TOKENJUICE_AVANTE_BEGIN}[\\s\\S]*?${TOKENJUICE_AVANTE_END}\\n?`, "u");
-  if (!pattern.test(text)) {
-    return { text, removed: false };
-  }
-  return {
-    text: text.replace(pattern, "\n").replace(/\n{3,}/gu, "\n\n").trim(),
-    removed: true,
-  };
-}
-
-function upsertTokenjuiceBlock(text: string): string {
-  const withoutBlock = removeTokenjuiceBlock(text).text.trim();
-  if (!withoutBlock) {
-    return `${buildAvanteBlock()}\n`;
-  }
-  return `${withoutBlock}\n\n${buildAvanteBlock()}\n`;
-}
+const TOKENJUICE_AVANTE_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_AVANTE_BEGIN,
+  endMarker: TOKENJUICE_AVANTE_END,
+  block: TOKENJUICE_AVANTE_BLOCK,
+};
 
 export async function installAvanteInstructions(
   instructionsPath?: string,
   options: AvanteInstructionsOptions = {},
 ): Promise<InstallAvanteInstructionsResult> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  let backupPath: string | undefined;
-  if (existing.exists) {
-    backupPath = `${resolvedInstructionsPath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
-  }
-
-  await mkdir(dirname(resolvedInstructionsPath), { recursive: true });
-  const tempPath = `${resolvedInstructionsPath}.tmp`;
-  await writeFile(tempPath, upsertTokenjuiceBlock(existing.text), "utf8");
-  await rename(tempPath, resolvedInstructionsPath);
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_AVANTE_BLOCK_CONFIG);
   return {
-    instructionsPath: resolvedInstructionsPath,
-    ...(backupPath ? { backupPath } : {}),
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
   };
 }
 
 export async function uninstallAvanteInstructions(instructionsPath = getDefaultInstructionsPath()): Promise<UninstallAvanteInstructionsResult> {
-  const existing = await readInstructions(instructionsPath);
-  if (!existing.exists) {
-    return { instructionsPath, removed: false };
-  }
-  const removed = removeTokenjuiceBlock(existing.text);
-  if (!removed.removed) {
-    return { instructionsPath, removed: false };
-  }
-  if (removed.text.trim()) {
-    await writeFile(instructionsPath, `${removed.text.trim()}\n`, "utf8");
-  } else {
-    await rm(instructionsPath, { force: true });
-  }
-  return { instructionsPath, removed: true };
+  const result = await uninstallMarkerDelimitedBlock(instructionsPath, TOKENJUICE_AVANTE_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
 }
 
 export async function doctorAvanteInstructions(
@@ -124,28 +83,34 @@ export async function doctorAvanteInstructions(
   options: AvanteInstructionsOptions = {},
 ): Promise<AvanteDoctorReport> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  if (!existing.exists || !existing.text.includes(TOKENJUICE_AVANTE_BEGIN)) {
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_AVANTE_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
       status: "disabled",
       issues: ["tokenjuice Avante instructions are not installed"],
-      advisories: ["Avante support is beta and instruction-based; it guides command usage but does not intercept tool output."],
+      advisories: [TOKENJUICE_AVANTE_ADVISORY],
       fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
       checkedPaths: [],
       missingPaths: [],
     };
   }
 
-  const issues = existing.text.includes(TOKENJUICE_AVANTE_END)
-    ? []
-    : ["configured Avante instructions have a tokenjuice start marker without an end marker"];
+  const issues: string[] = [];
+  if (markerState.hasBegin && !markerState.hasEnd) {
+    issues.push("configured Avante instructions have a tokenjuice start marker without an end marker");
+  } else if (!markerState.hasBegin && markerState.hasEnd) {
+    issues.push("configured Avante instructions have a tokenjuice end marker without a start marker");
+  } else if (markerState.completeBlockCount !== 1) {
+    issues.push("configured Avante instructions have multiple tokenjuice blocks; run tokenjuice install avante to repair");
+  }
 
   return {
     instructionsPath: resolvedInstructionsPath,
     status: issues.length > 0 ? "broken" : "ok",
     issues,
-    advisories: ["Avante support is beta and instruction-based; it guides command usage but does not intercept tool output."],
+    advisories: [TOKENJUICE_AVANTE_ADVISORY],
     fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
     checkedPaths: [],
     missingPaths: [],

--- a/test/hosts/avante.test.ts
+++ b/test/hosts/avante.test.ts
@@ -29,6 +29,10 @@ async function createTempDir(): Promise<string> {
 }
 
 describe("avante instructions", () => {
+  function countTokenjuiceBlocks(text: string): number {
+    return text.match(/<!-- tokenjuice:begin -->/gu)?.length ?? 0;
+  }
+
   it("installs a marker-delimited instruction block", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, "avante.md");
@@ -60,6 +64,35 @@ describe("avante instructions", () => {
     expect(instructions).toContain("<!-- tokenjuice:begin -->");
   });
 
+  it("replaces stale tokenjuice instructions without duplicating the block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "avante.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "- keep this",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "another stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installAvanteInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("- keep this");
+    expect(instructions).not.toContain("stale tokenjuice block");
+    expect(countTokenjuiceBlocks(instructions)).toBe(1);
+  });
+
   it("reports installed and uninstalled instruction health", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, "avante.md");
@@ -75,6 +108,29 @@ describe("avante instructions", () => {
 
     expect(removed.removed).toBe(true);
     expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken instructions with unmatched tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "avante.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorAvanteInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+  });
+
+  it("leaves unrelated instructions untouched when uninstall finds no tokenjuice block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "avante.md");
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const removed = await uninstallAvanteInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(removed.removed).toBe(false);
+    expect(instructions).toBe("# project instructions\n\n- keep this\n");
   });
 
   it("uses AVANTE_PROJECT_DIR for the default instructions file", async () => {


### PR DESCRIPTION
## Summary
- refactor the Avante beta integration onto the shared marker-delimited instructions helper
- preserve the existing install, uninstall, and doctor surface while removing duplicated file-marker logic
- harden Avante doctor/install behavior for duplicate and malformed tokenjuice marker blocks
- add tests for stale block replacement, unmatched markers, and uninstall no-op preservation

## Test plan
- pnpm exec vitest run test/hosts/avante.test.ts test/hosts/zed.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify