### PR TITLE
refactor(hosts): share hook JSON output helpers

### DIFF
--- a/src/hosts/cline/index.ts
+++ b/src/hosts/cline/index.ts
@@ -9,7 +9,7 @@ import {
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
 import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
-import { buildCompactedOutputContext } from "../shared/hook-output.js";
+import { buildCompactedOutputContext, writeHookJsonLine } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
 export type ClineHookCommandOptions = TokenjuiceHookCommandOptions & {
@@ -162,26 +162,27 @@ function isShellToolName(value: unknown): boolean {
   return value === "execute_command" || value === "executeCommand" || value === "terminal";
 }
 
+function writeClineResponse(contextModification = ""): void {
+  writeHookJsonLine({ cancel: false, contextModification, errorMessage: "" });
+}
+
 export async function runClinePostToolUseHook(rawText: string): Promise<number> {
   let payload: ClinePostToolUsePayload;
   try {
     payload = JSON.parse(rawText) as ClinePostToolUsePayload;
   } catch {
-    process.stdout.write(JSON.stringify({ cancel: false, contextModification: "", errorMessage: "" }));
-    process.stdout.write("\n");
+    writeClineResponse();
     return 0;
   }
 
   if (payload.hookName !== "PostToolUse" || !isRecord(payload.postToolUse)) {
-    process.stdout.write(JSON.stringify({ cancel: false, contextModification: "", errorMessage: "" }));
-    process.stdout.write("\n");
+    writeClineResponse();
     return 0;
   }
 
   const tool = payload.postToolUse;
   if (!isShellToolName(tool.toolName) && !isShellToolName(tool.tool)) {
-    process.stdout.write(JSON.stringify({ cancel: false, contextModification: "", errorMessage: "" }));
-    process.stdout.write("\n");
+    writeClineResponse();
     return 0;
   }
 
@@ -189,8 +190,7 @@ export async function runClinePostToolUseHook(rawText: string): Promise<number> 
   const command = readStringField(parameters, ["command", "cmd"]) ?? readStringField(tool, ["command"]);
   const result = readStringField(tool, ["result"]);
   if (!command || !result) {
-    process.stdout.write(JSON.stringify({ cancel: false, contextModification: "", errorMessage: "" }));
-    process.stdout.write("\n");
+    writeClineResponse();
     return 0;
   }
 
@@ -208,18 +208,12 @@ export async function runClinePostToolUseHook(rawText: string): Promise<number> 
       skipGenericFallbackForCompoundCommands: true,
     });
 
-    process.stdout.write(JSON.stringify({
-      cancel: false,
-      contextModification: outcome.action === "rewrite"
-        ? buildCompactedOutputContext(outcome.result.inlineText)
-        : "",
-      errorMessage: "",
-    }));
-    process.stdout.write("\n");
+    writeClineResponse(
+      outcome.action === "rewrite" ? buildCompactedOutputContext(outcome.result.inlineText) : "",
+    );
     return 0;
   } catch {
-    process.stdout.write(JSON.stringify({ cancel: false, contextModification: "", errorMessage: "" }));
-    process.stdout.write("\n");
+    writeClineResponse();
     return 0;
   }
 }

--- a/src/hosts/gemini-cli/index.ts
+++ b/src/hosts/gemini-cli/index.ts
@@ -8,7 +8,7 @@ import {
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
 import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
-import { buildCompactedOutputContext } from "../shared/hook-output.js";
+import { buildCompactedOutputContext, writeEmptyHookJsonLine, writeHookJsonLine } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
 export type GeminiCliHookCommandOptions = TokenjuiceHookCommandOptions;
@@ -252,12 +252,12 @@ export async function runGeminiCliAfterToolHook(rawText: string): Promise<number
   try {
     payload = JSON.parse(rawText) as GeminiCliAfterToolPayload;
   } catch {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
   if (payload.hook_event_name !== "AfterTool" || payload.tool_name !== "run_shell_command") {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
@@ -265,7 +265,7 @@ export async function runGeminiCliAfterToolHook(rawText: string): Promise<number
   const command = toolInput ? readStringField(toolInput, ["command", "cmd"]) : undefined;
   const visibleText = readGeminiOutputText(payload.tool_response);
   if (!command || !visibleText.trim()) {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
@@ -285,18 +285,18 @@ export async function runGeminiCliAfterToolHook(rawText: string): Promise<number
     });
 
     if (outcome.action === "keep") {
-      process.stdout.write("{}\n");
+      writeEmptyHookJsonLine();
       return 0;
     }
 
-    process.stdout.write(`${JSON.stringify({
+    writeHookJsonLine({
       decision: "deny",
       reason: buildCompactedOutputContext(outcome.result.inlineText),
       suppressOutput: true,
-    })}\n`);
+    });
     return 0;
   } catch {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 }

--- a/src/hosts/openhands/index.ts
+++ b/src/hosts/openhands/index.ts
@@ -7,7 +7,7 @@ import {
   type TokenjuiceHookCommandOptions,
 } from "../shared/host-command.js";
 import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
-import { buildCompactedOutputContext } from "../shared/hook-output.js";
+import { buildCompactedOutputContext, writeEmptyHookJsonLine, writeHookJsonLine } from "../shared/hook-output.js";
 import { isRecord } from "../shared/hooks-json-file.js";
 
 export type OpenHandsHookCommandOptions = TokenjuiceHookCommandOptions & {
@@ -233,12 +233,12 @@ export async function runOpenHandsPostToolUseHook(rawText: string): Promise<numb
   try {
     payload = JSON.parse(rawText) as OpenHandsPostToolUsePayload;
   } catch {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
   if (payload.event_type !== "PostToolUse" || payload.tool_name !== "terminal") {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
@@ -246,7 +246,7 @@ export async function runOpenHandsPostToolUseHook(rawText: string): Promise<numb
   const command = toolInput ? readStringField(toolInput, ["command", "cmd"]) : undefined;
   const visibleText = readOpenHandsOutputText(payload.tool_response);
   if (!command || !visibleText.trim()) {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 
@@ -264,16 +264,16 @@ export async function runOpenHandsPostToolUseHook(rawText: string): Promise<numb
     });
 
     if (outcome.action === "keep") {
-      process.stdout.write("{}\n");
+      writeEmptyHookJsonLine();
       return 0;
     }
 
-    process.stdout.write(`${JSON.stringify({
+    writeHookJsonLine({
       additionalContext: buildCompactedOutputContext(outcome.result.inlineText),
-    })}\n`);
+    });
     return 0;
   } catch {
-    process.stdout.write("{}\n");
+    writeEmptyHookJsonLine();
     return 0;
   }
 }

--- a/src/hosts/shared/hook-output.ts
+++ b/src/hosts/shared/hook-output.ts
@@ -8,3 +8,11 @@ export function buildCompactionHint(rawRefId?: string): string {
 export function buildCompactedOutputContext(inlineText: string): string {
   return `${inlineText}\n\n${buildCompactionHint()}`;
 }
+
+export function writeHookJsonLine(payload: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+export function writeEmptyHookJsonLine(): void {
+  writeHookJsonLine({});
+}


### PR DESCRIPTION
## Summary
- add shared helpers for writing JSON hook responses
- use them in Cline, OpenHands, and Gemini CLI runtime hooks
- keep existing stdout response shapes unchanged

## Test plan
- pnpm exec vitest run test/hosts/cline.test.ts test/hosts/openhands.test.ts test/hosts/gemini-cli.test.ts
- pnpm typecheck
- pnpm verify