### PR TITLE
refactor(junie): harden instructions integration

### DIFF
--- a/src/hosts/junie/index.ts
+++ b/src/hosts/junie/index.ts
@@ -1,5 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+
+import {
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  readInstructionFile,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
 
 export type JunieInstructionsOptions = {
   projectDir?: string;
@@ -28,6 +34,7 @@ export type JunieDoctorReport = {
 const TOKENJUICE_JUNIE_FIX_COMMAND = "tokenjuice install junie";
 const TOKENJUICE_JUNIE_BEGIN = "<!-- tokenjuice:begin -->";
 const TOKENJUICE_JUNIE_END = "<!-- tokenjuice:end -->";
+const TOKENJUICE_JUNIE_ADVISORY = "Junie support is beta and instruction-based; it guides command usage but does not intercept tool output.";
 
 function getProjectDir(options: JunieInstructionsOptions = {}): string {
   return options.projectDir || process.env.JUNIE_PROJECT_DIR || process.cwd();
@@ -37,86 +44,38 @@ function getDefaultInstructionsPath(options: JunieInstructionsOptions = {}): str
   return join(getProjectDir(options), ".junie", "AGENTS.md");
 }
 
-function buildJunieBlock(): string {
-  return [
-    TOKENJUICE_JUNIE_BEGIN,
-    "## tokenjuice terminal output compaction",
-    "",
-    "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-    "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-    "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-    "- Do not suggest both raw and full reruns; use the raw escape hatch.",
-    TOKENJUICE_JUNIE_END,
-  ].join("\n");
-}
+const TOKENJUICE_JUNIE_BLOCK = [
+  TOKENJUICE_JUNIE_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
+  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
+  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
+  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  TOKENJUICE_JUNIE_END,
+].join("\n");
 
-async function readInstructions(instructionsPath: string): Promise<{ text: string; exists: boolean }> {
-  try {
-    return { text: await readFile(instructionsPath, "utf8"), exists: true };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { text: "", exists: false };
-    }
-    throw error;
-  }
-}
-
-function removeTokenjuiceBlock(text: string): { text: string; removed: boolean } {
-  const pattern = new RegExp(`\\n?${TOKENJUICE_JUNIE_BEGIN}[\\s\\S]*?${TOKENJUICE_JUNIE_END}\\n?`, "u");
-  if (!pattern.test(text)) {
-    return { text, removed: false };
-  }
-  return {
-    text: text.replace(pattern, "\n").replace(/\n{3,}/gu, "\n\n").trim(),
-    removed: true,
-  };
-}
-
-function upsertTokenjuiceBlock(text: string): string {
-  const withoutBlock = removeTokenjuiceBlock(text).text.trim();
-  if (!withoutBlock) {
-    return `${buildJunieBlock()}\n`;
-  }
-  return `${withoutBlock}\n\n${buildJunieBlock()}\n`;
-}
+const TOKENJUICE_JUNIE_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_JUNIE_BEGIN,
+  endMarker: TOKENJUICE_JUNIE_END,
+  block: TOKENJUICE_JUNIE_BLOCK,
+};
 
 export async function installJunieInstructions(
   instructionsPath?: string,
   options: JunieInstructionsOptions = {},
 ): Promise<InstallJunieInstructionsResult> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  let backupPath: string | undefined;
-  if (existing.exists) {
-    backupPath = `${resolvedInstructionsPath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
-  }
-
-  await mkdir(dirname(resolvedInstructionsPath), { recursive: true });
-  const tempPath = `${resolvedInstructionsPath}.tmp`;
-  await writeFile(tempPath, upsertTokenjuiceBlock(existing.text), "utf8");
-  await rename(tempPath, resolvedInstructionsPath);
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_JUNIE_BLOCK_CONFIG);
   return {
-    instructionsPath: resolvedInstructionsPath,
-    ...(backupPath ? { backupPath } : {}),
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
   };
 }
 
 export async function uninstallJunieInstructions(instructionsPath = getDefaultInstructionsPath()): Promise<UninstallJunieInstructionsResult> {
-  const existing = await readInstructions(instructionsPath);
-  if (!existing.exists) {
-    return { instructionsPath, removed: false };
-  }
-  const removed = removeTokenjuiceBlock(existing.text);
-  if (!removed.removed) {
-    return { instructionsPath, removed: false };
-  }
-  if (removed.text.trim()) {
-    await writeFile(instructionsPath, `${removed.text.trim()}\n`, "utf8");
-  } else {
-    await rm(instructionsPath, { force: true });
-  }
-  return { instructionsPath, removed: true };
+  const result = await uninstallMarkerDelimitedBlock(instructionsPath, TOKENJUICE_JUNIE_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
 }
 
 export async function doctorJunieInstructions(
@@ -124,28 +83,34 @@ export async function doctorJunieInstructions(
   options: JunieInstructionsOptions = {},
 ): Promise<JunieDoctorReport> {
   const resolvedInstructionsPath = instructionsPath ?? getDefaultInstructionsPath(options);
-  const existing = await readInstructions(resolvedInstructionsPath);
-  if (!existing.exists || !existing.text.includes(TOKENJUICE_JUNIE_BEGIN)) {
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_JUNIE_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
       status: "disabled",
       issues: ["tokenjuice Junie instructions are not installed"],
-      advisories: ["Junie support is beta and instruction-based; it guides command usage but does not intercept tool output."],
+      advisories: [TOKENJUICE_JUNIE_ADVISORY],
       fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
       checkedPaths: [],
       missingPaths: [],
     };
   }
 
-  const issues = existing.text.includes(TOKENJUICE_JUNIE_END)
-    ? []
-    : ["configured Junie instructions have a tokenjuice start marker without an end marker"];
+  const issues: string[] = [];
+  if (markerState.hasBegin && !markerState.hasEnd) {
+    issues.push("configured Junie instructions have a tokenjuice start marker without an end marker");
+  } else if (!markerState.hasBegin && markerState.hasEnd) {
+    issues.push("configured Junie instructions have a tokenjuice end marker without a start marker");
+  } else if (markerState.completeBlockCount !== 1) {
+    issues.push("configured Junie instructions have multiple tokenjuice blocks; run tokenjuice install junie to repair");
+  }
 
   return {
     instructionsPath: resolvedInstructionsPath,
     status: issues.length > 0 ? "broken" : "ok",
     issues,
-    advisories: ["Junie support is beta and instruction-based; it guides command usage but does not intercept tool output."],
+    advisories: [TOKENJUICE_JUNIE_ADVISORY],
     fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
     checkedPaths: [],
     missingPaths: [],

--- a/test/hosts/junie.test.ts
+++ b/test/hosts/junie.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -29,6 +29,10 @@ async function createTempDir(): Promise<string> {
 }
 
 describe("junie instructions", () => {
+  function countTokenjuiceBlocks(text: string): number {
+    return text.match(/<!-- tokenjuice:begin -->/gu)?.length ?? 0;
+  }
+
   it("installs a marker-delimited instruction block", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, ".junie", "AGENTS.md");
@@ -60,6 +64,36 @@ describe("junie instructions", () => {
     expect(instructions).toContain("<!-- tokenjuice:begin -->");
   });
 
+  it("replaces stale tokenjuice instructions without duplicating the block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".junie", "AGENTS.md");
+    await mkdir(join(home, ".junie"), { recursive: true });
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "- keep this",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "another stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installJunieInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("- keep this");
+    expect(instructions).not.toContain("stale tokenjuice block");
+    expect(countTokenjuiceBlocks(instructions)).toBe(1);
+  });
+
   it("reports installed and uninstalled instruction health", async () => {
     const home = await createTempDir();
     const instructionsPath = join(home, ".junie", "AGENTS.md");
@@ -75,6 +109,31 @@ describe("junie instructions", () => {
 
     expect(removed.removed).toBe(true);
     expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken instructions with unmatched tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".junie", "AGENTS.md");
+    await mkdir(join(home, ".junie"), { recursive: true });
+    await writeFile(instructionsPath, "<!-- tokenjuice:begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorJunieInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+  });
+
+  it("leaves unrelated instructions untouched when uninstall finds no tokenjuice block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, ".junie", "AGENTS.md");
+    await mkdir(join(home, ".junie"), { recursive: true });
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const removed = await uninstallJunieInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(removed.removed).toBe(false);
+    expect(instructions).toBe("# project instructions\n\n- keep this\n");
   });
 
   it("uses JUNIE_PROJECT_DIR for the default instructions file", async () => {


### PR DESCRIPTION
## Summary
- refactor the Junie beta integration onto the shared marker-delimited instructions helper
- preserve the existing install, uninstall, and doctor surface while removing duplicated file-marker logic
- harden Junie doctor/install behavior for duplicate and malformed tokenjuice marker blocks
- add tests for stale block replacement, unmatched markers, and uninstall no-op preservation

## Test plan
- pnpm exec vitest run test/hosts/junie.test.ts test/hosts/zed.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify