### PR TITLE
refactor(aider): harden convention integration

### DIFF
--- a/src/hosts/aider/index.ts
+++ b/src/hosts/aider/index.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
+
+import { readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
 
 export type AiderConventionOptions = {
   projectDir?: string;
@@ -27,6 +28,9 @@ export type AiderDoctorReport = {
 
 const TOKENJUICE_AIDER_FIX_COMMAND = "tokenjuice install aider";
 const TOKENJUICE_AIDER_MARKER = "tokenjuice terminal output compaction";
+const TOKENJUICE_AIDER_ADVISORY = "Aider support is beta and convention-based; load it with aider --read CONVENTIONS.tokenjuice.md.";
+const TOKENJUICE_AIDER_WRAP_COMMAND = "tokenjuice wrap -- <command>";
+const TOKENJUICE_AIDER_RAW_COMMAND = "tokenjuice wrap --raw -- <command>";
 
 function getProjectDir(options: AiderConventionOptions = {}): string {
   return options.projectDir || process.env.AIDER_PROJECT_DIR || process.cwd();
@@ -36,59 +40,33 @@ function getDefaultConventionPath(options: AiderConventionOptions = {}): string 
   return join(getProjectDir(options), "CONVENTIONS.tokenjuice.md");
 }
 
-function buildAiderConvention(): string {
-  return [
-    `# ${TOKENJUICE_AIDER_MARKER}`,
-    "",
-    "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-    "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-    "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-    "- Do not suggest both raw and full reruns; use the raw escape hatch.",
-    "",
-    "Load this file with `aider --read CONVENTIONS.tokenjuice.md` or add it to `.aider.conf.yml`.",
-    "",
-  ].join("\n");
-}
-
-async function readConvention(conventionPath: string): Promise<{ text: string; exists: boolean }> {
-  try {
-    return { text: await readFile(conventionPath, "utf8"), exists: true };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { text: "", exists: false };
-    }
-    throw error;
-  }
-}
+const TOKENJUICE_AIDER_CONVENTION = [
+  `# ${TOKENJUICE_AIDER_MARKER}`,
+  "",
+  `- For terminal commands likely to produce long output, run them through \`${TOKENJUICE_AIDER_WRAP_COMMAND}\`.`,
+  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
+  `- If raw bytes are required, rerun the command with exactly \`${TOKENJUICE_AIDER_RAW_COMMAND}\`.`,
+  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  "",
+  "Load this file with `aider --read CONVENTIONS.tokenjuice.md` or add it to `.aider.conf.yml`.",
+  "",
+].join("\n");
 
 export async function installAiderConvention(
   conventionPath?: string,
   options: AiderConventionOptions = {},
 ): Promise<InstallAiderConventionResult> {
   const resolvedConventionPath = conventionPath ?? getDefaultConventionPath(options);
-  const existing = await readConvention(resolvedConventionPath);
-  let backupPath: string | undefined;
-  if (existing.exists) {
-    backupPath = `${resolvedConventionPath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
-  }
-
-  await mkdir(dirname(resolvedConventionPath), { recursive: true });
-  const tempPath = `${resolvedConventionPath}.tmp`;
-  await writeFile(tempPath, buildAiderConvention(), "utf8");
-  await rename(tempPath, resolvedConventionPath);
+  const result = await writeInstructionFile(resolvedConventionPath, TOKENJUICE_AIDER_CONVENTION);
   return {
-    conventionPath: resolvedConventionPath,
-    ...(backupPath ? { backupPath } : {}),
+    conventionPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
   };
 }
 
 export async function uninstallAiderConvention(conventionPath = getDefaultConventionPath()): Promise<UninstallAiderConventionResult> {
-  const existing = await readConvention(conventionPath);
-  if (existing.exists) {
-    await rm(conventionPath, { force: true });
-  }
-  return { conventionPath, removed: existing.exists };
+  const result = await removeInstructionFile(conventionPath);
+  return { conventionPath: result.filePath, removed: result.removed };
 }
 
 export async function doctorAiderConvention(
@@ -96,28 +74,38 @@ export async function doctorAiderConvention(
   options: AiderConventionOptions = {},
 ): Promise<AiderDoctorReport> {
   const resolvedConventionPath = conventionPath ?? getDefaultConventionPath(options);
-  const existing = await readConvention(resolvedConventionPath);
+  const existing = await readInstructionFile(resolvedConventionPath);
   if (!existing.exists) {
     return {
       conventionPath: resolvedConventionPath,
       status: "disabled",
       issues: ["tokenjuice Aider convention file is not installed"],
-      advisories: ["Aider support is beta and convention-based; load it with aider --read CONVENTIONS.tokenjuice.md."],
+      advisories: [TOKENJUICE_AIDER_ADVISORY],
       fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
       checkedPaths: [],
       missingPaths: [],
     };
   }
 
-  const issues = existing.text.includes(TOKENJUICE_AIDER_MARKER)
-    ? []
-    : ["configured Aider convention file does not look like the tokenjuice convention"];
+  const issues: string[] = [];
+  if (!existing.text.includes(TOKENJUICE_AIDER_MARKER)) {
+    issues.push("configured Aider convention file does not look like the tokenjuice convention");
+  }
+  if (!existing.text.includes(TOKENJUICE_AIDER_WRAP_COMMAND)) {
+    issues.push("configured Aider convention file is missing tokenjuice wrap guidance");
+  }
+  if (!existing.text.includes(TOKENJUICE_AIDER_RAW_COMMAND)) {
+    issues.push("configured Aider convention file is missing the raw escape hatch");
+  }
+  if (existing.text.includes("tokenjuice wrap --full -- <command>")) {
+    issues.push("configured Aider convention file still suggests the full escape hatch");
+  }
 
   return {
     conventionPath: resolvedConventionPath,
     status: issues.length > 0 ? "broken" : "ok",
     issues,
-    advisories: ["Aider support is beta and convention-based; load it with aider --read CONVENTIONS.tokenjuice.md."],
+    advisories: [TOKENJUICE_AIDER_ADVISORY],
     fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
     checkedPaths: [],
     missingPaths: [],

--- a/src/hosts/shared/instruction-file.ts
+++ b/src/hosts/shared/instruction-file.ts
@@ -1,0 +1,54 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type InstructionFileSnapshot = {
+  text: string;
+  exists: boolean;
+};
+
+export type WriteInstructionFileResult = {
+  filePath: string;
+  backupPath?: string;
+};
+
+export type RemoveInstructionFileResult = {
+  filePath: string;
+  removed: boolean;
+};
+
+export async function readInstructionFile(filePath: string): Promise<InstructionFileSnapshot> {
+  try {
+    return { text: await readFile(filePath, "utf8"), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { text: "", exists: false };
+    }
+    throw error;
+  }
+}
+
+export async function writeInstructionFile(filePath: string, text: string): Promise<WriteInstructionFileResult> {
+  const existing = await readInstructionFile(filePath);
+  let backupPath: string | undefined;
+  if (existing.exists) {
+    backupPath = `${filePath}.bak`;
+    await writeFile(backupPath, existing.text, "utf8");
+  }
+
+  await mkdir(dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp`;
+  await writeFile(tempPath, text, "utf8");
+  await rename(tempPath, filePath);
+  return {
+    filePath,
+    ...(backupPath ? { backupPath } : {}),
+  };
+}
+
+export async function removeInstructionFile(filePath: string): Promise<RemoveInstructionFileResult> {
+  const existing = await readInstructionFile(filePath);
+  if (existing.exists) {
+    await rm(filePath, { force: true });
+  }
+  return { filePath, removed: existing.exists };
+}

--- a/src/hosts/shared/marker-instructions.ts
+++ b/src/hosts/shared/marker-instructions.ts
@@ -1,15 +1,13 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { rm, writeFile } from "node:fs/promises";
+
+import { readInstructionFile, writeInstructionFile } from "./instruction-file.js";
+
+export { readInstructionFile } from "./instruction-file.js";
 
 export type MarkerDelimitedBlockConfig = {
   beginMarker: string;
   endMarker: string;
   block: string;
-};
-
-export type InstructionFileSnapshot = {
-  text: string;
-  exists: boolean;
 };
 
 export type MarkerDelimitedBlockState = {
@@ -34,17 +32,6 @@ function escapeRegExp(value: string): string {
 
 function buildBlockPattern(config: MarkerDelimitedBlockConfig): RegExp {
   return new RegExp(`\\n?${escapeRegExp(config.beginMarker)}[\\s\\S]*?${escapeRegExp(config.endMarker)}\\n?`, "gu");
-}
-
-export async function readInstructionFile(filePath: string): Promise<InstructionFileSnapshot> {
-  try {
-    return { text: await readFile(filePath, "utf8"), exists: true };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { text: "", exists: false };
-    }
-    throw error;
-  }
 }
 
 export function inspectMarkerDelimitedBlock(text: string, config: MarkerDelimitedBlockConfig): MarkerDelimitedBlockState {
@@ -76,19 +63,10 @@ export function upsertMarkerDelimitedBlock(text: string, config: MarkerDelimited
 
 export async function installMarkerDelimitedBlock(filePath: string, config: MarkerDelimitedBlockConfig): Promise<InstallMarkerDelimitedBlockResult> {
   const existing = await readInstructionFile(filePath);
-  let backupPath: string | undefined;
-  if (existing.exists) {
-    backupPath = `${filePath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
-  }
-
-  await mkdir(dirname(filePath), { recursive: true });
-  const tempPath = `${filePath}.tmp`;
-  await writeFile(tempPath, upsertMarkerDelimitedBlock(existing.text, config), "utf8");
-  await rename(tempPath, filePath);
+  const result = await writeInstructionFile(filePath, upsertMarkerDelimitedBlock(existing.text, config));
   return {
-    filePath,
-    ...(backupPath ? { backupPath } : {}),
+    filePath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
   };
 }
 

--- a/test/hosts/aider.test.ts
+++ b/test/hosts/aider.test.ts
@@ -55,6 +55,7 @@ describe("aider conventions", () => {
 
     expect(result.backupPath).toBe(`${conventionPath}.bak`);
     await expect(readFile(`${conventionPath}.bak`, "utf8")).resolves.toBe("custom local convention\n");
+    await expect(readFile(conventionPath, "utf8")).resolves.toContain("tokenjuice wrap --raw -- <command>");
   });
 
   it("reports installed and uninstalled convention health", async () => {
@@ -72,6 +73,38 @@ describe("aider conventions", () => {
 
     expect(removed.removed).toBe(true);
     expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken conventions when required tokenjuice guidance is stale", async () => {
+    const home = await createTempDir();
+    const conventionPath = join(home, "CONVENTIONS.tokenjuice.md");
+    await writeFile(
+      conventionPath,
+      [
+        "# tokenjuice terminal output compaction",
+        "",
+        "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
+        "- If output looks wrong, rerun with `tokenjuice wrap --full -- <command>`.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorAiderConvention(conventionPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Aider convention file is missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Aider convention file still suggests the full escape hatch");
+  });
+
+  it("removes an existing convention file without requiring tokenjuice content", async () => {
+    const home = await createTempDir();
+    const conventionPath = join(home, "CONVENTIONS.tokenjuice.md");
+    await writeFile(conventionPath, "custom local convention\n", "utf8");
+
+    const removed = await uninstallAiderConvention(conventionPath);
+
+    expect(removed.removed).toBe(true);
+    await expect(access(conventionPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("uses AIDER_PROJECT_DIR for the default convention file", async () => {


### PR DESCRIPTION
## Summary
- extract generic instruction-file read/write/remove helpers for host integrations
- refactor the Aider beta integration onto the shared helper while preserving the install, uninstall, and doctor surface
- keep Zed marker handling compatible with the new helper
- harden Aider doctor checks for stale convention files that are missing raw guidance or still suggest full reruns
- add tests for replacement, stale guidance detection, and uninstall behavior

## Test plan
- pnpm exec vitest run test/hosts/aider.test.ts test/hosts/zed.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify