### PR TITLE
fix(cli): quiet doctor hooks output

### DIFF
--- a/src/cli/doctor-output.ts
+++ b/src/cli/doctor-output.ts
@@ -1,0 +1,85 @@
+import { getAvailableHookIntegrationNames, getInstalledHookIntegrations } from "../hosts/shared/hook-doctor.js";
+import type { HookDoctorReport } from "../hosts/shared/hook-doctor.js";
+
+type IntegrationDoctorReport = HookDoctorReport["integrations"][keyof HookDoctorReport["integrations"]];
+
+function getIntegrationPath(report: IntegrationDoctorReport): string {
+  if ("hooksPath" in report) {
+    return report.hooksPath;
+  }
+  if ("settingsPath" in report) {
+    return report.settingsPath;
+  }
+  if ("hookPath" in report) {
+    return report.hookPath;
+  }
+  if ("rulePath" in report) {
+    return report.rulePath;
+  }
+  if ("conventionPath" in report) {
+    return report.conventionPath;
+  }
+  if ("instructionsPath" in report) {
+    return report.instructionsPath;
+  }
+  return report.extensionPath;
+}
+
+function appendInstallHint(lines: string[]): void {
+  lines.push("");
+  lines.push(`available integrations: ${getAvailableHookIntegrationNames().join(", ")}`);
+  lines.push("enable another integration: tokenjuice install <host>");
+}
+
+export function formatHookDoctorReport(report: HookDoctorReport): string {
+  const lines = [`hook health: ${report.status}`];
+  const installedIntegrations = getInstalledHookIntegrations(report);
+
+  if (installedIntegrations.length === 0) {
+    lines.push("no tokenjuice hooks installed");
+    appendInstallHint(lines);
+    return `${lines.join("\n")}\n`;
+  }
+
+  for (const [index, [name, integrationReport]] of installedIntegrations.entries()) {
+    if (index > 0) {
+      lines.push("");
+    }
+    lines.push(`${name}:`);
+    lines.push(`- path: ${getIntegrationPath(integrationReport)}`);
+    lines.push(`- health: ${integrationReport.status}`);
+    if ("expectedCommand" in integrationReport) {
+      lines.push(`- expected command: ${integrationReport.expectedCommand}`);
+    }
+    if ("detectedCommand" in integrationReport && integrationReport.detectedCommand) {
+      lines.push(`- configured command: ${integrationReport.detectedCommand}`);
+    }
+    if (integrationReport.issues.length > 0) {
+      lines.push("- issues:");
+      for (const issue of integrationReport.issues) {
+        lines.push(`  - ${issue}`);
+      }
+    }
+    if (integrationReport.missingPaths.length > 0) {
+      lines.push("- missing paths:");
+      for (const path of integrationReport.missingPaths) {
+        lines.push(`  - ${path}`);
+      }
+    }
+    if ("featureFlag" in integrationReport && integrationReport.featureFlag) {
+      const flag = integrationReport.featureFlag;
+      if (flag.enabled) {
+        lines.push(`- feature flag: codex_hooks is enabled (${flag.configPath})`);
+      } else {
+        const where = flag.configExists
+          ? `${flag.configPath} (missing or disabled)`
+          : `no ${flag.configPath}`;
+        lines.push(`- feature flag: codex_hooks not enabled — ${where}`);
+      }
+    }
+    lines.push(`- repair: ${integrationReport.fixCommand}`);
+  }
+
+  appendInstallHint(lines);
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -47,6 +47,7 @@ import {
 } from "../hosts/vscode-copilot/index.js";
 import { doctorZedInstructions, installZedInstructions, uninstallZedInstructions } from "../hosts/zed/index.js";
 import { doctorInstalledHooks } from "../hosts/shared/hook-doctor.js";
+import { formatHookDoctorReport } from "./doctor-output.js";
 import { formatInstallSuccess } from "./install-output.js";
 
 type Format = "text" | "json";
@@ -1153,57 +1154,7 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       return report.status === "broken" ? 1 : 0;
     }
 
-    process.stdout.write(`hook health: ${report.status}\n`);
-    for (const [name, integrationReport] of Object.entries(report.integrations)) {
-      const pathLabel = "hooksPath" in integrationReport
-        ? integrationReport.hooksPath
-        : "settingsPath" in integrationReport
-          ? integrationReport.settingsPath
-          : "hookPath" in integrationReport
-            ? integrationReport.hookPath
-            : "rulePath" in integrationReport
-              ? integrationReport.rulePath
-              : "conventionPath" in integrationReport
-                ? integrationReport.conventionPath
-                : "instructionsPath" in integrationReport
-                  ? integrationReport.instructionsPath
-                  : integrationReport.extensionPath;
-      process.stdout.write(`${name}:\n`);
-      process.stdout.write(`- path: ${pathLabel}\n`);
-      process.stdout.write(`- health: ${integrationReport.status}\n`);
-      if ("expectedCommand" in integrationReport) {
-        process.stdout.write(`- expected command: ${integrationReport.expectedCommand}\n`);
-      }
-      if ("detectedCommand" in integrationReport && integrationReport.detectedCommand) {
-        process.stdout.write(`- configured command: ${integrationReport.detectedCommand}\n`);
-      }
-      if (integrationReport.issues.length > 0) {
-        process.stdout.write("- issues:\n");
-        for (const issue of integrationReport.issues) {
-          process.stdout.write(`  - ${issue}\n`);
-        }
-      }
-      if (integrationReport.missingPaths.length > 0) {
-        process.stdout.write("- missing paths:\n");
-        for (const path of integrationReport.missingPaths) {
-          process.stdout.write(`  - ${path}\n`);
-        }
-      }
-      if ("featureFlag" in integrationReport && integrationReport.featureFlag) {
-        const flag = integrationReport.featureFlag;
-        if (flag.enabled) {
-          process.stdout.write(
-            `- feature flag: codex_hooks is enabled (${flag.configPath})\n`,
-          );
-        } else {
-          const where = flag.configExists
-            ? `${flag.configPath} (missing or disabled)`
-            : `no ${flag.configPath}`;
-          process.stdout.write(`- feature flag: codex_hooks not enabled — ${where}\n`);
-        }
-      }
-      process.stdout.write(`- repair: ${integrationReport.fixCommand}\n`);
-    }
+    process.stdout.write(formatHookDoctorReport(report));
     return report.status === "broken" ? 1 : 0;
   }
 

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -32,7 +32,7 @@ import type { PiDoctorReport } from "../pi/index.js";
 import type { VscodeCopilotDoctorReport } from "../vscode-copilot/index.js";
 import type { ZedDoctorReport } from "../zed/index.js";
 
-type HookHealthStatus = "ok" | "warn" | "broken" | "disabled";
+export type HookHealthStatus = "ok" | "warn" | "broken" | "disabled";
 
 export type HookIntegrationDoctorReport = {
   aider: AiderDoctorReport;
@@ -59,6 +59,38 @@ export type HookDoctorReport = {
 };
 
 export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions;
+export type HookIntegrationDoctorEntry = [
+  keyof HookIntegrationDoctorReport,
+  HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
+];
+type HookDoctorIntegrationDoctors = {
+  [Name in keyof HookIntegrationDoctorReport]: (
+    options: HookDoctorCommandOptions,
+  ) => Promise<HookIntegrationDoctorReport[Name]>;
+};
+
+const hookDoctorIntegrationDoctors = {
+  aider: () => doctorAiderConvention(),
+  avante: () => doctorAvanteInstructions(),
+  codex: (options) => doctorCodexHook(undefined, options),
+  "claude-code": (options) => doctorClaudeCodeHook(undefined, getHookCommandOptions(options)),
+  cline: (options) => doctorClineHook(undefined, getHookCommandOptions(options)),
+  codebuddy: (options) => doctorCodeBuddyHook(undefined, getHookCommandOptions(options)),
+  continue: () => doctorContinueRule(),
+  cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
+  droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
+  "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
+  junie: () => doctorJunieInstructions(),
+  openhands: (options) => doctorOpenHandsHook(undefined, getHookCommandOptions(options)),
+  pi: () => doctorPiExtension(),
+  "vscode-copilot": (options) => doctorVscodeCopilotHook(undefined, getHookCommandOptions(options)),
+  zed: () => doctorZedInstructions(),
+  "copilot-cli": (options) => doctorCopilotCliHook(undefined, getHookCommandOptions(options)),
+} satisfies HookDoctorIntegrationDoctors;
+
+export function getAvailableHookIntegrationNames(): Array<keyof HookIntegrationDoctorReport> {
+  return Object.keys(hookDoctorIntegrationDoctors) as Array<keyof HookIntegrationDoctorReport>;
+}
 
 function mergeStatus(left: HookHealthStatus, right: HookHealthStatus): HookHealthStatus {
   if (left === "broken" || right === "broken") {
@@ -80,65 +112,47 @@ function mergeStatuses(statuses: readonly HookHealthStatus[]): HookHealthStatus 
   return statuses.reduce(mergeStatus, "disabled");
 }
 
-export async function doctorInstalledHooks(options: HookDoctorCommandOptions = {}): Promise<HookDoctorReport> {
-  const aider = await doctorAiderConvention();
-  const avante = await doctorAvanteInstructions();
-  const codex = await doctorCodexHook(undefined, options);
-  const hookCommandOptions = {
+function getHookCommandOptions(options: HookDoctorCommandOptions): HookDoctorCommandOptions {
+  return {
     ...(typeof options.local === "boolean" ? { local: options.local } : {}),
     ...(typeof options.binaryPath === "string" ? { binaryPath: options.binaryPath } : {}),
     ...(typeof options.nodePath === "string" ? { nodePath: options.nodePath } : {}),
   };
-  const claudeCode = await doctorClaudeCodeHook(undefined, hookCommandOptions);
-  const cline = await doctorClineHook(undefined, hookCommandOptions);
-  const codebuddy = await doctorCodeBuddyHook(undefined, hookCommandOptions);
-  const continueRule = await doctorContinueRule();
-  const cursor = await doctorCursorHook(undefined, hookCommandOptions);
-  const droid = await doctorDroidHook(undefined, hookCommandOptions);
-  const geminiCli = await doctorGeminiCliHook(undefined, hookCommandOptions);
-  const junie = await doctorJunieInstructions();
-  const openhands = await doctorOpenHandsHook(undefined, hookCommandOptions);
-  const pi = await doctorPiExtension();
-  const vscodeCopilot = await doctorVscodeCopilotHook(undefined, hookCommandOptions);
-  const zed = await doctorZedInstructions();
-  const copilotCli = await doctorCopilotCliHook(undefined, hookCommandOptions);
+}
+
+function hasDetectedCommand(report: HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport]): boolean {
+  return "detectedCommand" in report && typeof report.detectedCommand === "string" && report.detectedCommand.length > 0;
+}
+
+export function isInstalledHookIntegration(
+  report: HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
+): boolean {
+  if (hasDetectedCommand(report)) {
+    return true;
+  }
+  // Command-backed hosts can warn about missing config even when tokenjuice is
+  // not installed. Instruction/extension hosts have no expected command, so a
+  // non-disabled status means their tokenjuice artifact exists.
+  return report.status !== "disabled" && !("expectedCommand" in report);
+}
+
+export function getInstalledHookIntegrations(report: HookDoctorReport): HookIntegrationDoctorEntry[] {
+  return (Object.entries(report.integrations) as HookIntegrationDoctorEntry[])
+    .filter(([, integrationReport]) => isInstalledHookIntegration(integrationReport));
+}
+
+export async function doctorInstalledHooks(options: HookDoctorCommandOptions = {}): Promise<HookDoctorReport> {
+  const integrationEntries = await Promise.all(
+    (Object.entries(hookDoctorIntegrationDoctors) as Array<[
+      keyof HookIntegrationDoctorReport,
+      HookDoctorIntegrationDoctors[keyof HookIntegrationDoctorReport],
+    ]>).map(async ([name, doctor]) => [name, await doctor(options)] as const),
+  );
+  const integrations = Object.fromEntries(integrationEntries) as HookIntegrationDoctorReport;
+  const installedIntegrations = getInstalledHookIntegrations({ status: "disabled", integrations });
 
   return {
-    status: mergeStatuses([
-      aider.status,
-      avante.status,
-      codex.status,
-      claudeCode.status,
-      cline.status,
-      codebuddy.status,
-      continueRule.status,
-      cursor.status,
-      droid.status,
-      geminiCli.status,
-      junie.status,
-      openhands.status,
-      pi.status,
-      vscodeCopilot.status,
-      zed.status,
-      copilotCli.status,
-    ]),
-    integrations: {
-      aider,
-      avante,
-      codex,
-      "claude-code": claudeCode,
-      cline,
-      codebuddy,
-      continue: continueRule,
-      cursor,
-      droid,
-      "gemini-cli": geminiCli,
-      junie,
-      openhands,
-      pi,
-      "vscode-copilot": vscodeCopilot,
-      zed,
-      "copilot-cli": copilotCli,
-    },
+    status: mergeStatuses(installedIntegrations.map(([, integrationReport]) => integrationReport.status)),
+    integrations,
   };
 }

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { formatHookDoctorReport } from "../../src/cli/doctor-output.js";
+import type { HookDoctorReport } from "../../src/index.js";
+
+function disabledReport(path: string): {
+  hooksPath: string;
+  status: "disabled";
+  issues: string[];
+  missingPaths: string[];
+  fixCommand: string;
+} {
+  return {
+    hooksPath: path,
+    status: "disabled",
+    issues: ["tokenjuice hook is not installed"],
+    missingPaths: [],
+    fixCommand: "tokenjuice install codex",
+  };
+}
+
+describe("formatHookDoctorReport", () => {
+  it("omits disabled integrations from text output", () => {
+    const report = {
+      status: "ok",
+      integrations: {
+        codex: disabledReport("/tmp/codex/hooks.json"),
+        "claude-code": {
+          settingsPath: "/tmp/claude/settings.json",
+          status: "ok",
+          expectedCommand: "tokenjuice claude-code-post-tool-use",
+          detectedCommand: "tokenjuice claude-code-post-tool-use",
+          issues: [],
+          missingPaths: [],
+          fixCommand: "tokenjuice install claude-code",
+        },
+      },
+    } as unknown as HookDoctorReport;
+
+    expect(formatHookDoctorReport(report)).toBe([
+      "hook health: ok",
+      "claude-code:",
+      "- path: /tmp/claude/settings.json",
+      "- health: ok",
+      "- expected command: tokenjuice claude-code-post-tool-use",
+      "- configured command: tokenjuice claude-code-post-tool-use",
+      "- repair: tokenjuice install claude-code",
+      "",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, openhands, pi, vscode-copilot, zed, copilot-cli",
+      "enable another integration: tokenjuice install <host>",
+      "",
+    ].join("\n"));
+  });
+
+  it("prints a compact empty state when no hooks are installed", () => {
+    const report = {
+      status: "disabled",
+      integrations: {
+        codex: disabledReport("/tmp/codex/hooks.json"),
+        "claude-code": {
+          settingsPath: "/tmp/claude/settings.json",
+          status: "disabled",
+          issues: ["tokenjuice hook is not installed"],
+          missingPaths: [],
+          fixCommand: "tokenjuice install claude-code",
+        },
+      },
+    } as unknown as HookDoctorReport;
+
+    expect(formatHookDoctorReport(report)).toBe([
+      "hook health: disabled",
+      "no tokenjuice hooks installed",
+      "",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, openhands, pi, vscode-copilot, zed, copilot-cli",
+      "enable another integration: tokenjuice install <host>",
+      "",
+    ].join("\n"));
+  });
+});

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -5,10 +5,12 @@ import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { doctorClaudeCodeHook, doctorInstalledHooks, installClaudeCodeHook, installCodeBuddyHook, installCodexHook, installCursorHook, installPiExtension, runClaudeCodePostToolUseHook } from "../../src/index.js";
+import { getInstalledHookIntegrations } from "../../src/hosts/shared/hook-doctor.js";
 
 const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
 const originalHome = process.env.HOME;
+const originalFactoryHome = process.env.FACTORY_HOME;
 
 afterEach(async () => {
   delete process.env.CLAUDE_CONFIG_DIR;
@@ -17,6 +19,7 @@ afterEach(async () => {
   delete process.env.CODEBUDDY_HOME;
   delete process.env.CODEX_HOME;
   delete process.env.CURSOR_HOME;
+  delete process.env.FACTORY_HOME;
   delete process.env.PI_CODING_AGENT_DIR;
   delete process.env.COPILOT_HOME;
   process.env.PATH = originalPath;
@@ -24,6 +27,11 @@ afterEach(async () => {
     delete process.env.HOME;
   } else {
     process.env.HOME = originalHome;
+  }
+  if (originalFactoryHome === undefined) {
+    delete process.env.FACTORY_HOME;
+  } else {
+    process.env.FACTORY_HOME = originalFactoryHome;
   }
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
@@ -423,6 +431,29 @@ describe("doctorClaudeCodeHook", () => {
 });
 
 describe("doctorInstalledHooks", () => {
+  it("does not treat missing command-backed provider configs as installed hooks", async () => {
+    const home = await createTempDir();
+    const binDir = join(home, "bin");
+
+    process.env.PATH = binDir;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = join(home, "codex");
+    process.env.CLAUDE_HOME = join(home, "claude");
+    process.env.CODEBUDDY_HOME = join(home, "codebuddy");
+    process.env.CURSOR_HOME = join(home, "cursor");
+    process.env.FACTORY_HOME = join(home, "factory");
+    process.env.COPILOT_HOME = join(home, "copilot");
+    process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
+    await mkdir(binDir, { recursive: true });
+    await writeFile(join(binDir, "tokenjuice"), "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const report = await doctorInstalledHooks();
+
+    expect(report.status).toBe("disabled");
+    expect(report.integrations["claude-code"].status).toBe("warn");
+    expect(getInstalledHookIntegrations(report)).toEqual([]);
+  });
+
   it("reports codex and claude-code health together", async () => {
     const home = await createTempDir();
     const binDir = join(home, "bin");
@@ -435,6 +466,7 @@ describe("doctorInstalledHooks", () => {
     process.env.CLAUDE_HOME = home;
     process.env.CODEBUDDY_HOME = codebuddyHome;
     process.env.CURSOR_HOME = home;
+    process.env.FACTORY_HOME = join(home, "factory");
     process.env.COPILOT_HOME = home;
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
@@ -466,6 +498,7 @@ describe("doctorInstalledHooks", () => {
     process.env.CLAUDE_HOME = home;
     process.env.CODEBUDDY_HOME = codebuddyHome;
     process.env.CURSOR_HOME = home;
+    process.env.FACTORY_HOME = join(home, "factory");
     process.env.COPILOT_HOME = home;
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
@@ -515,6 +548,7 @@ describe("doctorInstalledHooks", () => {
     process.env.CLAUDE_HOME = claudeHome;
     process.env.CODEBUDDY_HOME = codebuddyHome;
     process.env.CURSOR_HOME = cursorHome;
+    process.env.FACTORY_HOME = join(home, "factory");
     process.env.COPILOT_HOME = home;
     process.env.PI_CODING_AGENT_DIR = piAgentDir;
     await mkdir(binDir, { recursive: true });


### PR DESCRIPTION
## Summary
- show only installed tokenjuice integrations in `doctor hooks` text output
- keep full aggregate diagnostics available in JSON
- add an installed-integration helper and available integration hint for enabling other hosts

## Test plan
- `pnpm exec vitest run test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm verify`
