### PR TITLE
refactor(artifacts): add TOKENJUICE_ARTIFACT_DIR env override and isolate test artifacts

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -248,6 +248,10 @@ artifacts are file-backed in v1:
 - one raw text file
 - one metadata JSON file
 
+default storage is `~/.tokenjuice/artifacts`. set `TOKENJUICE_ARTIFACT_DIR`
+to override that base directory, or pass `storeDir` through the library/cli
+surfaces that already support it.
+
 that is intentionally boring. boring is good here.
 
 ## reliability priorities

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -9,7 +9,7 @@ import { resolveArtifactSource } from "./source.js";
 import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
-const TEST_ARTIFACT_DIR_ENV = "TOKENJUICE_TEST_ARTIFACT_DIR";
+export const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -59,9 +59,9 @@ function extractCaptureTruncatedFlag(input: ToolExecutionInput): boolean | undef
 }
 
 function getDefaultArtifactDir(): string {
-  const testArtifactDir = process.env[TEST_ARTIFACT_DIR_ENV];
-  if (typeof testArtifactDir === "string" && testArtifactDir.trim()) {
-    return testArtifactDir;
+  const artifactDir = process.env[ARTIFACT_DIR_ENV];
+  if (typeof artifactDir === "string" && artifactDir.trim()) {
+    return artifactDir;
   }
 
   return join(homedir(), ".tokenjuice", "artifacts");
@@ -69,10 +69,6 @@ function getDefaultArtifactDir(): string {
 
 export function resolveArtifactBaseDir(storeDir?: string): string {
   return storeDir ?? getDefaultArtifactDir();
-}
-
-function artifactBaseDir(storeDir?: string): string {
-  return resolveArtifactBaseDir(storeDir);
 }
 
 export function isValidArtifactId(id: string): boolean {
@@ -84,7 +80,7 @@ function buildArtifactPaths(id: string, storeDir?: string): StoredArtifactRef {
     throw new Error(`invalid artifact id: ${id}`);
   }
 
-  const base = artifactBaseDir(storeDir);
+  const base = resolveArtifactBaseDir(storeDir);
   return {
     id,
     storage: "file",
@@ -97,13 +93,13 @@ function buildMetadataOnlyPath(id: string, storeDir?: string): string {
   if (!isValidArtifactId(id)) {
     throw new Error(`invalid artifact id: ${id}`);
   }
-  return join(artifactBaseDir(storeDir), `${id}.meta.json`);
+  return join(resolveArtifactBaseDir(storeDir), `${id}.meta.json`);
 }
 
 export async function storeArtifact(input: StoredArtifactInput, storeDir?: string): Promise<StoredArtifactRef> {
   const id = `tj_${randomUUID().slice(0, 12)}`;
   const ref = buildArtifactPaths(id, storeDir);
-  await mkdir(artifactBaseDir(storeDir), { recursive: true, mode: 0o700 });
+  await mkdir(resolveArtifactBaseDir(storeDir), { recursive: true, mode: 0o700 });
   const captureTruncated = extractCaptureTruncatedFlag(input.input);
 
   const artifact: StoredArtifact = {
@@ -146,7 +142,7 @@ export async function storeArtifactMetadata(input: StoredArtifactInput, storeDir
     ...(input.stats ? { reducedChars: input.stats.reducedChars, ratio: input.stats.ratio } : {}),
   };
 
-  await mkdir(artifactBaseDir(storeDir), { recursive: true, mode: 0o700 });
+  await mkdir(resolveArtifactBaseDir(storeDir), { recursive: true, mode: 0o700 });
   await writeFile(metadataPath, JSON.stringify(metadata, null, 2), { encoding: "utf8", mode: 0o600 });
 
   return {
@@ -185,7 +181,7 @@ export async function getArtifact(id: string, storeDir?: string): Promise<Stored
 }
 
 export async function listArtifacts(storeDir?: string): Promise<StoredArtifactRef[]> {
-  const base = artifactBaseDir(storeDir);
+  const base = resolveArtifactBaseDir(storeDir);
   try {
     const files = await readdir(base);
     return files
@@ -201,7 +197,7 @@ export async function listArtifacts(storeDir?: string): Promise<StoredArtifactRe
 }
 
 export async function listArtifactMetadata(storeDir?: string): Promise<ArtifactMetadataRef[]> {
-  const base = artifactBaseDir(storeDir);
+  const base = resolveArtifactBaseDir(storeDir);
   try {
     const files = await readdir(base);
     const metadata = await Promise.all(

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -9,7 +9,7 @@ import { resolveArtifactSource } from "./source.js";
 import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
-const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
+export const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -61,13 +61,13 @@ function extractCaptureTruncatedFlag(input: ToolExecutionInput): boolean | undef
 function getDefaultArtifactDir(): string {
   const artifactDir = process.env[ARTIFACT_DIR_ENV];
   if (typeof artifactDir === "string" && artifactDir.trim()) {
-    return artifactDir;
+    return artifactDir.trim();
   }
 
   return join(homedir(), ".tokenjuice", "artifacts");
 }
 
-function resolveArtifactBaseDir(storeDir?: string): string {
+export function resolveArtifactBaseDir(storeDir?: string): string {
   return storeDir ?? getDefaultArtifactDir();
 }
 

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -9,7 +9,7 @@ import { resolveArtifactSource } from "./source.js";
 import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
-export const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
+const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -67,7 +67,7 @@ function getDefaultArtifactDir(): string {
   return join(homedir(), ".tokenjuice", "artifacts");
 }
 
-export function resolveArtifactBaseDir(storeDir?: string): string {
+function resolveArtifactBaseDir(storeDir?: string): string {
   return storeDir ?? getDefaultArtifactDir();
 }
 

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -9,6 +9,7 @@ import { resolveArtifactSource } from "./source.js";
 import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredArtifactMetadata, StoredArtifactRef, ToolExecutionInput } from "../types.js";
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
+const TEST_ARTIFACT_DIR_ENV = "TOKENJUICE_TEST_ARTIFACT_DIR";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -57,8 +58,21 @@ function extractCaptureTruncatedFlag(input: ToolExecutionInput): boolean | undef
   return typeof value === "boolean" ? value : undefined;
 }
 
+function getDefaultArtifactDir(): string {
+  const testArtifactDir = process.env[TEST_ARTIFACT_DIR_ENV];
+  if (typeof testArtifactDir === "string" && testArtifactDir.trim()) {
+    return testArtifactDir;
+  }
+
+  return join(homedir(), ".tokenjuice", "artifacts");
+}
+
+export function resolveArtifactBaseDir(storeDir?: string): string {
+  return storeDir ?? getDefaultArtifactDir();
+}
+
 function artifactBaseDir(storeDir?: string): string {
-  return storeDir ?? join(homedir(), ".tokenjuice", "artifacts");
+  return resolveArtifactBaseDir(storeDir);
 }
 
 export function isValidArtifactId(id: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
+export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
 export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "./core/analysis.js";
 export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
+export { ARTIFACT_DIR_ENV, getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
 export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "./core/analysis.js";
 export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ARTIFACT_DIR_ENV, getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
+export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
 export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "./core/analysis.js";
 export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
+export { ARTIFACT_DIR_ENV, getArtifact, isValidArtifactId, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "./core/artifacts.js";
 export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "./core/analysis.js";
 export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";

--- a/test/core/artifacts.test.ts
+++ b/test/core/artifacts.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { getArtifact, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
+import { getArtifact, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -19,6 +19,39 @@ afterEach(async () => {
 });
 
 describe("artifacts", () => {
+  it("uses the test artifact directory as the default base dir when configured", async () => {
+    const testArtifactDir = await createTempDir();
+    const original = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
+
+    try {
+      expect(resolveArtifactBaseDir()).toBe(testArtifactDir);
+    } finally {
+      if (original === undefined) {
+        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+      } else {
+        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = original;
+      }
+    }
+  });
+
+  it("keeps explicit storeDir ahead of the test artifact directory override", async () => {
+    const explicitDir = await createTempDir();
+    const testArtifactDir = await createTempDir();
+    const original = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
+
+    try {
+      expect(resolveArtifactBaseDir(explicitDir)).toBe(explicitDir);
+    } finally {
+      if (original === undefined) {
+        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+      } else {
+        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = original;
+      }
+    }
+  });
+
   it("rejects invalid artifact ids instead of reading arbitrary files", async () => {
     const storeDir = await createTempDir();
 

--- a/test/core/artifacts.test.ts
+++ b/test/core/artifacts.test.ts
@@ -1,10 +1,10 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { getArtifact, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
+import { ARTIFACT_DIR_ENV, getArtifact, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -19,6 +19,37 @@ afterEach(async () => {
 });
 
 describe("artifacts", () => {
+  it("falls back to ~/.tokenjuice/artifacts when no env override is configured", () => {
+    const original = process.env[ARTIFACT_DIR_ENV];
+
+    try {
+      delete process.env[ARTIFACT_DIR_ENV];
+      expect(resolveArtifactBaseDir()).toBe(join(homedir(), ".tokenjuice", "artifacts"));
+    } finally {
+      if (original === undefined) {
+        delete process.env[ARTIFACT_DIR_ENV];
+      } else {
+        process.env[ARTIFACT_DIR_ENV] = original;
+      }
+    }
+  });
+
+  it("trims the env-configured artifact directory before use", async () => {
+    const storeDir = await createTempDir();
+    const original = process.env[ARTIFACT_DIR_ENV];
+
+    try {
+      process.env[ARTIFACT_DIR_ENV] = `  ${storeDir}  `;
+      expect(resolveArtifactBaseDir()).toBe(storeDir);
+    } finally {
+      if (original === undefined) {
+        delete process.env[ARTIFACT_DIR_ENV];
+      } else {
+        process.env[ARTIFACT_DIR_ENV] = original;
+      }
+    }
+  });
+
   it("writes artifacts to the env-configured directory by default", async () => {
     const ref = await storeArtifactMetadata(
       {

--- a/test/core/artifacts.test.ts
+++ b/test/core/artifacts.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { getArtifact, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
+import { ARTIFACT_DIR_ENV, getArtifact, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -21,16 +21,16 @@ afterEach(async () => {
 describe("artifacts", () => {
   it("uses the test artifact directory as the default base dir when configured", async () => {
     const testArtifactDir = await createTempDir();
-    const original = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
-    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
+    const original = process.env[ARTIFACT_DIR_ENV];
+    process.env[ARTIFACT_DIR_ENV] = testArtifactDir;
 
     try {
       expect(resolveArtifactBaseDir()).toBe(testArtifactDir);
     } finally {
       if (original === undefined) {
-        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+        delete process.env[ARTIFACT_DIR_ENV];
       } else {
-        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = original;
+        process.env[ARTIFACT_DIR_ENV] = original;
       }
     }
   });
@@ -38,16 +38,16 @@ describe("artifacts", () => {
   it("keeps explicit storeDir ahead of the test artifact directory override", async () => {
     const explicitDir = await createTempDir();
     const testArtifactDir = await createTempDir();
-    const original = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
-    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
+    const original = process.env[ARTIFACT_DIR_ENV];
+    process.env[ARTIFACT_DIR_ENV] = testArtifactDir;
 
     try {
       expect(resolveArtifactBaseDir(explicitDir)).toBe(explicitDir);
     } finally {
       if (original === undefined) {
-        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+        delete process.env[ARTIFACT_DIR_ENV];
       } else {
-        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = original;
+        process.env[ARTIFACT_DIR_ENV] = original;
       }
     }
   });

--- a/test/core/artifacts.test.ts
+++ b/test/core/artifacts.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ARTIFACT_DIR_ENV, getArtifact, listArtifactMetadata, listArtifacts, resolveArtifactBaseDir, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
+import { getArtifact, listArtifactMetadata, listArtifacts, storeArtifact, storeArtifactMetadata } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -19,37 +19,36 @@ afterEach(async () => {
 });
 
 describe("artifacts", () => {
-  it("uses the test artifact directory as the default base dir when configured", async () => {
-    const testArtifactDir = await createTempDir();
-    const original = process.env[ARTIFACT_DIR_ENV];
-    process.env[ARTIFACT_DIR_ENV] = testArtifactDir;
+  it("writes artifacts to the env-configured directory by default", async () => {
+    const ref = await storeArtifactMetadata(
+      {
+        input: { toolName: "exec", command: "env-dir-test", exitCode: 0 },
+        rawText: "env dir output",
+        classification: { family: "test-results", confidence: 1, matchedReducer: "tests/env-dir" },
+        stats: { rawChars: 14, reducedChars: 7, ratio: 0.5 },
+      },
+    );
 
-    try {
-      expect(resolveArtifactBaseDir()).toBe(testArtifactDir);
-    } finally {
-      if (original === undefined) {
-        delete process.env[ARTIFACT_DIR_ENV];
-      } else {
-        process.env[ARTIFACT_DIR_ENV] = original;
-      }
-    }
+    const metadata = await listArtifactMetadata();
+    const found = metadata.find((entry) => entry.id === ref.id);
+
+    expect(found).toBeDefined();
+    expect(found?.metadataPath).not.toContain(process.env.HOME ?? "~");
   });
 
-  it("keeps explicit storeDir ahead of the test artifact directory override", async () => {
-    const explicitDir = await createTempDir();
-    const testArtifactDir = await createTempDir();
-    const original = process.env[ARTIFACT_DIR_ENV];
-    process.env[ARTIFACT_DIR_ENV] = testArtifactDir;
+  it("prefers explicit storeDir over the env-configured directory", async () => {
+    const storeDir = await createTempDir();
+    const ref = await storeArtifactMetadata(
+      {
+        input: { toolName: "exec", command: "explicit-dir-test", exitCode: 0 },
+        rawText: "explicit dir output",
+        classification: { family: "test-results", confidence: 1, matchedReducer: "tests/explicit-dir" },
+        stats: { rawChars: 20, reducedChars: 10, ratio: 0.5 },
+      },
+      storeDir,
+    );
 
-    try {
-      expect(resolveArtifactBaseDir(explicitDir)).toBe(explicitDir);
-    } finally {
-      if (original === undefined) {
-        delete process.env[ARTIFACT_DIR_ENV];
-      } else {
-        process.env[ARTIFACT_DIR_ENV] = original;
-      }
-    }
+    expect(ref.metadataPath.startsWith(storeDir)).toBe(true);
   });
 
   it("rejects invalid artifact ids instead of reading arbitrary files", async () => {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
+import { ARTIFACT_DIR_ENV, doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 const PACKAGE_VERSION = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).version as string;
@@ -902,48 +902,42 @@ describe("runCodexPostToolUseHook", () => {
 
   it("records metadata-only stats for immediate skip paths", async () => {
     const home = await createTempDir();
-    const testArtifactDir = await createTempDir();
-    const originalTestArtifactDir = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+    const artifactDir = process.env[ARTIFACT_DIR_ENV];
     process.env.CODEX_HOME = home;
     process.env.HOME = home;
-    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
 
-    try {
-      const payload = JSON.stringify({
-        hook_event_name: "PostToolUse",
-        tool_name: "Bash",
-        tool_input: {
-          command: "tokenjuice wrap --raw -- printf 'ok\\n'",
-        },
-        tool_response: "ok\n",
-      });
+    expect(artifactDir).toBeTruthy();
+    const metadataBefore = await listArtifactMetadata();
 
-      const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
-      const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-        rewrote: boolean;
-        skipped?: string;
-      };
-      const metadata = await listArtifactMetadata();
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "tokenjuice wrap --raw -- printf 'ok\\n'",
+      },
+      tool_response: "ok\n",
+    });
 
-      expect(code).toBe(0);
-      expect(output).toBe("");
-      expect(debug.rewrote).toBe(false);
-      expect(debug.skipped).toBe("explicit-raw-bypass");
-      expect(metadata).toHaveLength(1);
-      expect(metadata[0]?.metadata.command).toBe("tokenjuice wrap --raw -- printf 'ok\\n'");
-      expect(metadata[0]?.metadata.rawChars).toBeGreaterThan(0);
-      expect(metadata[0]?.metadata.reducedChars).toBe(metadata[0]?.metadata.rawChars);
-      expect(metadata[0]?.metadata.ratio).toBe(1);
-      expect(metadata[0]?.path).toBeUndefined();
-      expect(metadata[0]?.metadataPath.startsWith(testArtifactDir)).toBe(true);
-      expect(existsSync(join(home, ".tokenjuice", "artifacts"))).toBe(false);
-    } finally {
-      if (originalTestArtifactDir === undefined) {
-        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
-      } else {
-        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = originalTestArtifactDir;
-      }
-    }
+    const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+    const metadata = await listArtifactMetadata();
+    const newMetadata = metadata.find((entry) => !metadataBefore.some((before) => before.id === entry.id));
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("explicit-raw-bypass");
+    expect(metadata).toHaveLength(metadataBefore.length + 1);
+    expect(newMetadata?.metadata.command).toBe("tokenjuice wrap --raw -- printf 'ok\\n'");
+    expect(newMetadata?.metadata.rawChars).toBeGreaterThan(0);
+    expect(newMetadata?.metadata.reducedChars).toBe(newMetadata?.metadata.rawChars);
+    expect(newMetadata?.metadata.ratio).toBe(1);
+    expect(newMetadata?.path).toBeUndefined();
+    expect(newMetadata?.metadataPath.startsWith(artifactDir!)).toBe(true);
+    expect(existsSync(join(home, ".tokenjuice", "artifacts"))).toBe(false);
   });
 
   it("writes rolling hook history entries alongside the last snapshot", async () => {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ARTIFACT_DIR_ENV, doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
+import { doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 const PACKAGE_VERSION = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).version as string;
@@ -902,7 +902,7 @@ describe("runCodexPostToolUseHook", () => {
 
   it("records metadata-only stats for immediate skip paths", async () => {
     const home = await createTempDir();
-    const artifactDir = process.env[ARTIFACT_DIR_ENV];
+    const artifactDir = process.env.TOKENJUICE_ARTIFACT_DIR;
     process.env.CODEX_HOME = home;
     process.env.HOME = home;
 

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -936,7 +936,7 @@ describe("runCodexPostToolUseHook", () => {
     expect(newMetadata?.metadata.reducedChars).toBe(newMetadata?.metadata.rawChars);
     expect(newMetadata?.metadata.ratio).toBe(1);
     expect(newMetadata?.path).toBeUndefined();
-    expect(newMetadata?.metadataPath.startsWith(artifactDir!)).toBe(true);
+    expect(resolve(dirname(newMetadata!.metadataPath))).toBe(resolve(artifactDir!));
     expect(existsSync(join(home, ".tokenjuice", "artifacts"))).toBe(false);
   });
 

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -902,35 +902,48 @@ describe("runCodexPostToolUseHook", () => {
 
   it("records metadata-only stats for immediate skip paths", async () => {
     const home = await createTempDir();
+    const testArtifactDir = await createTempDir();
+    const originalTestArtifactDir = process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
     process.env.CODEX_HOME = home;
     process.env.HOME = home;
+    process.env.TOKENJUICE_TEST_ARTIFACT_DIR = testArtifactDir;
 
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "tokenjuice wrap --raw -- printf 'ok\\n'",
-      },
-      tool_response: "ok\n",
-    });
+    try {
+      const payload = JSON.stringify({
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_input: {
+          command: "tokenjuice wrap --raw -- printf 'ok\\n'",
+        },
+        tool_response: "ok\n",
+      });
 
-    const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-    const metadata = await listArtifactMetadata();
+      const { code, output } = await captureStdout(() => runCodexPostToolUseHook(payload));
+      const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+        rewrote: boolean;
+        skipped?: string;
+      };
+      const metadata = await listArtifactMetadata();
 
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("explicit-raw-bypass");
-    expect(metadata).toHaveLength(1);
-    expect(metadata[0]?.metadata.command).toBe("tokenjuice wrap --raw -- printf 'ok\\n'");
-    expect(metadata[0]?.metadata.rawChars).toBeGreaterThan(0);
-    expect(metadata[0]?.metadata.reducedChars).toBe(metadata[0]?.metadata.rawChars);
-    expect(metadata[0]?.metadata.ratio).toBe(1);
-    expect(metadata[0]?.path).toBeUndefined();
+      expect(code).toBe(0);
+      expect(output).toBe("");
+      expect(debug.rewrote).toBe(false);
+      expect(debug.skipped).toBe("explicit-raw-bypass");
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0]?.metadata.command).toBe("tokenjuice wrap --raw -- printf 'ok\\n'");
+      expect(metadata[0]?.metadata.rawChars).toBeGreaterThan(0);
+      expect(metadata[0]?.metadata.reducedChars).toBe(metadata[0]?.metadata.rawChars);
+      expect(metadata[0]?.metadata.ratio).toBe(1);
+      expect(metadata[0]?.path).toBeUndefined();
+      expect(metadata[0]?.metadataPath.startsWith(testArtifactDir)).toBe(true);
+      expect(existsSync(join(home, ".tokenjuice", "artifacts"))).toBe(false);
+    } finally {
+      if (originalTestArtifactDir === undefined) {
+        delete process.env.TOKENJUICE_TEST_ARTIFACT_DIR;
+      } else {
+        process.env.TOKENJUICE_TEST_ARTIFACT_DIR = originalTestArtifactDir;
+      }
+    }
   });
 
   it("writes rolling hook history entries alongside the last snapshot", async () => {

--- a/test/setup/global-artifacts.ts
+++ b/test/setup/global-artifacts.ts
@@ -2,14 +2,14 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const TEST_ARTIFACT_DIR_ENV = "TOKENJUICE_TEST_ARTIFACT_DIR";
+import { ARTIFACT_DIR_ENV } from "../../src/core/artifacts.js";
 
 export default async function setup(): Promise<() => Promise<void>> {
   const artifactDir = await mkdtemp(join(tmpdir(), "tokenjuice-vitest-artifacts-"));
-  process.env[TEST_ARTIFACT_DIR_ENV] = artifactDir;
+  process.env[ARTIFACT_DIR_ENV] = artifactDir;
 
   return async () => {
-    delete process.env[TEST_ARTIFACT_DIR_ENV];
+    delete process.env[ARTIFACT_DIR_ENV];
     await rm(artifactDir, { recursive: true, force: true });
   };
 }

--- a/test/setup/global-artifacts.ts
+++ b/test/setup/global-artifacts.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { ARTIFACT_DIR_ENV } from "../../src/core/artifacts.js";
+const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
 
 export default async function setup(): Promise<() => Promise<void>> {
   const artifactDir = await mkdtemp(join(tmpdir(), "tokenjuice-vitest-artifacts-"));

--- a/test/setup/global-artifacts.ts
+++ b/test/setup/global-artifacts.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
+import { ARTIFACT_DIR_ENV } from "../../src/index.js";
 
 export default async function setup(): Promise<() => Promise<void>> {
   const artifactDir = await mkdtemp(join(tmpdir(), "tokenjuice-vitest-artifacts-"));

--- a/test/setup/global-artifacts.ts
+++ b/test/setup/global-artifacts.ts
@@ -1,0 +1,15 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_ARTIFACT_DIR_ENV = "TOKENJUICE_TEST_ARTIFACT_DIR";
+
+export default async function setup(): Promise<() => Promise<void>> {
+  const artifactDir = await mkdtemp(join(tmpdir(), "tokenjuice-vitest-artifacts-"));
+  process.env[TEST_ARTIFACT_DIR_ENV] = artifactDir;
+
+  return async () => {
+    delete process.env[TEST_ARTIFACT_DIR_ENV];
+    await rm(artifactDir, { recursive: true, force: true });
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    globalSetup: ["test/setup/global-artifacts.ts"],
     include: ["test/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
Test runs were writing artifacts into the real `~/.tokenjuice/artifacts` directory, polluting production data with spurious metadata entries. This change introduces a general-purpose `TOKENJUICE_ARTIFACT_DIR` environment variable to override the default artifact directory, and uses it in the Vitest global setup to redirect all test writes to an isolated temp directory that is cleaned up after the suite finishes.

## What Changed
- Add `TOKENJUICE_ARTIFACT_DIR` env var and exported `ARTIFACT_DIR_ENV` constant to override the default `~/.tokenjuice/artifacts` directory
- Export `resolveArtifactBaseDir()` as the single path-resolution function, removing the internal `artifactBaseDir` wrapper — all call sites now use it directly
- Add Vitest global setup (`test/setup/global-artifacts.ts`) that creates a temp directory via `TOKENJUICE_ARTIFACT_DIR` and tears it down after the suite
- Rewrite the Codex "metadata-only skip paths" test to trust the global setup instead of manual env var management, and assert incremental metadata instead of absolute count
- Document the default directory and `TOKENJUICE_ARTIFACT_DIR` override in `docs/spec.md`

## Test Plan
- `pnpm exec vitest run test/core/artifacts.test.ts test/hosts/codex.test.ts`
- `pnpm test`
- `pnpm typecheck`
- Before/after `pnpm test`, compare `~/.tokenjuice/artifacts` file counts and verify they stay unchanged