### PR TITLE
refactor(hosts): share hook command doctor reports

### DIFF
--- a/src/hosts/cline/index.ts
+++ b/src/hosts/cline/index.ts
@@ -5,10 +5,10 @@ import { homedir } from "node:os";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import {
   buildTokenjuiceHookCommand,
-  findMissingHookCommandPaths,
   pathExists,
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
+import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
 import { buildCompactedOutputContext } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
@@ -46,6 +46,8 @@ type ClinePostToolUsePayload = {
 
 const TOKENJUICE_CLINE_SUBCOMMAND = "cline-post-tool-use";
 const TOKENJUICE_CLINE_FIX_COMMAND = "tokenjuice install cline";
+const TOKENJUICE_CLINE_DISABLED_ADVISORY = "Cline support is beta; enable the generated PostToolUse hook in Cline's Hooks tab after install.";
+const TOKENJUICE_CLINE_ADVISORY = "Cline support is beta and currently injects compacted context without suppressing the original tool result.";
 const TOKENJUICE_CLINE_HOOK_FILENAME = process.platform === "win32"
   ? "tokenjuice-post-tool-use.ps1"
   : "tokenjuice-post-tool-use";
@@ -124,38 +126,17 @@ export async function doctorClineHook(
   const resolvedHookPath = hookPath ?? getDefaultHookPath(options);
   const expectedCommand = await buildTokenjuiceHookCommand(TOKENJUICE_CLINE_SUBCOMMAND, "cline", options);
   const detectedCommand = await readConfiguredCommand(resolvedHookPath);
-  if (!detectedCommand) {
-    return {
-      hookPath: resolvedHookPath,
-      status: "disabled",
-      issues: ["tokenjuice PostToolUse hook script is not installed for Cline"],
-      advisories: ["Cline support is beta; enable the generated PostToolUse hook in Cline's Hooks tab after install."],
-      fixCommand: TOKENJUICE_CLINE_FIX_COMMAND,
-      expectedCommand,
-      checkedPaths: [],
-      missingPaths: [],
-    };
-  }
-
-  const missingPaths = await findMissingHookCommandPaths(detectedCommand);
-  const issues: string[] = [];
-  if (detectedCommand !== expectedCommand) {
-    issues.push("configured Cline hook command does not match the current recommended command");
-  }
-  if (missingPaths.length > 0) {
-    issues.push(`configured Cline hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
-  }
 
   return {
     hookPath: resolvedHookPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: ["Cline support is beta and currently injects compacted context without suppressing the original tool result."],
-    fixCommand: TOKENJUICE_CLINE_FIX_COMMAND,
-    expectedCommand,
-    detectedCommand,
-    checkedPaths: [],
-    missingPaths,
+    ...(await buildHookCommandDoctorFields({
+      expectedCommand,
+      detectedCommand,
+      disabledIssue: "tokenjuice PostToolUse hook script is not installed for Cline",
+      hostLabel: "Cline",
+      advisory: detectedCommand ? TOKENJUICE_CLINE_ADVISORY : TOKENJUICE_CLINE_DISABLED_ADVISORY,
+      fixCommand: TOKENJUICE_CLINE_FIX_COMMAND,
+    })),
   };
 }
 

--- a/src/hosts/gemini-cli/index.ts
+++ b/src/hosts/gemini-cli/index.ts
@@ -5,9 +5,9 @@ import { homedir } from "node:os";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import {
   buildTokenjuiceHookCommand,
-  findMissingHookCommandPaths,
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
+import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
 import { buildCompactedOutputContext } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
@@ -50,6 +50,8 @@ type GeminiCliAfterToolPayload = {
 
 const TOKENJUICE_GEMINI_CLI_SUBCOMMAND = "gemini-cli-after-tool";
 const TOKENJUICE_GEMINI_CLI_FIX_COMMAND = "tokenjuice install gemini-cli";
+const TOKENJUICE_GEMINI_CLI_DISABLED_ADVISORY = "Gemini CLI support is beta; verify live hook behavior after install.";
+const TOKENJUICE_GEMINI_CLI_ADVISORY = "Gemini CLI support is beta; AfterTool replacement depends on current hook semantics.";
 
 function getGeminiCliHome(): string {
   return process.env.GEMINI_HOME || join(homedir(), ".gemini");
@@ -198,38 +200,17 @@ export async function doctorGeminiCliHook(
   const expectedCommand = await buildTokenjuiceHookCommand(TOKENJUICE_GEMINI_CLI_SUBCOMMAND, "gemini-cli", options);
   const { config, exists } = await readGeminiSettings(settingsPath);
   const detectedCommand = findTokenjuiceGeminiHookCommand(config);
-  if (!exists || !detectedCommand) {
-    return {
-      settingsPath,
-      status: "disabled",
-      issues: ["tokenjuice AfterTool hook is not installed for Gemini CLI"],
-      advisories: ["Gemini CLI support is beta; verify live hook behavior after install."],
-      fixCommand: TOKENJUICE_GEMINI_CLI_FIX_COMMAND,
-      expectedCommand,
-      checkedPaths: [],
-      missingPaths: [],
-    };
-  }
-
-  const missingPaths = await findMissingHookCommandPaths(detectedCommand);
-  const issues: string[] = [];
-  if (detectedCommand !== expectedCommand) {
-    issues.push("configured Gemini CLI hook command does not match the current recommended command");
-  }
-  if (missingPaths.length > 0) {
-    issues.push(`configured Gemini CLI hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
-  }
 
   return {
     settingsPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: ["Gemini CLI support is beta; AfterTool replacement depends on current hook semantics."],
-    fixCommand: TOKENJUICE_GEMINI_CLI_FIX_COMMAND,
-    expectedCommand,
-    detectedCommand,
-    checkedPaths: [],
-    missingPaths,
+    ...(await buildHookCommandDoctorFields({
+      expectedCommand,
+      detectedCommand: exists ? detectedCommand : undefined,
+      disabledIssue: "tokenjuice AfterTool hook is not installed for Gemini CLI",
+      hostLabel: "Gemini CLI",
+      advisory: detectedCommand ? TOKENJUICE_GEMINI_CLI_ADVISORY : TOKENJUICE_GEMINI_CLI_DISABLED_ADVISORY,
+      fixCommand: TOKENJUICE_GEMINI_CLI_FIX_COMMAND,
+    })),
   };
 }
 

--- a/src/hosts/openhands/index.ts
+++ b/src/hosts/openhands/index.ts
@@ -4,9 +4,9 @@ import { dirname, join } from "node:path";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import {
   buildTokenjuiceHookCommand,
-  findMissingHookCommandPaths,
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
+import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
 import { buildCompactedOutputContext } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
@@ -51,6 +51,7 @@ type OpenHandsPostToolUsePayload = {
 
 const TOKENJUICE_OPENHANDS_SUBCOMMAND = "openhands-post-tool-use";
 const TOKENJUICE_OPENHANDS_FIX_COMMAND = "tokenjuice install openhands";
+const TOKENJUICE_OPENHANDS_ADVISORY = "OpenHands support is beta and currently injects compacted context without suppressing the original tool result.";
 
 function getProjectDir(options: OpenHandsHookCommandOptions = {}): string {
   return options.projectDir || process.env.OPENHANDS_PROJECT_DIR || process.cwd();
@@ -193,38 +194,17 @@ export async function doctorOpenHandsHook(
   const expectedCommand = await buildTokenjuiceHookCommand(TOKENJUICE_OPENHANDS_SUBCOMMAND, "openhands", options);
   const { config, exists } = await readOpenHandsHooksConfig(resolvedHooksPath);
   const detectedCommand = findTokenjuiceOpenHandsHookCommand(config);
-  if (!exists || !detectedCommand) {
-    return {
-      hooksPath: resolvedHooksPath,
-      status: "disabled",
-      issues: ["tokenjuice PostToolUse hook is not installed for OpenHands"],
-      advisories: ["OpenHands support is beta and currently injects compacted context without suppressing the original tool result."],
-      fixCommand: TOKENJUICE_OPENHANDS_FIX_COMMAND,
-      expectedCommand,
-      checkedPaths: [],
-      missingPaths: [],
-    };
-  }
-
-  const missingPaths = await findMissingHookCommandPaths(detectedCommand);
-  const issues: string[] = [];
-  if (detectedCommand !== expectedCommand) {
-    issues.push("configured OpenHands hook command does not match the current recommended command");
-  }
-  if (missingPaths.length > 0) {
-    issues.push(`configured OpenHands hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
-  }
 
   return {
     hooksPath: resolvedHooksPath,
-    status: issues.length > 0 ? "broken" : "ok",
-    issues,
-    advisories: ["OpenHands support is beta and currently injects compacted context without suppressing the original tool result."],
-    fixCommand: TOKENJUICE_OPENHANDS_FIX_COMMAND,
-    expectedCommand,
-    detectedCommand,
-    checkedPaths: [],
-    missingPaths,
+    ...(await buildHookCommandDoctorFields({
+      expectedCommand,
+      detectedCommand: exists ? detectedCommand : undefined,
+      disabledIssue: "tokenjuice PostToolUse hook is not installed for OpenHands",
+      hostLabel: "OpenHands",
+      advisory: TOKENJUICE_OPENHANDS_ADVISORY,
+      fixCommand: TOKENJUICE_OPENHANDS_FIX_COMMAND,
+    })),
   };
 }
 

--- a/src/hosts/shared/hook-command-doctor.ts
+++ b/src/hosts/shared/hook-command-doctor.ts
@@ -1,0 +1,55 @@
+import { findMissingHookCommandPaths } from "./host-command.js";
+
+export type HookCommandDoctorStatus = "ok" | "broken" | "disabled";
+
+export type HookCommandDoctorFields = {
+  status: HookCommandDoctorStatus;
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+export async function buildHookCommandDoctorFields(options: {
+  expectedCommand: string;
+  detectedCommand: string | undefined;
+  disabledIssue: string;
+  hostLabel: string;
+  advisory: string;
+  fixCommand: string;
+}): Promise<HookCommandDoctorFields> {
+  if (!options.detectedCommand) {
+    return {
+      status: "disabled",
+      issues: [options.disabledIssue],
+      advisories: [options.advisory],
+      fixCommand: options.fixCommand,
+      expectedCommand: options.expectedCommand,
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  const missingPaths = await findMissingHookCommandPaths(options.detectedCommand);
+  const issues: string[] = [];
+  if (options.detectedCommand !== options.expectedCommand) {
+    issues.push(`configured ${options.hostLabel} hook command does not match the current recommended command`);
+  }
+  if (missingPaths.length > 0) {
+    issues.push(`configured ${options.hostLabel} hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
+  }
+
+  return {
+    status: issues.length > 0 ? "broken" : "ok",
+    issues,
+    advisories: [options.advisory],
+    fixCommand: options.fixCommand,
+    expectedCommand: options.expectedCommand,
+    detectedCommand: options.detectedCommand,
+    checkedPaths: [],
+    missingPaths,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared helper for hook-command doctor report fields
- use it across Cline, Gemini CLI, and OpenHands beta hook adapters
- keep existing report shape and status behavior unchanged

## Test plan
- pnpm exec vitest run test/hosts/cline.test.ts test/hosts/openhands.test.ts test/hosts/gemini-cli.test.ts
- pnpm typecheck
- pnpm verify