### PR TITLE
refactor(hosts): share instruction doctor reports

### DIFF
--- a/src/hosts/aider/index.ts
+++ b/src/hosts/aider/index.ts
@@ -2,6 +2,10 @@ import { join } from "node:path";
 
 import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
 import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
 
 export type AiderConventionOptions = {
   projectDir?: string;
@@ -74,12 +78,12 @@ export async function doctorAiderConvention(
   if (!existing.exists) {
     return {
       conventionPath: resolvedConventionPath,
-      status: "disabled",
-      issues: ["tokenjuice Aider convention file is not installed"],
-      advisories: [TOKENJUICE_AIDER_ADVISORY],
-      fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
-      checkedPaths: [],
-      missingPaths: [],
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Aider convention file is not installed"],
+        advisory: TOKENJUICE_AIDER_ADVISORY,
+        fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
+      }),
     };
   }
 
@@ -108,11 +112,11 @@ export async function doctorAiderConvention(
 
   return {
     conventionPath: resolvedConventionPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: [TOKENJUICE_AIDER_ADVISORY],
-    fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
-    checkedPaths: [],
-    missingPaths: [],
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_AIDER_ADVISORY,
+      fixCommand: TOKENJUICE_AIDER_FIX_COMMAND,
+    }),
   };
 }

--- a/src/hosts/avante/index.ts
+++ b/src/hosts/avante/index.ts
@@ -7,6 +7,10 @@ import {
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
 import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type AvanteInstructionsOptions = {
@@ -87,12 +91,12 @@ export async function doctorAvanteInstructions(
   if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
-      status: "disabled",
-      issues: ["tokenjuice Avante instructions are not installed"],
-      advisories: [TOKENJUICE_AVANTE_ADVISORY],
-      fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
-      checkedPaths: [],
-      missingPaths: [],
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Avante instructions are not installed"],
+        advisory: TOKENJUICE_AVANTE_ADVISORY,
+        fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
+      }),
     };
   }
 
@@ -103,11 +107,11 @@ export async function doctorAvanteInstructions(
 
   return {
     instructionsPath: resolvedInstructionsPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: [TOKENJUICE_AVANTE_ADVISORY],
-    fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
-    checkedPaths: [],
-    missingPaths: [],
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_AVANTE_ADVISORY,
+      fixCommand: TOKENJUICE_AVANTE_FIX_COMMAND,
+    }),
   };
 }

--- a/src/hosts/continue/index.ts
+++ b/src/hosts/continue/index.ts
@@ -2,6 +2,10 @@ import { join } from "node:path";
 
 import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
 import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
 
 export type ContinueRuleOptions = {
   projectDir?: string;
@@ -76,12 +80,12 @@ export async function doctorContinueRule(
   if (!existing.exists) {
     return {
       rulePath: resolvedRulePath,
-      status: "disabled",
-      issues: ["tokenjuice Continue rule is not installed"],
-      advisories: [TOKENJUICE_CONTINUE_ADVISORY],
-      fixCommand: TOKENJUICE_CONTINUE_FIX_COMMAND,
-      checkedPaths: [],
-      missingPaths: [],
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Continue rule is not installed"],
+        advisory: TOKENJUICE_CONTINUE_ADVISORY,
+        fixCommand: TOKENJUICE_CONTINUE_FIX_COMMAND,
+      }),
     };
   }
 
@@ -110,11 +114,11 @@ export async function doctorContinueRule(
 
   return {
     rulePath: resolvedRulePath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: [TOKENJUICE_CONTINUE_ADVISORY],
-    fixCommand: TOKENJUICE_CONTINUE_FIX_COMMAND,
-    checkedPaths: [],
-    missingPaths: [],
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_CONTINUE_ADVISORY,
+      fixCommand: TOKENJUICE_CONTINUE_FIX_COMMAND,
+    }),
   };
 }

--- a/src/hosts/junie/index.ts
+++ b/src/hosts/junie/index.ts
@@ -7,6 +7,10 @@ import {
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
 import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type JunieInstructionsOptions = {
@@ -87,12 +91,12 @@ export async function doctorJunieInstructions(
   if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
-      status: "disabled",
-      issues: ["tokenjuice Junie instructions are not installed"],
-      advisories: [TOKENJUICE_JUNIE_ADVISORY],
-      fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
-      checkedPaths: [],
-      missingPaths: [],
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Junie instructions are not installed"],
+        advisory: TOKENJUICE_JUNIE_ADVISORY,
+        fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
+      }),
     };
   }
 
@@ -103,11 +107,11 @@ export async function doctorJunieInstructions(
 
   return {
     instructionsPath: resolvedInstructionsPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: [TOKENJUICE_JUNIE_ADVISORY],
-    fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
-    checkedPaths: [],
-    missingPaths: [],
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_JUNIE_ADVISORY,
+      fixCommand: TOKENJUICE_JUNIE_FIX_COMMAND,
+    }),
   };
 }

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -73,6 +73,10 @@ function mergeStatus(left: HookHealthStatus, right: HookHealthStatus): HookHealt
   return "ok";
 }
 
+function mergeStatuses(statuses: readonly HookHealthStatus[]): HookHealthStatus {
+  return statuses.reduce(mergeStatus, "disabled");
+}
+
 export async function doctorInstalledHooks(options: HookDoctorCommandOptions = {}): Promise<HookDoctorReport> {
   const aider = await doctorAiderConvention();
   const avante = await doctorAvanteInstructions();
@@ -96,25 +100,23 @@ export async function doctorInstalledHooks(options: HookDoctorCommandOptions = {
   const copilotCli = await doctorCopilotCliHook(undefined, hookCommandOptions);
 
   return {
-    status: mergeStatus(
-      mergeStatus(
-        mergeStatus(
-          mergeStatus(
-            mergeStatus(
-              mergeStatus(
-                mergeStatus(mergeStatus(mergeStatus(mergeStatus(aider.status, avante.status), codex.status), claudeCode.status), cline.status),
-                codebuddy.status,
-              ),
-              continueRule.status,
-            ),
-            mergeStatus(mergeStatus(cursor.status, geminiCli.status), junie.status),
-          ),
-          mergeStatus(openhands.status, pi.status),
-        ),
-        mergeStatus(vscodeCopilot.status, zed.status),
-      ),
+    status: mergeStatuses([
+      aider.status,
+      avante.status,
+      codex.status,
+      claudeCode.status,
+      cline.status,
+      codebuddy.status,
+      continueRule.status,
+      cursor.status,
+      geminiCli.status,
+      junie.status,
+      openhands.status,
+      pi.status,
+      vscodeCopilot.status,
+      zed.status,
       copilotCli.status,
-    ),
+    ]),
     integrations: {
       aider,
       avante,

--- a/src/hosts/shared/instruction-doctor.ts
+++ b/src/hosts/shared/instruction-doctor.ts
@@ -1,0 +1,30 @@
+export type InstructionDoctorStatus = "ok" | "broken" | "disabled";
+
+export type InstructionDoctorReportFields = {
+  status: InstructionDoctorStatus;
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+export function instructionDoctorStatusFromIssues(issues: readonly unknown[]): "ok" | "broken" {
+  return issues.length > 0 ? "broken" : "ok";
+}
+
+export function buildInstructionDoctorReportFields(options: {
+  status: InstructionDoctorStatus;
+  issues?: string[];
+  advisory: string;
+  fixCommand: string;
+}): InstructionDoctorReportFields {
+  return {
+    status: options.status,
+    issues: options.issues ?? [],
+    advisories: [options.advisory],
+    fixCommand: options.fixCommand,
+    checkedPaths: [],
+    missingPaths: [],
+  };
+}

--- a/src/hosts/zed/index.ts
+++ b/src/hosts/zed/index.ts
@@ -7,6 +7,10 @@ import {
   uninstallMarkerDelimitedBlock,
 } from "../shared/marker-instructions.js";
 import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
 import { readInstructionFile } from "../shared/instruction-file.js";
 
 export type ZedInstructionsOptions = {
@@ -87,12 +91,12 @@ export async function doctorZedInstructions(
   if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
     return {
       instructionsPath: resolvedInstructionsPath,
-      status: "disabled",
-      issues: ["tokenjuice Zed rules are not installed"],
-      advisories: [TOKENJUICE_ZED_ADVISORY],
-      fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
-      checkedPaths: [],
-      missingPaths: [],
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Zed rules are not installed"],
+        advisory: TOKENJUICE_ZED_ADVISORY,
+        fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
+      }),
     };
   }
 
@@ -103,11 +107,11 @@ export async function doctorZedInstructions(
 
   return {
     instructionsPath: resolvedInstructionsPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: [TOKENJUICE_ZED_ADVISORY],
-    fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
-    checkedPaths: [],
-    missingPaths: [],
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_ZED_ADVISORY,
+      fixCommand: TOKENJUICE_ZED_FIX_COMMAND,
+    }),
   };
 }


### PR DESCRIPTION
## Summary
- add a shared helper for instruction-based host doctor report fields
- use it across Aider, Avante, Continue, Junie, and Zed
- flatten aggregate doctor status merging

## Test plan
- pnpm exec vitest run test/hosts/aider.test.ts test/hosts/avante.test.ts test/hosts/continue.test.ts test/hosts/junie.test.ts test/hosts/zed.test.ts
- pnpm typecheck
- pnpm verify