### PR TITLE
refactor(hosts): centralize instruction issue checks

### DIFF
--- a/src/hosts/aider/index.ts
+++ b/src/hosts/aider/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
 
 export type AiderConventionOptions = {
   projectDir?: string;
@@ -87,19 +87,28 @@ export async function doctorAiderConvention(
     };
   }
 
-  const issues: string[] = [];
-  if (!existing.text.includes(TOKENJUICE_AIDER_MARKER)) {
-    issues.push("configured Aider convention file does not look like the tokenjuice convention");
-  }
-  if (!existing.text.includes(TOKENJUICE_AIDER_WRAP_COMMAND)) {
-    issues.push("configured Aider convention file is missing tokenjuice wrap guidance");
-  }
-  if (!existing.text.includes(TOKENJUICE_AIDER_RAW_COMMAND)) {
-    issues.push("configured Aider convention file is missing the raw escape hatch");
-  }
-  if (existing.text.includes("tokenjuice wrap --full -- <command>")) {
-    issues.push("configured Aider convention file still suggests the full escape hatch");
-  }
+  const issues = collectGuidanceIssues(existing.text, {
+    required: [
+      {
+        requiredText: TOKENJUICE_AIDER_MARKER,
+        missingIssue: "configured Aider convention file does not look like the tokenjuice convention",
+      },
+      {
+        requiredText: TOKENJUICE_AIDER_WRAP_COMMAND,
+        missingIssue: "configured Aider convention file is missing tokenjuice wrap guidance",
+      },
+      {
+        requiredText: TOKENJUICE_AIDER_RAW_COMMAND,
+        missingIssue: "configured Aider convention file is missing the raw escape hatch",
+      },
+    ],
+    forbidden: [
+      {
+        forbiddenText: "tokenjuice wrap --full -- <command>",
+        presentIssue: "configured Aider convention file still suggests the full escape hatch",
+      },
+    ],
+  });
 
   return {
     conventionPath: resolvedConventionPath,

--- a/src/hosts/avante/index.ts
+++ b/src/hosts/avante/index.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
 
 import {
+  collectMarkerDelimitedBlockIssues,
   inspectMarkerDelimitedBlock,
   installMarkerDelimitedBlock,
-  readInstructionFile,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type AvanteInstructionsOptions = {
   projectDir?: string;
@@ -97,14 +98,10 @@ export async function doctorAvanteInstructions(
     };
   }
 
-  const issues: string[] = [];
-  if (markerState.hasBegin && !markerState.hasEnd) {
-    issues.push("configured Avante instructions have a tokenjuice start marker without an end marker");
-  } else if (!markerState.hasBegin && markerState.hasEnd) {
-    issues.push("configured Avante instructions have a tokenjuice end marker without a start marker");
-  } else if (markerState.completeBlockCount !== 1) {
-    issues.push("configured Avante instructions have multiple tokenjuice blocks; run tokenjuice install avante to repair");
-  }
+  const issues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Avante instructions",
+    repairCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
+  });
 
   return {
     instructionsPath: resolvedInstructionsPath,

--- a/src/hosts/continue/index.ts
+++ b/src/hosts/continue/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
 
 export type ContinueRuleOptions = {
   projectDir?: string;
@@ -87,19 +87,28 @@ export async function doctorContinueRule(
     };
   }
 
-  const issues: string[] = [];
-  if (!existing.text.includes(TOKENJUICE_CONTINUE_RULE_MARKER)) {
-    issues.push("configured Continue rule file does not look like the tokenjuice rule");
-  }
-  if (!existing.text.includes(TOKENJUICE_CONTINUE_WRAP_COMMAND)) {
-    issues.push("configured Continue rule file is missing tokenjuice wrap guidance");
-  }
-  if (!existing.text.includes(TOKENJUICE_CONTINUE_RAW_COMMAND)) {
-    issues.push("configured Continue rule file is missing the raw escape hatch");
-  }
-  if (existing.text.includes("tokenjuice wrap --full -- <command>")) {
-    issues.push("configured Continue rule file still suggests the full escape hatch");
-  }
+  const issues = collectGuidanceIssues(existing.text, {
+    required: [
+      {
+        requiredText: TOKENJUICE_CONTINUE_RULE_MARKER,
+        missingIssue: "configured Continue rule file does not look like the tokenjuice rule",
+      },
+      {
+        requiredText: TOKENJUICE_CONTINUE_WRAP_COMMAND,
+        missingIssue: "configured Continue rule file is missing tokenjuice wrap guidance",
+      },
+      {
+        requiredText: TOKENJUICE_CONTINUE_RAW_COMMAND,
+        missingIssue: "configured Continue rule file is missing the raw escape hatch",
+      },
+    ],
+    forbidden: [
+      {
+        forbiddenText: "tokenjuice wrap --full -- <command>",
+        presentIssue: "configured Continue rule file still suggests the full escape hatch",
+      },
+    ],
+  });
 
   return {
     rulePath: resolvedRulePath,

--- a/src/hosts/junie/index.ts
+++ b/src/hosts/junie/index.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
 
 import {
+  collectMarkerDelimitedBlockIssues,
   inspectMarkerDelimitedBlock,
   installMarkerDelimitedBlock,
-  readInstructionFile,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type JunieInstructionsOptions = {
   projectDir?: string;
@@ -97,14 +98,10 @@ export async function doctorJunieInstructions(
     };
   }
 
-  const issues: string[] = [];
-  if (markerState.hasBegin && !markerState.hasEnd) {
-    issues.push("configured Junie instructions have a tokenjuice start marker without an end marker");
-  } else if (!markerState.hasBegin && markerState.hasEnd) {
-    issues.push("configured Junie instructions have a tokenjuice end marker without a start marker");
-  } else if (markerState.completeBlockCount !== 1) {
-    issues.push("configured Junie instructions have multiple tokenjuice blocks; run tokenjuice install junie to repair");
-  }
+  const issues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Junie instructions",
+    repairCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
+  });
 
   return {
     instructionsPath: resolvedInstructionsPath,

--- a/src/hosts/shared/instruction-file.ts
+++ b/src/hosts/shared/instruction-file.ts
@@ -16,6 +16,21 @@ export type RemoveInstructionFileResult = {
   removed: boolean;
 };
 
+export type GuidanceIssueCheck = {
+  requiredText: string;
+  missingIssue: string;
+};
+
+export type ForbiddenGuidanceCheck = {
+  forbiddenText: string;
+  presentIssue: string;
+};
+
+export type GuidanceIssueOptions = {
+  required: GuidanceIssueCheck[];
+  forbidden?: ForbiddenGuidanceCheck[];
+};
+
 export async function readInstructionFile(filePath: string): Promise<InstructionFileSnapshot> {
   try {
     return { text: await readFile(filePath, "utf8"), exists: true };
@@ -51,4 +66,19 @@ export async function removeInstructionFile(filePath: string): Promise<RemoveIns
     await rm(filePath, { force: true });
   }
   return { filePath, removed: existing.exists };
+}
+
+export function collectGuidanceIssues(text: string, options: GuidanceIssueOptions): string[] {
+  const issues: string[] = [];
+  for (const check of options.required) {
+    if (!text.includes(check.requiredText)) {
+      issues.push(check.missingIssue);
+    }
+  }
+  for (const check of options.forbidden ?? []) {
+    if (text.includes(check.forbiddenText)) {
+      issues.push(check.presentIssue);
+    }
+  }
+  return issues;
 }

--- a/src/hosts/shared/marker-instructions.ts
+++ b/src/hosts/shared/marker-instructions.ts
@@ -2,8 +2,6 @@ import { rm, writeFile } from "node:fs/promises";
 
 import { readInstructionFile, writeInstructionFile } from "./instruction-file.js";
 
-export { readInstructionFile } from "./instruction-file.js";
-
 export type MarkerDelimitedBlockConfig = {
   beginMarker: string;
   endMarker: string;
@@ -14,6 +12,11 @@ export type MarkerDelimitedBlockState = {
   hasBegin: boolean;
   hasEnd: boolean;
   completeBlockCount: number;
+};
+
+export type MarkerDelimitedBlockIssueOptions = {
+  configuredLabel: string;
+  repairCommand: string;
 };
 
 export type InstallMarkerDelimitedBlockResult = {
@@ -40,6 +43,22 @@ export function inspectMarkerDelimitedBlock(text: string, config: MarkerDelimite
     hasEnd: text.includes(config.endMarker),
     completeBlockCount: [...text.matchAll(buildBlockPattern(config))].length,
   };
+}
+
+export function collectMarkerDelimitedBlockIssues(
+  state: MarkerDelimitedBlockState,
+  options: MarkerDelimitedBlockIssueOptions,
+): string[] {
+  if (state.hasBegin && !state.hasEnd) {
+    return [`configured ${options.configuredLabel} have a tokenjuice start marker without an end marker`];
+  }
+  if (!state.hasBegin && state.hasEnd) {
+    return [`configured ${options.configuredLabel} have a tokenjuice end marker without a start marker`];
+  }
+  if (state.completeBlockCount !== 1) {
+    return [`configured ${options.configuredLabel} have multiple tokenjuice blocks; run ${options.repairCommand} to repair`];
+  }
+  return [];
 }
 
 export function removeMarkerDelimitedBlock(text: string, config: MarkerDelimitedBlockConfig): { text: string; removed: boolean } {

--- a/src/hosts/zed/index.ts
+++ b/src/hosts/zed/index.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
 
 import {
+  collectMarkerDelimitedBlockIssues,
   inspectMarkerDelimitedBlock,
   installMarkerDelimitedBlock,
-  readInstructionFile,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type ZedInstructionsOptions = {
   projectDir?: string;
@@ -97,14 +98,10 @@ export async function doctorZedInstructions(
     };
   }
 
-  const issues: string[] = [];
-  if (markerState.hasBegin && !markerState.hasEnd) {
-    issues.push("configured Zed rules have a tokenjuice start marker without an end marker");
-  } else if (!markerState.hasBegin && markerState.hasEnd) {
-    issues.push("configured Zed rules have a tokenjuice end marker without a start marker");
-  } else if (markerState.completeBlockCount !== 1) {
-    issues.push("configured Zed rules have multiple tokenjuice blocks; run tokenjuice install zed to repair");
-  }
+  const issues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Zed rules",
+    repairCommand: TOKENJUICE_ZED_FIX_COMMAND,
+  });
 
   return {
     instructionsPath: resolvedInstructionsPath,

--- a/test/hosts/shared/instruction-file.test.ts
+++ b/test/hosts/shared/instruction-file.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { collectGuidanceIssues } from "../../../src/hosts/shared/instruction-file.js";
+
+describe("collectGuidanceIssues", () => {
+  it("reports missing required guidance and present forbidden guidance in order", () => {
+    const issues = collectGuidanceIssues("marker\nuse `tokenjuice wrap -- <command>`\nuse `tokenjuice wrap --full -- <command>`", {
+      required: [
+        { requiredText: "marker", missingIssue: "missing marker" },
+        { requiredText: "tokenjuice wrap -- <command>", missingIssue: "missing wrap" },
+        { requiredText: "tokenjuice wrap --raw -- <command>", missingIssue: "missing raw" },
+      ],
+      forbidden: [
+        { forbiddenText: "tokenjuice wrap --full -- <command>", presentIssue: "has full" },
+      ],
+    });
+
+    expect(issues).toEqual(["missing raw", "has full"]);
+  });
+});

--- a/test/hosts/shared/marker-instructions.test.ts
+++ b/test/hosts/shared/marker-instructions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+} from "../../../src/hosts/shared/marker-instructions.js";
+
+const config = {
+  beginMarker: "<!-- tokenjuice:begin -->",
+  endMarker: "<!-- tokenjuice:end -->",
+  block: "<!-- tokenjuice:begin -->\nbody\n<!-- tokenjuice:end -->",
+};
+
+describe("marker instruction helpers", () => {
+  it("reports unmatched and duplicate marker blocks", () => {
+    const startOnly = inspectMarkerDelimitedBlock("prefix\n<!-- tokenjuice:begin -->\nbody", config);
+    expect(collectMarkerDelimitedBlockIssues(startOnly, {
+      configuredLabel: "Zed rules",
+      repairCommand: "tokenjuice install zed",
+    })).toEqual(["configured Zed rules have a tokenjuice start marker without an end marker"]);
+
+    const duplicate = inspectMarkerDelimitedBlock(`${config.block}\n\n${config.block}`, config);
+    expect(collectMarkerDelimitedBlockIssues(duplicate, {
+      configuredLabel: "Zed rules",
+      repairCommand: "tokenjuice install zed",
+    })).toEqual(["configured Zed rules have multiple tokenjuice blocks; run tokenjuice install zed to repair"]);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize stale guidance issue checks for tokenjuice-owned instruction files
- centralize marker-delimited block doctor issue checks for Avante, Junie, and Zed
- move marker hosts to import file reads from the instruction-file helper directly instead of through marker-instructions
- add helper-level tests for guidance and marker issue collection

## Test plan
- pnpm exec vitest run test/hosts/aider.test.ts test/hosts/continue.test.ts test/hosts/avante.test.ts test/hosts/junie.test.ts test/hosts/zed.test.ts test/hosts/shared/instruction-file.test.ts test/hosts/shared/marker-instructions.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify