### PR TITLE
fix(gh): keep actions log error signals

### DIFF
--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -6,7 +6,8 @@ export type CompactionKind =
   | "git-diff-hunk-clip"
   | "inspection-package-lock-summary"
   | "inspection-large-document-summary"
-  | "github-actions-command-list-omission";
+  | "github-actions-command-list-omission"
+  | "github-actions-log-signal-filter";
 
 export type CompactionMetadata = {
   authoritative: boolean;

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -6,6 +6,9 @@ import type { ToolExecutionInput } from "../types.js";
 const LONG_SEARCH_LINE_MAX_CHARS = 420;
 const LONG_CHANGED_LINE_MAX_CHARS = 260;
 const GIT_DIFF_CHANGED_LINES_PER_HUNK = 8;
+const GH_RUN_LOG_SIGNAL_CONTEXT_LINES = 1;
+const GH_RUN_LOG_SIGNAL_PATTERN =
+  /(?:##\[error\]|::error|(?:^|[\s|])(?:FAIL|FAILED|FAILURE)(?:[\s|:]|$)|\bAssertionError\b|\bError:\s+Process completed with exit code\b|\berror\s+TS\d+\b|\bELIFECYCLE\b|\bCommand failed\b|\bfailed with exit code\b|\bfailed in build-artifacts\b|\bERR_[A-Z0-9_]+\b)/iu;
 
 function rewriteGitStatusLine(line: string): string | null {
   const trimmed = line.trim();
@@ -469,6 +472,65 @@ function formatGhTableLine(line: string): string {
   return compactWhitespace(trimmed);
 }
 
+function isGhRunLogCommand(input: ToolExecutionInput): boolean {
+  const argv = input.argv ?? [];
+  return argv[0] === "gh"
+    && argv.includes("run")
+    && argv.includes("view")
+    && argv.some((arg) => arg === "--log" || arg === "--log-failed" || arg.startsWith("--log="));
+}
+
+function formatOmittedGhLogLines(count: number): string {
+  return `... ${count} non-signal log lines omitted ...`;
+}
+
+function filterGhRunLogSignalLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+  const signalIndexes = lines
+    .map((line, index) => GH_RUN_LOG_SIGNAL_PATTERN.test(line) ? index : -1)
+    .filter((index) => index >= 0);
+
+  if (signalIndexes.length === 0) {
+    return { lines };
+  }
+
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const index of signalIndexes) {
+    const start = Math.max(0, index - GH_RUN_LOG_SIGNAL_CONTEXT_LINES);
+    const end = Math.min(lines.length - 1, index + GH_RUN_LOG_SIGNAL_CONTEXT_LINES);
+    const previous = ranges.at(-1);
+    if (previous && start <= previous.end + 1) {
+      previous.end = Math.max(previous.end, end);
+      continue;
+    }
+    ranges.push({ start, end });
+  }
+
+  const rewritten: string[] = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    const omittedBefore = range.start - cursor;
+    if (omittedBefore > 0) {
+      rewritten.push(formatOmittedGhLogLines(omittedBefore));
+    }
+    rewritten.push(...lines.slice(range.start, range.end + 1));
+    cursor = range.end + 1;
+  }
+
+  const omittedAfter = lines.length - cursor;
+  if (omittedAfter > 0) {
+    rewritten.push(formatOmittedGhLogLines(omittedAfter));
+  }
+
+  if (rewritten.length >= lines.length) {
+    return { lines };
+  }
+
+  return {
+    lines: rewritten,
+    compaction: createCompactionMetadata("github-actions-log-signal-filter"),
+  };
+}
+
 export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { lines: string[]; compaction?: CompactionMetadata } {
   const nonEmpty = lines.filter((line) => line.trim() !== "");
   if (nonEmpty.length === 0) {
@@ -506,7 +568,11 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
   }
 
   if ((input.argv ?? [])[0] === "gh") {
-    return { lines: lines.map(formatGhTableLine) };
+    const formattedLines = lines.map(formatGhTableLine);
+    if (isGhRunLogCommand(input)) {
+      return filterGhRunLogSignalLines(formattedLines);
+    }
+    return { lines: formattedLines };
   }
 
   return { lines };

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1470,6 +1470,33 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("2026-04-20T19:00:10.000Z");
   });
 
+  it("keeps middle gh actions error signals from long run logs", async () => {
+    const filler = Array.from(
+      { length: 80 },
+      (_, index) =>
+        `check-test-types\tRun check shard\t2026-04-28T06:34:${String(index % 60).padStart(2, "0")}.000Z\tprogress line ${index}`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 25037757449 --repo openclaw/openclaw --log",
+      argv: ["gh", "run", "view", "25037757449", "--log"],
+      combinedText: [
+        ...filler.slice(0, 40),
+        "check-test-types\tRun check shard\t2026-04-28T06:35:06.000Z\t##[error]extensions/tokenjuice/tool-result-middleware.test.ts(89,19): error TS2345: Argument of type Mock is not assignable",
+        "check-test-types\tRun check shard\t2026-04-28T06:35:07.000Z\tELIFECYCLE Command failed with exit code 2",
+        ...filler.slice(40),
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("error TS2345");
+    expect(result.inlineText).toContain("ELIFECYCLE Command failed with exit code 2");
+    expect(result.inlineText).toContain("non-signal log lines omitted");
+    expect(result.inlineText).not.toContain("progress line 0");
+    expect(result.inlineText).not.toContain("2026-04-28T06:35:06.000Z");
+  });
+
   it("preserves emoji and CJK while stripping ANSI from user-facing output and stats", async () => {
     const visibleText = ["错误🔥", "修复🙂", "完了✅"].join("\n");
     const coloredText = [


### PR DESCRIPTION
Summary:
- preserve GitHub Actions error/failure signals when compacting gh run view --log output
- keep one line of surrounding context and insert deterministic omission markers
- add reducer coverage for a buried TypeScript error in a long run log

Tests:
- pnpm exec vitest run test/core/reduce.test.ts -t "gh actions"
- pnpm exec vitest run test/core/reduce.test.ts test/core/rules.test.ts
- pnpm typecheck
- pnpm build
- pnpm verify (rerun outside sandbox; 715 tests passed)