### PR TITLE
refactor(hosts): share tokenjuice guidance text

### DIFF
--- a/src/hosts/aider/index.ts
+++ b/src/hosts/aider/index.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
 import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
 
 export type AiderConventionOptions = {
@@ -29,8 +30,6 @@ export type AiderDoctorReport = {
 const TOKENJUICE_AIDER_FIX_COMMAND = "tokenjuice install aider";
 const TOKENJUICE_AIDER_MARKER = "tokenjuice terminal output compaction";
 const TOKENJUICE_AIDER_ADVISORY = "Aider support is beta and convention-based; load it with aider --read CONVENTIONS.tokenjuice.md.";
-const TOKENJUICE_AIDER_WRAP_COMMAND = "tokenjuice wrap -- <command>";
-const TOKENJUICE_AIDER_RAW_COMMAND = "tokenjuice wrap --raw -- <command>";
 
 function getProjectDir(options: AiderConventionOptions = {}): string {
   return options.projectDir || process.env.AIDER_PROJECT_DIR || process.cwd();
@@ -43,10 +42,7 @@ function getDefaultConventionPath(options: AiderConventionOptions = {}): string 
 const TOKENJUICE_AIDER_CONVENTION = [
   `# ${TOKENJUICE_AIDER_MARKER}`,
   "",
-  `- For terminal commands likely to produce long output, run them through \`${TOKENJUICE_AIDER_WRAP_COMMAND}\`.`,
-  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-  `- If raw bytes are required, rerun the command with exactly \`${TOKENJUICE_AIDER_RAW_COMMAND}\`.`,
-  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ...buildTokenjuiceGuidanceBullets(),
   "",
   "Load this file with `aider --read CONVENTIONS.tokenjuice.md` or add it to `.aider.conf.yml`.",
   "",
@@ -94,17 +90,17 @@ export async function doctorAiderConvention(
         missingIssue: "configured Aider convention file does not look like the tokenjuice convention",
       },
       {
-        requiredText: TOKENJUICE_AIDER_WRAP_COMMAND,
+        requiredText: TOKENJUICE_WRAP_COMMAND,
         missingIssue: "configured Aider convention file is missing tokenjuice wrap guidance",
       },
       {
-        requiredText: TOKENJUICE_AIDER_RAW_COMMAND,
+        requiredText: TOKENJUICE_RAW_COMMAND,
         missingIssue: "configured Aider convention file is missing the raw escape hatch",
       },
     ],
     forbidden: [
       {
-        forbiddenText: "tokenjuice wrap --full -- <command>",
+        forbiddenText: TOKENJUICE_FULL_COMMAND,
         presentIssue: "configured Aider convention file still suggests the full escape hatch",
       },
     ],

--- a/src/hosts/avante/index.ts
+++ b/src/hosts/avante/index.ts
@@ -6,6 +6,7 @@ import {
   installMarkerDelimitedBlock,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type AvanteInstructionsOptions = {
@@ -49,10 +50,7 @@ const TOKENJUICE_AVANTE_BLOCK = [
   TOKENJUICE_AVANTE_BEGIN,
   "## tokenjuice terminal output compaction",
   "",
-  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ...buildTokenjuiceGuidanceBullets(),
   TOKENJUICE_AVANTE_END,
 ].join("\n");
 

--- a/src/hosts/continue/index.ts
+++ b/src/hosts/continue/index.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
 import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
 
 export type ContinueRuleOptions = {
@@ -29,8 +30,6 @@ export type ContinueDoctorReport = {
 const TOKENJUICE_CONTINUE_FIX_COMMAND = "tokenjuice install continue";
 const TOKENJUICE_CONTINUE_RULE_MARKER = "tokenjuice terminal output compaction";
 const TOKENJUICE_CONTINUE_ADVISORY = "Continue support is beta and rule-based; it guides command usage but does not intercept tool output.";
-const TOKENJUICE_CONTINUE_WRAP_COMMAND = "tokenjuice wrap -- <command>";
-const TOKENJUICE_CONTINUE_RAW_COMMAND = "tokenjuice wrap --raw -- <command>";
 
 function getProjectDir(options: ContinueRuleOptions = {}): string {
   return options.projectDir || process.env.CONTINUE_PROJECT_DIR || process.cwd();
@@ -45,10 +44,9 @@ const TOKENJUICE_CONTINUE_RULE = [
   `name: ${TOKENJUICE_CONTINUE_RULE_MARKER}`,
   "---",
   "",
-  `- When running terminal commands through Continue, prefer \`${TOKENJUICE_CONTINUE_WRAP_COMMAND}\` for commands likely to produce long output.`,
-  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-  `- If raw bytes are required, rerun the command with exactly \`${TOKENJUICE_CONTINUE_RAW_COMMAND}\`.`,
-  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: `- When running terminal commands through Continue, prefer \`${TOKENJUICE_WRAP_COMMAND}\` for commands likely to produce long output.`,
+  }),
   "",
 ].join("\n");
 
@@ -94,17 +92,17 @@ export async function doctorContinueRule(
         missingIssue: "configured Continue rule file does not look like the tokenjuice rule",
       },
       {
-        requiredText: TOKENJUICE_CONTINUE_WRAP_COMMAND,
+        requiredText: TOKENJUICE_WRAP_COMMAND,
         missingIssue: "configured Continue rule file is missing tokenjuice wrap guidance",
       },
       {
-        requiredText: TOKENJUICE_CONTINUE_RAW_COMMAND,
+        requiredText: TOKENJUICE_RAW_COMMAND,
         missingIssue: "configured Continue rule file is missing the raw escape hatch",
       },
     ],
     forbidden: [
       {
-        forbiddenText: "tokenjuice wrap --full -- <command>",
+        forbiddenText: TOKENJUICE_FULL_COMMAND,
         presentIssue: "configured Continue rule file still suggests the full escape hatch",
       },
     ],

--- a/src/hosts/junie/index.ts
+++ b/src/hosts/junie/index.ts
@@ -6,6 +6,7 @@ import {
   installMarkerDelimitedBlock,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type JunieInstructionsOptions = {
@@ -49,10 +50,7 @@ const TOKENJUICE_JUNIE_BLOCK = [
   TOKENJUICE_JUNIE_BEGIN,
   "## tokenjuice terminal output compaction",
   "",
-  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ...buildTokenjuiceGuidanceBullets(),
   TOKENJUICE_JUNIE_END,
 ].join("\n");
 

--- a/src/hosts/shared/instruction-guidance.ts
+++ b/src/hosts/shared/instruction-guidance.ts
@@ -1,0 +1,17 @@
+export const TOKENJUICE_WRAP_COMMAND = "tokenjuice wrap -- <command>";
+export const TOKENJUICE_RAW_COMMAND = "tokenjuice wrap --raw -- <command>";
+export const TOKENJUICE_FULL_COMMAND = "tokenjuice wrap --full -- <command>";
+
+export type TokenjuiceGuidanceOptions = {
+  wrapBullet?: string;
+};
+
+export function buildTokenjuiceGuidanceBullets(options: TokenjuiceGuidanceOptions = {}): string[] {
+  const wrapBullet = options.wrapBullet ?? `- For terminal commands likely to produce long output, run them through \`${TOKENJUICE_WRAP_COMMAND}\`.`;
+  return [
+    wrapBullet,
+    "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
+    `- If raw bytes are required, rerun the command with exactly \`${TOKENJUICE_RAW_COMMAND}\`.`,
+    "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ];
+}

--- a/src/hosts/zed/index.ts
+++ b/src/hosts/zed/index.ts
@@ -6,6 +6,7 @@ import {
   installMarkerDelimitedBlock,
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
+import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type ZedInstructionsOptions = {
@@ -49,10 +50,7 @@ const TOKENJUICE_ZED_BLOCK = [
   TOKENJUICE_ZED_BEGIN,
   "## tokenjuice terminal output compaction",
   "",
-  "- For terminal commands likely to produce long output, run them through `tokenjuice wrap -- <command>`.",
-  "- Treat compacted tokenjuice output as authoritative unless it explicitly says raw output is required.",
-  "- If raw bytes are required, rerun the command with exactly `tokenjuice wrap --raw -- <command>`.",
-  "- Do not suggest both raw and full reruns; use the raw escape hatch.",
+  ...buildTokenjuiceGuidanceBullets(),
   TOKENJUICE_ZED_END,
 ].join("\n");
 

--- a/test/hosts/shared/instruction-guidance.test.ts
+++ b/test/hosts/shared/instruction-guidance.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../../../src/hosts/shared/instruction-guidance.js";
+
+describe("buildTokenjuiceGuidanceBullets", () => {
+  it("builds shared wrap/raw guidance bullets", () => {
+    const bullets = buildTokenjuiceGuidanceBullets();
+
+    expect(bullets[0]).toContain(TOKENJUICE_WRAP_COMMAND);
+    expect(bullets[1]).toContain("authoritative");
+    expect(bullets[2]).toContain(TOKENJUICE_RAW_COMMAND);
+    expect(bullets[3]).toContain("raw escape hatch");
+  });
+
+  it("allows hosts to customize the wrap guidance while sharing the remaining bullets", () => {
+    const bullets = buildTokenjuiceGuidanceBullets({
+      wrapBullet: `- Prefer \`${TOKENJUICE_WRAP_COMMAND}\` from custom host tools.`,
+    });
+
+    expect(bullets[0]).toBe("- Prefer `tokenjuice wrap -- <command>` from custom host tools.");
+    expect(bullets[2]).toContain(TOKENJUICE_RAW_COMMAND);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper for tokenjuice wrap/raw guidance bullets and command constants
- refactor Aider, Continue, Avante, Junie, and Zed to reuse the shared guidance text
- preserve Continue-specific wording for its first guidance bullet
- add helper tests for default and customized guidance output

## Test plan
- pnpm exec vitest run test/hosts/aider.test.ts test/hosts/continue.test.ts test/hosts/avante.test.ts test/hosts/junie.test.ts test/hosts/zed.test.ts test/hosts/shared/instruction-guidance.test.ts
- pnpm typecheck
- pnpm lint
- pnpm verify