### PR TITLE
fix: only show authoritative wrap footer for real compaction

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,6 +8,7 @@ import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifa
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
 import { parseReduceJsonRequest } from "../core/json-protocol.js";
+import { WRAP_AUTHORITATIVE_FOOTER } from "../core/compaction-metadata.js";
 import { reduceExecution } from "../core/reduce.js";
 import { verifyRules } from "../core/rules.js";
 import { runWrappedCommand } from "../core/wrap.js";
@@ -434,17 +435,14 @@ async function runWrap(args: ParsedArgs): Promise<number> {
 }
 
 function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): string {
-  if (raw) {
-    return result.inlineText;
-  }
   const { rawChars, reducedChars } = result.stats;
-  if (rawChars <= reducedChars || reducedChars === 0) {
+  if (raw || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
     return result.inlineText;
   }
   const footer = [
     "",
     "---",
-    "[tokenjuice] This is the complete, authoritative output for this command. It was deterministically compacted to remove low-signal noise; the omitted content is not retrievable. Do not re-run the command, vary flags, or switch tools to try to recover it. Proceed with the task using this output.",
+    WRAP_AUTHORITATIVE_FOOTER,
   ].join("\n");
   return `${result.inlineText}${footer}`;
 }

--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -1,0 +1,37 @@
+export type CompactionKind =
+  | "head-tail-omission"
+  | "middle-truncation"
+  | "tail-truncation"
+  | "hashed-middle-clip"
+  | "git-diff-hunk-clip"
+  | "inspection-package-lock-summary"
+  | "inspection-large-document-summary"
+  | "github-actions-command-list-omission";
+
+export type CompactionMetadata = {
+  authoritative: boolean;
+  kinds: CompactionKind[];
+};
+
+export const NO_COMPACTION_METADATA: CompactionMetadata = {
+  authoritative: false,
+  kinds: [],
+};
+
+export const WRAP_AUTHORITATIVE_FOOTER = "[tokenjuice] This is the complete, authoritative output for this command. It was deterministically compacted to remove low-signal noise; the omitted content is not retrievable. Do not re-run the command, vary flags, or switch tools to try to recover it. Proceed with the task using this output.";
+
+export function createCompactionMetadata(...kinds: CompactionKind[]): CompactionMetadata {
+  if (kinds.length === 0) {
+    return NO_COMPACTION_METADATA;
+  }
+
+  return {
+    authoritative: true,
+    kinds: Array.from(new Set(kinds)),
+  };
+}
+
+export function mergeCompactionMetadata(...values: Array<CompactionMetadata | undefined>): CompactionMetadata {
+  const kinds = values.flatMap((value) => value?.kinds ?? []);
+  return createCompactionMetadata(...kinds);
+}

--- a/src/core/github-actions-summary.ts
+++ b/src/core/github-actions-summary.ts
@@ -1,5 +1,6 @@
 import type { ToolExecutionInput } from "../types.js";
 
+import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { normalizeLines, stripAnsi, trimEmptyEdges } from "./text.js";
 
 const GITHUB_ACTIONS_EXIT_PATTERN = /^Error: Process completed with exit code (\d+)\.?$/u;
@@ -70,22 +71,25 @@ function extractRunCommands(lines: string[]): string[] {
   return dedupeAdjacent(commands).filter((line) => !isShellSetupLine(line));
 }
 
-function formatCommandList(commands: string[]): string[] {
+function formatCommandList(commands: string[]): { lines: string[]; compaction?: CompactionMetadata } {
   if (commands.length <= MAX_LISTED_COMMANDS) {
-    return commands.map((command) => `- ${command}`);
+    return { lines: commands.map((command) => `- ${command}`) };
   }
 
   const headCount = Math.floor(MAX_LISTED_COMMANDS * 0.65);
   const tailCount = MAX_LISTED_COMMANDS - headCount;
   const omitted = commands.length - headCount - tailCount;
-  return [
-    ...commands.slice(0, headCount).map((command) => `- ${command}`),
-    `... ${omitted} commands omitted ...`,
-    ...commands.slice(-tailCount).map((command) => `- ${command}`),
-  ];
+  return {
+    lines: [
+      ...commands.slice(0, headCount).map((command) => `- ${command}`),
+      `... ${omitted} commands omitted ...`,
+      ...commands.slice(-tailCount).map((command) => `- ${command}`),
+    ],
+    compaction: createCompactionMetadata("github-actions-command-list-omission"),
+  };
 }
 
-export function buildGithubActionsFailureSummary(input: ToolExecutionInput, rawText: string): string | null {
+export function buildGithubActionsFailureSummary(input: ToolExecutionInput, rawText: string): { text: string; compaction?: CompactionMetadata } | null {
   const lines = trimEmptyEdges(normalizeLines(stripAnsi(rawText))).map((line) => line.trimEnd());
   const exitLine = [...lines].reverse().find((line) => GITHUB_ACTIONS_EXIT_PATTERN.test(stripGithubActionsScriptPrefix(line)));
   const exitCode = exitLine?.match(GITHUB_ACTIONS_EXIT_PATTERN)?.[1] ?? (input.exitCode && input.exitCode !== 0 ? String(input.exitCode) : null);
@@ -98,14 +102,18 @@ export function buildGithubActionsFailureSummary(input: ToolExecutionInput, rawT
     return null;
   }
 
+  const commandList = formatCommandList(commands);
   const summary = [`GitHub Actions shell step failed (exit ${exitCode}).`];
   if (commands.length === 1) {
     summary.push(`Failing command: ${commands[0]}`);
   } else {
     summary.push(`Failing command: not visible; this shell step ran ${commands.length} commands without per-command failure markers.`);
     summary.push("Commands in step:");
-    summary.push(...formatCommandList(commands));
+    summary.push(...commandList.lines);
   }
   summary.push(stripGithubActionsScriptPrefix(exitLine));
-  return summary.join("\n");
+  return {
+    text: summary.join("\n"),
+    ...(commandList.compaction ? { compaction: commandList.compaction } : {}),
+  };
 }

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -170,7 +170,7 @@ function extractGhDuration(record: Record<string, unknown>): string | null {
   return null;
 }
 
-function formatGhJsonRecord(record: Record<string, unknown>): string | null {
+function formatGhJsonRecord(record: Record<string, unknown>): { line: string; compaction?: CompactionMetadata } | null {
   const comment = formatGhCommentJsonRecord(record);
   if (comment) {
     return comment;
@@ -223,7 +223,7 @@ function formatGhJsonRecord(record: Record<string, unknown>): string | null {
   if (updatedAt) {
     parts.push(updatedAt);
   }
-  return parts.join(" ");
+  return { line: parts.join(" ") };
 }
 
 function getNestedLogin(value: unknown): string | null {
@@ -236,7 +236,7 @@ function getNestedLogin(value: unknown): string | null {
   return null;
 }
 
-function formatGhCommentJsonRecord(record: Record<string, unknown>): string | null {
+function formatGhCommentJsonRecord(record: Record<string, unknown>): { line: string; compaction?: CompactionMetadata } | null {
   const body = typeof record.body === "string" ? record.body
     : typeof record.bodyText === "string" ? record.bodyText
       : null;
@@ -261,6 +261,7 @@ function formatGhCommentJsonRecord(record: Record<string, unknown>): string | nu
   const createdAt = typeof record.createdAt === "string" ? record.createdAt.slice(0, 10)
     : typeof record.created_at === "string" ? record.created_at.slice(0, 10)
       : null;
+  const clippedBody = clipMiddleWithHash(compactWhitespace(body), 180);
 
   const location = path ? `${path}${line !== null ? `:${line}` : ""}` : null;
   const parts = [
@@ -270,9 +271,12 @@ function formatGhCommentJsonRecord(record: Record<string, unknown>): string | nu
     location,
     state ? `[${state}]` : null,
     createdAt,
-    `body=${clipMiddleWithHash(compactWhitespace(body), 180).text}`,
+    `body=${clippedBody.text}`,
   ].filter((part): part is string => Boolean(part));
-  return parts.join(" ");
+  return {
+    line: parts.join(" "),
+    ...(clippedBody.compaction ? { compaction: clippedBody.compaction } : {}),
+  };
 }
 
 function getGhCollection(value: unknown): unknown[] {
@@ -285,26 +289,41 @@ function getGhCollection(value: unknown): unknown[] {
   return [];
 }
 
-function formatGhJsonValue(value: unknown): string[] {
+function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
+  const compactions: CompactionMetadata[] = [];
   if (Array.isArray(value)) {
-    return value.flatMap((entry) => {
+    const lines = value.flatMap((entry) => {
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         return [];
       }
       const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
-      return formatted ? [formatted] : [];
+      if (!formatted) {
+        return [];
+      }
+      if (formatted.compaction) {
+        compactions.push(formatted.compaction);
+      }
+      return [formatted.line];
     });
+
+    return {
+      lines,
+      ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
+    };
   }
 
   if (typeof value !== "object" || value === null) {
-    return [];
+    return { lines: [] };
   }
 
   const record = value as Record<string, unknown>;
   const lines: string[] = [];
   const header = formatGhJsonRecord(record);
   if (header) {
-    lines.push(header);
+    lines.push(header.line);
+    if (header.compaction) {
+      compactions.push(header.compaction);
+    }
   }
 
   for (const collectionKey of ["jobs", "workflowRuns", "items", "artifacts", "comments", "reviews", "reviewThreads"]) {
@@ -319,12 +338,18 @@ function formatGhJsonValue(value: unknown): string[] {
       }
       const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
       if (formatted) {
-        lines.push(formatted);
+        lines.push(formatted.line);
+        if (formatted.compaction) {
+          compactions.push(formatted.compaction);
+        }
       }
     }
   }
 
-  return lines;
+  return {
+    lines,
+    ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
+  };
 }
 
 export function rewriteSearchLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
@@ -444,33 +469,45 @@ function formatGhTableLine(line: string): string {
   return compactWhitespace(trimmed);
 }
 
-export function rewriteGhLines(lines: string[], input: ToolExecutionInput): string[] {
+export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { lines: string[]; compaction?: CompactionMetadata } {
   const nonEmpty = lines.filter((line) => line.trim() !== "");
   if (nonEmpty.length === 0) {
-    return [];
+    return { lines: [] };
   }
 
   const parsedWholeJson = parseJsonValue(nonEmpty.join("\n"));
   if (parsedWholeJson !== null) {
     const rewrittenWholeJson = formatGhJsonValue(parsedWholeJson);
-    if (rewrittenWholeJson.length > 0) {
+    if (rewrittenWholeJson.lines.length > 0) {
       return rewrittenWholeJson;
     }
   }
 
   const parsedJsonLines = nonEmpty.map(parseJsonObjectLine);
   if (parsedJsonLines.every((entry) => entry !== null)) {
+    const compactions: CompactionMetadata[] = [];
     const rewritten = parsedJsonLines
       .map((entry) => formatGhJsonRecord(entry!))
-      .filter((line): line is string => typeof line === "string" && line.length > 0);
+      .flatMap((line) => {
+        if (!line || line.line.length === 0) {
+          return [];
+        }
+        if (line.compaction) {
+          compactions.push(line.compaction);
+        }
+        return [line.line];
+      });
     if (rewritten.length > 0) {
-      return rewritten;
+      return {
+        lines: rewritten,
+        ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
+      };
     }
   }
 
   if ((input.argv ?? [])[0] === "gh") {
-    return lines.map(formatGhTableLine);
+    return { lines: lines.map(formatGhTableLine) };
   }
 
-  return lines;
+  return { lines };
 }

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -1,3 +1,4 @@
+import { createCompactionMetadata, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { compactWhitespace, clipMiddleWithHash, parseJsonObjectLine, parseJsonValue } from "./reduce-utils.js";
 
 import type { ToolExecutionInput } from "../types.js";
@@ -269,7 +270,7 @@ function formatGhCommentJsonRecord(record: Record<string, unknown>): string | nu
     location,
     state ? `[${state}]` : null,
     createdAt,
-    `body=${clipMiddleWithHash(compactWhitespace(body), 180)}`,
+    `body=${clipMiddleWithHash(compactWhitespace(body), 180).text}`,
   ].filter((part): part is string => Boolean(part));
   return parts.join(" ");
 }
@@ -326,19 +327,34 @@ function formatGhJsonValue(value: unknown): string[] {
   return lines;
 }
 
-export function rewriteSearchLines(lines: string[]): string[] {
-  return lines.map((line) => {
+export function rewriteSearchLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+  const compactions: CompactionMetadata[] = [];
+  const rewritten = lines.map((line) => {
     const match = /^(.+?:\d+(?::|-))(.*)$/u.exec(line);
     if (!match) {
-      return clipMiddleWithHash(line, LONG_SEARCH_LINE_MAX_CHARS);
+      const clipped = clipMiddleWithHash(line, LONG_SEARCH_LINE_MAX_CHARS);
+      if (clipped.compaction) {
+        compactions.push(clipped.compaction);
+      }
+      return clipped.text;
     }
     const [, prefix, rest] = match;
-    return `${prefix}${clipMiddleWithHash(rest ?? "", LONG_SEARCH_LINE_MAX_CHARS)}`;
+    const clipped = clipMiddleWithHash(rest ?? "", LONG_SEARCH_LINE_MAX_CHARS);
+    if (clipped.compaction) {
+      compactions.push(clipped.compaction);
+    }
+    return `${prefix}${clipped.text}`;
   });
+
+  return {
+    lines: rewritten,
+    ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
+  };
 }
 
-export function rewriteGitDiffLines(lines: string[]): string[] {
+export function rewriteGitDiffLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
   const rewritten: string[] = [];
+  const compactions: CompactionMetadata[] = [];
   let emittedChangedLinesInHunk = 0;
   let omittedAdded = 0;
   let omittedRemoved = 0;
@@ -346,6 +362,7 @@ export function rewriteGitDiffLines(lines: string[]): string[] {
   const flushOmitted = () => {
     if (omittedAdded > 0 || omittedRemoved > 0) {
       rewritten.push(`... hunk clipped: ${omittedAdded} added, ${omittedRemoved} removed lines omitted`);
+      compactions.push(createCompactionMetadata("git-diff-hunk-clip"));
       omittedAdded = 0;
       omittedRemoved = 0;
     }
@@ -373,7 +390,11 @@ export function rewriteGitDiffLines(lines: string[]): string[] {
 
     if (emittedChangedLinesInHunk < GIT_DIFF_CHANGED_LINES_PER_HUNK) {
       emittedChangedLinesInHunk += 1;
-      rewritten.push(clipMiddleWithHash(line, LONG_CHANGED_LINE_MAX_CHARS));
+      const clipped = clipMiddleWithHash(line, LONG_CHANGED_LINE_MAX_CHARS);
+      if (clipped.compaction) {
+        compactions.push(clipped.compaction);
+      }
+      rewritten.push(clipped.text);
       continue;
     }
 
@@ -385,7 +406,10 @@ export function rewriteGitDiffLines(lines: string[]): string[] {
   }
 
   flushOmitted();
-  return rewritten;
+  return {
+    lines: rewritten,
+    ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
+  };
 }
 
 function formatGhTableLine(line: string): string {

--- a/src/core/reduce-inspection-summary.ts
+++ b/src/core/reduce-inspection-summary.ts
@@ -1,4 +1,5 @@
 import { isFileContentInspectionCommand } from "./command-identity.js";
+import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { clipMiddleWithHash, parseJsonValue } from "./reduce-utils.js";
 import { countTextChars, headTail, normalizeLines, stripAnsi, trimEmptyEdges } from "./text.js";
 
@@ -13,6 +14,7 @@ export type InspectionSummaryReducerId = "generic/package-lock-summary" | "gener
 export type InspectionSummary = {
   lines: string[];
   matchedReducer: InspectionSummaryReducerId;
+  compaction: CompactionMetadata;
 };
 
 function buildPackageLockSummary(value: unknown): string[] {
@@ -49,11 +51,12 @@ function buildLargeDocumentSummary(lines: string[], rawText: string): string[] {
     .filter((line) => /^#{1,6}\s+\S/u.test(line))
     .slice(0, 24);
   const excerpt = headTail(lines, 6, 6);
+  const excerptLines = excerpt.lines.map((line) => clipMiddleWithHash(line, 180).text);
   return [
     `large document summary: ${lines.length} lines, ${countTextChars(rawText)} chars`,
-    ...(headings.length > 0 ? ["headings:", ...headings.map((line) => `- ${clipMiddleWithHash(line, 180)}`)] : []),
+    ...(headings.length > 0 ? ["headings:", ...headings.map((line) => `- ${clipMiddleWithHash(line, 180).text}`)] : []),
     "excerpt:",
-    ...excerpt.map((line) => clipMiddleWithHash(line, 180)),
+    ...excerptLines,
   ];
 }
 
@@ -109,7 +112,7 @@ export function buildInspectionSummary(input: ToolExecutionInput, rawText: strin
   if (PACKAGE_LOCK_RE.test(command)) {
     const lines = buildPackageLockSummary(parseJsonValue(rawText));
     return lines.length > 0
-      ? { lines, matchedReducer: "generic/package-lock-summary" }
+      ? { lines, matchedReducer: "generic/package-lock-summary", compaction: createCompactionMetadata("inspection-package-lock-summary") }
       : null;
   }
 
@@ -122,5 +125,6 @@ export function buildInspectionSummary(input: ToolExecutionInput, rawText: strin
   return {
     lines: buildLargeDocumentSummary(lines, rawText),
     matchedReducer: "generic/large-document-summary",
+    compaction: createCompactionMetadata("inspection-large-document-summary", "head-tail-omission", "hashed-middle-clip"),
   };
 }

--- a/src/core/reduce-inspection-summary.ts
+++ b/src/core/reduce-inspection-summary.ts
@@ -1,5 +1,5 @@
 import { isFileContentInspectionCommand } from "./command-identity.js";
-import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+import { createCompactionMetadata, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { clipMiddleWithHash, parseJsonValue } from "./reduce-utils.js";
 import { countTextChars, headTail, normalizeLines, stripAnsi, trimEmptyEdges } from "./text.js";
 
@@ -45,19 +45,43 @@ function buildPackageLockSummary(value: unknown): string[] {
   return lines;
 }
 
-function buildLargeDocumentSummary(lines: string[], rawText: string): string[] {
+function buildLargeDocumentSummary(lines: string[], rawText: string): { lines: string[]; compaction: CompactionMetadata } {
   const headings = lines
     .map((line) => line.trim())
     .filter((line) => /^#{1,6}\s+\S/u.test(line))
     .slice(0, 24);
   const excerpt = headTail(lines, 6, 6);
-  const excerptLines = excerpt.lines.map((line) => clipMiddleWithHash(line, 180).text);
-  return [
-    `large document summary: ${lines.length} lines, ${countTextChars(rawText)} chars`,
-    ...(headings.length > 0 ? ["headings:", ...headings.map((line) => `- ${clipMiddleWithHash(line, 180).text}`)] : []),
-    "excerpt:",
-    ...excerptLines,
-  ];
+  const clippedHeadingCompactions: CompactionMetadata[] = [];
+  const clippedHeadings = headings.map((line) => {
+    const clipped = clipMiddleWithHash(line, 180);
+    if (clipped.compaction) {
+      clippedHeadingCompactions.push(clipped.compaction);
+    }
+    return `- ${clipped.text}`;
+  });
+  const clippedExcerptCompactions: CompactionMetadata[] = [];
+  const excerptLines = excerpt.lines.map((line) => {
+    const clipped = clipMiddleWithHash(line, 180);
+    if (clipped.compaction) {
+      clippedExcerptCompactions.push(clipped.compaction);
+    }
+    return clipped.text;
+  });
+
+  return {
+    lines: [
+      `large document summary: ${lines.length} lines, ${countTextChars(rawText)} chars`,
+      ...(clippedHeadings.length > 0 ? ["headings:", ...clippedHeadings] : []),
+      "excerpt:",
+      ...excerptLines,
+    ],
+    compaction: mergeCompactionMetadata(
+      createCompactionMetadata("inspection-large-document-summary"),
+      excerpt.compaction,
+      ...clippedHeadingCompactions,
+      ...clippedExcerptCompactions,
+    ),
+  };
 }
 
 function isLikelyDocumentLine(line: string): boolean {
@@ -122,9 +146,10 @@ export function buildInspectionSummary(input: ToolExecutionInput, rawText: strin
     return null;
   }
 
+  const summary = buildLargeDocumentSummary(lines, rawText);
   return {
-    lines: buildLargeDocumentSummary(lines, rawText),
+    lines: summary.lines,
     matchedReducer: "generic/large-document-summary",
-    compaction: createCompactionMetadata("inspection-large-document-summary", "head-tail-omission", "hashed-middle-clip"),
+    compaction: summary.compaction,
   };
 }

--- a/src/core/reduce-utils.ts
+++ b/src/core/reduce-utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { countTextChars, sliceTextChars } from "./text.js";
 
 export function compactWhitespace(text: string): string {
@@ -10,14 +11,17 @@ function shortHash(text: string): string {
   return createHash("sha256").update(text).digest("hex").slice(0, 12);
 }
 
-export function clipMiddleWithHash(text: string, maxChars: number): string {
+export function clipMiddleWithHash(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
-    return text;
+    return { text };
   }
   const omitted = countTextChars(text) - maxChars;
   const headChars = Math.max(20, Math.floor(maxChars * 0.55));
   const tailChars = Math.max(20, maxChars - headChars);
-  return `${sliceTextChars(text, 0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${sliceTextChars(text, -tailChars)}`;
+  return {
+    text: `${sliceTextChars(text, 0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${sliceTextChars(text, -tailChars)}`,
+    compaction: createCompactionMetadata("hashed-middle-clip"),
+  };
 }
 
 export function parseJsonObjectLine(line: string): Record<string, unknown> | null {

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -101,8 +101,10 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
   const preRewriteLines = [...lines];
   let rewriteCompaction: CompactionMetadata | undefined;
   if (rule.id === "cloud/gh") {
-    counterLines = rewriteGhLines(counterLines, input);
-    lines = rewriteGhLines(lines, input);
+    counterLines = rewriteGhLines(counterLines, input).lines;
+    const rewritten = rewriteGhLines(lines, input);
+    lines = rewritten.lines;
+    rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
   if (rule.id === "search/rg") {
     const rewritten = rewriteSearchLines(lines);
@@ -246,27 +248,46 @@ function selectInlineText(
   rawText: string,
   compactText: string,
   maxInlineChars: number,
-): string {
+  compactCompaction: CompactionMetadata,
+): { text: string; compaction: CompactionMetadata } {
   const passthroughText = buildPassthroughText(input, rawText);
   const rawChars = countTextChars(stripAnsi(rawText));
   const compactChars = countTextChars(compactText);
   if (shouldKeepSmallOutput(classification, input, rawChars, compactChars, maxInlineChars)) {
-    return buildLiteralPassthroughText(input, rawText);
+    return {
+      text: buildLiteralPassthroughText(input, rawText),
+      compaction: NO_COMPACTION_METADATA,
+    };
   }
   if (classification.family === "git-status") {
-    return compactText;
+    return {
+      text: compactText,
+      compaction: compactCompaction,
+    };
   }
   if (rawChars <= maxInlineChars && compactChars >= rawChars) {
-    return passthroughText;
+    return {
+      text: passthroughText,
+      compaction: NO_COMPACTION_METADATA,
+    };
   }
   const passthroughLimit = classification.family === "help" ? maxInlineChars : TINY_OUTPUT_MAX_CHARS;
   if (countTextChars(passthroughText) > passthroughLimit) {
-    return compactText;
+    return {
+      text: compactText,
+      compaction: compactCompaction,
+    };
   }
   if (countTextChars(passthroughText) <= countTextChars(compactText)) {
-    return passthroughText;
+    return {
+      text: passthroughText,
+      compaction: NO_COMPACTION_METADATA,
+    };
   }
-  return compactText;
+  return {
+    text: compactText,
+    compaction: compactCompaction,
+  };
 }
 
 export async function reduceExecution(input: ToolExecutionInput, opts: ReduceOptions = {}): Promise<CompactResult> {
@@ -486,9 +507,9 @@ export async function reduceExecutionWithRules(
   const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText);
   const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts);
   const maxInlineChars = opts.maxInlineChars ?? 1200;
-  const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars);
-  const clamp = classification.family === "help" || selectedText.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
-  const provisionalInlineText = clamp(selectedText, maxInlineChars);
+  const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars, compaction);
+  const clamp = classification.family === "help" || selectedText.text.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
+  const provisionalInlineText = clamp(selectedText.text, maxInlineChars);
   const provisionalReducedChars = countTextChars(provisionalInlineText.text);
   const provisionalStats = {
     rawChars: measuredRawChars,
@@ -510,7 +531,7 @@ export async function reduceExecutionWithRules(
         opts.storeDir,
       )
     : undefined;
-  const inlineText = clamp(selectedText, maxInlineChars);
+  const inlineText = clamp(selectedText.text, maxInlineChars);
   const reducedChars = countTextChars(inlineText.text);
   const stats = {
     rawChars: measuredRawChars,
@@ -534,7 +555,7 @@ export async function reduceExecutionWithRules(
     inlineText: inlineText.text,
     ...(summary ? { previewText: summary } : {}),
     ...(Object.keys(facts).length > 0 ? { facts } : {}),
-    compaction: mergeCompactionMetadata(compaction, inlineText.compaction),
+    compaction: mergeCompactionMetadata(selectedText.compaction, inlineText.compaction),
     ...(trace ? { trace } : {}),
     ...(rawRef ? { rawRef } : {}),
     stats,

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -2,8 +2,9 @@ import { loadRules } from "./rules.js";
 import { classifyExecution, resolveRuleMatch } from "./classify.js";
 import { isFileContentInspectionCommand } from "./command-identity.js";
 import { normalizeExecutionInput } from "./execution-input.js";
-import { clampText, clampTextMiddle, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
+import { clampTextMiddleWithMetadata, clampTextWithMetadata, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
 import { storeArtifact, storeArtifactMetadata } from "./artifacts.js";
+import { NO_COMPACTION_METADATA, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { buildGithubActionsFailureSummary } from "./github-actions-summary.js";
 import { rewriteGhLines, rewriteGitDiffLines, rewriteGitStatusLines, rewriteSearchLines } from "./reduce-formatters.js";
 import { buildInspectionSummary } from "./reduce-inspection-summary.js";
@@ -48,7 +49,7 @@ function prettyPrintJsonIfPossible(text: string): string {
   return text;
 }
 
-function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawText: string): { summary: string; facts: Record<string, number> } {
+function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawText: string): { summary: string; facts: Record<string, number>; compaction: CompactionMetadata } {
   const rule = compiledRule.rule;
   if (rule.transforms?.prettyPrintJson) {
     rawText = prettyPrintJsonIfPossible(rawText);
@@ -66,6 +67,7 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
     return {
       summary: matchedOutput.message,
       facts,
+      compaction: NO_COMPACTION_METADATA,
     };
   }
 
@@ -97,15 +99,20 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
     lines = rewriteGitStatusLines(lines);
   }
   const preRewriteLines = [...lines];
+  let rewriteCompaction: CompactionMetadata | undefined;
   if (rule.id === "cloud/gh") {
     counterLines = rewriteGhLines(counterLines, input);
     lines = rewriteGhLines(lines, input);
   }
   if (rule.id === "search/rg") {
-    lines = rewriteSearchLines(lines);
+    const rewritten = rewriteSearchLines(lines);
+    lines = rewritten.lines;
+    rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
   if (rule.id === "git/diff") {
-    lines = rewriteGitDiffLines(lines);
+    const rewritten = rewriteGitDiffLines(lines);
+    lines = rewritten.lines;
+    rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
 
   for (const counter of compiledRule.compiled.counters) {
@@ -121,6 +128,7 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
     return {
       summary: rule.onEmpty,
       facts,
+      compaction: rewriteCompaction ?? NO_COMPACTION_METADATA,
     };
   }
 
@@ -136,8 +144,9 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
 
   const compacted = headTail(lines, summarize.head, summarize.tail);
   return {
-    summary: compacted.join("\n").trim(),
+    summary: compacted.lines.join("\n").trim(),
     facts,
+    compaction: mergeCompactionMetadata(rewriteCompaction, compacted.compaction),
   };
 }
 
@@ -328,6 +337,7 @@ export async function reduceExecutionWithRules(
 
     return {
       inlineText: rawText,
+      compaction: NO_COMPACTION_METADATA,
       ...(trace ? { trace } : {}),
       ...(rawRef ? { rawRef } : {}),
       stats: {
@@ -342,8 +352,8 @@ export async function reduceExecutionWithRules(
   const inspectionSummary = buildInspectionSummary(normalizedInput, rawText);
   if (inspectionSummary) {
     const summaryText = inspectionSummary.lines.join("\n").trim();
-    const selectedText = clampTextMiddle(summaryText, opts.maxInlineChars ?? 1200);
-    const reducedChars = countTextChars(selectedText);
+    const selectedText = clampTextMiddleWithMetadata(summaryText, opts.maxInlineChars ?? 1200);
+    const reducedChars = countTextChars(selectedText.text);
     const summaryClassification = {
       family: "structured-summary",
       confidence: 0.9,
@@ -379,8 +389,9 @@ export async function reduceExecutionWithRules(
     }
 
     return {
-      inlineText: selectedText,
+      inlineText: selectedText.text,
       previewText: summaryText,
+      compaction: mergeCompactionMetadata(inspectionSummary.compaction, selectedText.compaction),
       ...(trace ? { trace } : {}),
       ...(rawRef ? { rawRef } : {}),
       stats,
@@ -407,6 +418,7 @@ export async function reduceExecutionWithRules(
 
     return {
       inlineText: rawText,
+      compaction: NO_COMPACTION_METADATA,
       ...(trace ? { trace } : {}),
       stats: {
         rawChars: measuredRawChars,
@@ -429,8 +441,8 @@ export async function reduceExecutionWithRules(
     : null;
   if (githubActionsFailureSummary) {
     const maxInlineChars = opts.maxInlineChars ?? 1200;
-    const inlineText = clampTextMiddle(githubActionsFailureSummary, maxInlineChars);
-    const reducedChars = countTextChars(inlineText);
+    const inlineText = clampTextMiddleWithMetadata(githubActionsFailureSummary.text, maxInlineChars);
+    const reducedChars = countTextChars(inlineText.text);
     const stats = {
       rawChars: measuredRawChars,
       reducedChars,
@@ -461,8 +473,9 @@ export async function reduceExecutionWithRules(
     }
 
     return {
-      inlineText,
-      previewText: githubActionsFailureSummary,
+      inlineText: inlineText.text,
+      previewText: githubActionsFailureSummary.text,
+      compaction: mergeCompactionMetadata(githubActionsFailureSummary.compaction, inlineText.compaction),
       ...(trace ? { trace } : {}),
       ...(rawRef ? { rawRef } : {}),
       stats,
@@ -470,13 +483,13 @@ export async function reduceExecutionWithRules(
     };
   }
 
-  const { summary, facts } = applyRule(matchedRule, reducerInput, rawText);
+  const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText);
   const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts);
   const maxInlineChars = opts.maxInlineChars ?? 1200;
   const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars);
-  const clamp = classification.family === "help" || selectedText.includes("\n") ? clampTextMiddle : clampText;
+  const clamp = classification.family === "help" || selectedText.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
   const provisionalInlineText = clamp(selectedText, maxInlineChars);
-  const provisionalReducedChars = countTextChars(provisionalInlineText);
+  const provisionalReducedChars = countTextChars(provisionalInlineText.text);
   const provisionalStats = {
     rawChars: measuredRawChars,
     reducedChars: provisionalReducedChars,
@@ -498,7 +511,7 @@ export async function reduceExecutionWithRules(
       )
     : undefined;
   const inlineText = clamp(selectedText, maxInlineChars);
-  const reducedChars = countTextChars(inlineText);
+  const reducedChars = countTextChars(inlineText.text);
   const stats = {
     rawChars: measuredRawChars,
     reducedChars,
@@ -518,9 +531,10 @@ export async function reduceExecutionWithRules(
   }
 
   return {
-    inlineText,
+    inlineText: inlineText.text,
     ...(summary ? { previewText: summary } : {}),
     ...(Object.keys(facts).length > 0 ? { facts } : {}),
+    compaction: mergeCompactionMetadata(compaction, inlineText.compaction),
     ...(trace ? { trace } : {}),
     ...(rawRef ? { rawRef } : {}),
     stats,

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -1,3 +1,5 @@
+import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+
 const ANSI_CSI_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
 const ANSI_OSC_PATTERN = new RegExp(String.raw`\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)`, "g");
 const ANSI_CSI_INCOMPLETE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*$`, "g");
@@ -137,16 +139,25 @@ export function dedupeAdjacent(lines: string[]): string[] {
   return next;
 }
 
-export function headTail(lines: string[], head: number, tail: number): string[] {
-  if (lines.length <= head + tail) {
-    return lines;
+export function headTail(lines: string[], head: number, tail: number): { lines: string[]; compaction?: CompactionMetadata } {
+  const safeHead = Math.max(0, head);
+  const safeTail = Math.max(0, tail);
+  if (safeHead === 0 && safeTail === 0) {
+    return { lines };
   }
 
-  return [
-    ...lines.slice(0, head),
-    `... ${lines.length - head - tail} lines omitted ...`,
-    ...lines.slice(-tail),
-  ];
+  if (lines.length <= safeHead + safeTail) {
+    return { lines };
+  }
+
+  return {
+    lines: [
+      ...lines.slice(0, safeHead),
+      `... ${lines.length - safeHead - safeTail} lines omitted ...`,
+      ...lines.slice(-safeTail),
+    ],
+    compaction: createCompactionMetadata("head-tail-omission"),
+  };
 }
 
 export function clampText(text: string, maxChars: number): string {
@@ -158,9 +169,24 @@ export function clampText(text: string, maxChars: number): string {
   return `${head}${TRUNCATION_SUFFIX}`;
 }
 
-export function clampTextMiddle(text: string, maxChars: number): string {
+export function clampTextWithMetadata(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
-    return text;
+    return { text };
+  }
+
+  return {
+    text: clampText(text, maxChars),
+    compaction: createCompactionMetadata("tail-truncation"),
+  };
+}
+
+export function clampTextMiddle(text: string, maxChars: number): string {
+  return clampTextMiddleWithMetadata(text, maxChars).text;
+}
+
+export function clampTextMiddleWithMetadata(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+  if (countTextChars(text) <= maxChars) {
+    return { text };
   }
 
   const markerChars = countTextChars(MIDDLE_TRUNCATION_MARKER);
@@ -171,7 +197,10 @@ export function clampTextMiddle(text: string, maxChars: number): string {
   const head = trimHeadToLineBoundary(segments.slice(0, headChars).join(""));
   const tail = trimTailToLineBoundary(segments.slice(-tailChars).join(""));
 
-  return `${head}${MIDDLE_TRUNCATION_MARKER}${tail}`;
+  return {
+    text: `${head}${MIDDLE_TRUNCATION_MARKER}${tail}`,
+    compaction: createCompactionMetadata("middle-truncation"),
+  };
 }
 
 export function pluralize(count: number, noun: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export type CompactResult = {
   inlineText: string;
   previewText?: string;
   facts?: Record<string, number>;
+  compaction?: import("./core/compaction-metadata.js").CompactionMetadata;
   trace?: {
     normalizedCommand?: string;
     normalizedArgv?: string[];

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1099,6 +1099,52 @@ describe("reduceExecution", () => {
 
     expect(result.inlineText).toBe("ok: 93 rules validated, 93 fixtures verified");
     expect(result.stats.reducedChars).toBeLessThan(result.stats.rawChars);
+    expect(result.compaction?.authoritative).toBe(false);
+  });
+
+  it("marks head-tail summaries as authoritative compaction when lines were omitted", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git log --oneline",
+      argv: ["git", "log", "--oneline"],
+      combinedText: Array.from({ length: 20 }, (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`).join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toContain("commits");
+    expect(result.inlineText).toContain("omitted");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["head-tail-omission"] });
+  });
+
+  it("does not mark rewritten-but-lossless output as authoritative compaction", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git branch -d fix/cd-prefixed-raw-bypass-main 2>&1",
+      combinedText: "Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).\n",
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toBe("Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).");
+    expect(result.stats.reducedChars).toBeLessThan(result.stats.rawChars);
+    expect(result.compaction?.authoritative).toBe(false);
+  });
+
+  it("marks structured inspection summaries as authoritative compaction", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "sed -n '1,260p' notes.txt",
+      argv: ["sed", "-n", "1,260p", "notes.txt"],
+      combinedText: [
+        "# Review",
+        "intro",
+        "## Evidence",
+        ...Array.from({ length: 260 }, (_, index) => `paragraph ${index} ${"x".repeat(40)}`),
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/large-document-summary");
+    expect(result.compaction?.authoritative).toBe(true);
   });
 
   it("keeps search output raw when the rewritten form would be longer but still fits inline", async () => {

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1144,7 +1144,24 @@ describe("reduceExecution", () => {
     });
 
     expect(result.classification.matchedReducer).toBe("generic/large-document-summary");
-    expect(result.compaction?.authoritative).toBe(true);
+    expect(result.compaction).toEqual({
+      authoritative: true,
+      kinds: ["inspection-large-document-summary", "head-tail-omission"],
+    });
+  });
+
+  it("clears lossy compaction metadata when passthrough text wins", async () => {
+    const rawText = `${Array.from({ length: 13 }, (_, index) => `v${index}`).join("\n")}\n`;
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-tool inspect",
+      combinedText: rawText,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toBe(rawText.trimEnd());
+    expect(result.compaction?.authoritative).toBe(false);
   });
 
   it("keeps search output raw when the rewritten form would be longer but still fits inline", async () => {
@@ -1261,6 +1278,7 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("comment #123 @reviewer src/index.ts:42");
     expect(result.inlineText).toContain("sha256:");
     expect(result.inlineText).not.toContain("\"body\"");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["hashed-middle-clip"] });
   });
 
   it("clips large git diff hunks while keeping exact file and hunk headers", async () => {

--- a/test/core/text.test.ts
+++ b/test/core/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { clampText, countTerminalCells, countTextChars, stripAnsi } from "../../src/core/text.js";
+import { clampText, clampTextWithMetadata, countTerminalCells, countTextChars, headTail, stripAnsi } from "../../src/core/text.js";
 
 describe("text helpers", () => {
   it("strips xterm colors and OSC hyperlinks while preserving emoji and CJK", () => {
@@ -23,6 +23,18 @@ describe("text helpers", () => {
 
     expect(clamped).toBe("\n... truncated ...");
     expect(countTextChars(clamped)).toBeLessThanOrEqual(18);
+  });
+
+  it("records tail truncation metadata when clampTextWithMetadata shortens output", () => {
+    const result = clampTextWithMetadata("abcdefghijklmnopqrstuvwxyz", 10);
+
+    expect(result.text).toContain("... truncated ...");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["tail-truncation"] });
+  });
+
+  it("does not mark headTail as omission when both sides are zero or negative", () => {
+    expect(headTail(["a", "b", "c"], 0, 0)).toEqual({ lines: ["a", "b", "c"] });
+    expect(headTail(["a", "b", "c"], -2, -3)).toEqual({ lines: ["a", "b", "c"] });
   });
 
   it("counts terminal cells for emoji, cjk, and combining characters", () => {

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { listArtifactMetadata, listArtifacts, runWrappedCommand } from "../../src/index.js";
+import { WRAP_AUTHORITATIVE_FOOTER } from "../../src/core/compaction-metadata.js";
 
 const tempDirs: string[] = [];
 
@@ -108,5 +109,28 @@ describe("runWrappedCommand", () => {
     const metadata = await listArtifactMetadata(storeDir);
     expect(metadata).toHaveLength(1);
     expect(metadata[0]?.metadata.source).toBe("cursor");
+  });
+
+  it("does not flag lossless rewrites as authoritative compaction", async () => {
+    const wrapped = await runWrappedCommand([
+      "node",
+      "-e",
+      "process.stdout.write('Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).\\n');",
+    ]);
+
+    expect(wrapped.result.inlineText).toBe("Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).");
+    expect(wrapped.result.compaction?.authoritative).toBe(false);
+    expect(wrapped.result.inlineText).not.toContain(WRAP_AUTHORITATIVE_FOOTER);
+  });
+
+  it("flags omitted summaries as authoritative compaction", async () => {
+    const wrapped = await runWrappedCommand([
+      "node",
+      "-e",
+      "process.stdout.write(Array.from({ length: 40 }, (_, index) => `line ${index} ${'x'.repeat(80)}`).join('\\n'));",
+    ]);
+
+    expect(wrapped.result.inlineText).toContain("omitted");
+    expect(wrapped.result.compaction?.authoritative).toBe(true);
   });
 });

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -123,6 +123,18 @@ describe("runWrappedCommand", () => {
     expect(wrapped.result.inlineText).not.toContain(WRAP_AUTHORITATIVE_FOOTER);
   });
 
+  it("does not keep authoritative compaction when passthrough beats a lossy summary", async () => {
+    const wrapped = await runWrappedCommand([
+      "node",
+      "-e",
+      "process.stdout.write(Array.from({ length: 13 }, (_, index) => `v${index}`).join('\\n') + '\\n');",
+    ]);
+
+    expect(wrapped.result.inlineText).toBe(Array.from({ length: 13 }, (_, index) => `v${index}`).join("\n"));
+    expect(wrapped.result.compaction?.authoritative).toBe(false);
+    expect(wrapped.result.inlineText).not.toContain(WRAP_AUTHORITATIVE_FOOTER);
+  });
+
   it("flags omitted summaries as authoritative compaction", async () => {
     const wrapped = await runWrappedCommand([
       "node",


### PR DESCRIPTION
## Summary

Fixes a `wrap` bug where tokenjuice could append the authoritative compaction footer even when no meaningful content had actually been omitted.

The fix switches `wrap` away from inferring omission from `rawChars > reducedChars` alone, and instead uses structured `CompactionMetadata` emitted by reducers and text-compaction helpers. This keeps the existing reducer output text stable while making the footer decision accurate.

## Reproduction

Before this fix, a command like this could incorrectly get the long authoritative footer even though the visible output was effectively unchanged apart from trimming the trailing newline:

```bash
node dist/cli/main.js wrap -- node -e "process.stdout.write('Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).\\n')"
```

Before:

```text
Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).
---
[tokenjuice] This is the complete, authoritative output for this command. It was deterministically compacted to remove low-signal noise; the omitted content is not retrievable. Do not re-run the command, vary flags, or switch tools to try to recover it. Proceed with the task using this output.
```

After:

```text
Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).
```

A real omission case should still keep the footer:

```bash
node dist/cli/main.js wrap -- node -e "process.stdout.write(Array.from({ length: 40 }, (_, index) => 'line ' + index + ' ' + 'x'.repeat(80)).join('\\n'))"
```

That output still contains omission markers and still appends the authoritative footer.

## Changes

- add structured `CompactionMetadata` to reduction results and propagate it through the compaction pipeline
- teach text helpers and reducer helpers to report when they actually performed lossy compaction
- gate the `wrap` footer on structured authoritative compaction metadata plus real size reduction
- harden edge cases around `headTail()` and tail truncation metadata
- add regression tests for lossless rewrites, real omission cases, and text-helper metadata

## Testing

```bash
pnpm exec vitest run test/core/text.test.ts test/core/reduce.test.ts test/core/wrap.test.ts test/core/trace.test.ts
pnpm build
```
