### PR TITLE
fix(gh): preserve status check failures

### DIFF
--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -6,7 +6,8 @@ export type CompactionKind =
   | "git-diff-hunk-clip"
   | "inspection-package-lock-summary"
   | "inspection-large-document-summary"
-  | "github-actions-command-list-omission";
+  | "github-actions-command-list-omission"
+  | "github-status-check-rollup-omission";
 
 export type CompactionMetadata = {
   authoritative: boolean;

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -6,6 +6,7 @@ import type { ToolExecutionInput } from "../types.js";
 const LONG_SEARCH_LINE_MAX_CHARS = 420;
 const LONG_CHANGED_LINE_MAX_CHARS = 260;
 const GIT_DIFF_CHANGED_LINES_PER_HUNK = 8;
+const MAX_GH_STATUS_CHECK_ATTENTION_LINES = 12;
 
 function rewriteGitStatusLine(line: string): string | null {
   const trimmed = line.trim();
@@ -289,6 +290,87 @@ function getGhCollection(value: unknown): unknown[] {
   return [];
 }
 
+function getGhString(record: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function normalizeGhStatus(value: string | null): string | null {
+  return value ? value.trim().toUpperCase().replace(/-/gu, "_") : null;
+}
+
+function isGhStatusCheckOk(record: Record<string, unknown>): boolean {
+  const conclusion = normalizeGhStatus(getGhString(record, "conclusion"));
+  if (conclusion) {
+    return conclusion === "SUCCESS" || conclusion === "SKIPPED" || conclusion === "NEUTRAL";
+  }
+
+  const state = normalizeGhStatus(getGhString(record, "state"));
+  if (state) {
+    return state === "SUCCESS";
+  }
+
+  return false;
+}
+
+function formatGhStatusCheckLine(record: Record<string, unknown>): string | null {
+  const name = getGhString(record, "name", "context", "workflowName");
+  if (!name) {
+    return null;
+  }
+
+  const conclusion = normalizeGhStatus(getGhString(record, "conclusion", "state"));
+  const status = normalizeGhStatus(getGhString(record, "status"));
+  const workflow = getGhString(record, "workflowName");
+  const duration = extractGhDuration(record);
+  const detailsUrl = getGhString(record, "detailsUrl", "targetUrl");
+  const parts = [
+    "check",
+    compactWhitespace(name),
+    conclusion ? `[${conclusion}]` : status ? `[${status}]` : null,
+    workflow && workflow !== name ? `workflow=${compactWhitespace(workflow)}` : null,
+    duration ? `duration=${duration}` : null,
+    detailsUrl ? `url=${detailsUrl}` : null,
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" ");
+}
+
+function formatGhStatusCheckRollup(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
+  const records = getGhCollection(value)
+    .filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry));
+  if (records.length === 0) {
+    return { lines: [] };
+  }
+
+  const attention = records.filter((record) => !isGhStatusCheckOk(record));
+  const okCount = records.length - attention.length;
+  const lines = [`status checks: ${okCount} ok, ${attention.length} attention`];
+  const listed = attention.slice(0, MAX_GH_STATUS_CHECK_ATTENTION_LINES);
+  for (const record of listed) {
+    const line = formatGhStatusCheckLine(record);
+    if (line) {
+      lines.push(line);
+    }
+  }
+
+  const omittedAttention = attention.length - listed.length;
+  if (omittedAttention > 0) {
+    lines.push(`... ${omittedAttention} attention checks omitted ...`);
+  }
+
+  return {
+    lines,
+    ...(okCount > 0 || omittedAttention > 0
+      ? { compaction: createCompactionMetadata("github-status-check-rollup-omission") }
+      : {}),
+  };
+}
+
 function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
   const compactions: CompactionMetadata[] = [];
   if (Array.isArray(value)) {
@@ -323,6 +405,14 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
     lines.push(header.line);
     if (header.compaction) {
       compactions.push(header.compaction);
+    }
+  }
+
+  const statusCheckRollup = formatGhStatusCheckRollup(record.statusCheckRollup);
+  if (statusCheckRollup.lines.length > 0) {
+    lines.push(...statusCheckRollup.lines);
+    if (statusCheckRollup.compaction) {
+      compactions.push(statusCheckRollup.compaction);
     }
   }
 

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1403,6 +1403,54 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("\"jobs\"");
   });
 
+  it("preserves gh pr status check failures from long statusCheckRollup payloads", async () => {
+    const statusCheckRollup = Array.from({ length: 68 }, (_, index) => ({
+      __typename: "CheckRun",
+      name: `check-success-${index}`,
+      workflowName: "CI",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-04-28T08:38:00Z",
+      completedAt: "2026-04-28T08:38:05Z",
+      detailsUrl: `https://github.com/openclaw/openclaw/actions/runs/25042683853/job/${index}`,
+    }));
+    statusCheckRollup[61] = {
+      ...statusCheckRollup[61]!,
+      name: "checks-node-core-support-boundary",
+      conclusion: "FAILURE",
+      detailsUrl: "https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73349995139",
+    };
+    statusCheckRollup[67] = {
+      ...statusCheckRollup[67]!,
+      name: "checks-node-core",
+      conclusion: "FAILURE",
+      detailsUrl: "https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73350109175",
+    };
+
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh pr view 73340 --repo openclaw/openclaw --json number,title,statusCheckRollup,url",
+      argv: ["gh", "pr", "view", "73340", "--json", "number,title,statusCheckRollup,url"],
+      combinedText: JSON.stringify({
+        number: 73340,
+        title: "Test tokenjuice tool result middleware adapter",
+        url: "https://github.com/openclaw/openclaw/pull/73340",
+        statusCheckRollup,
+      }),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("#73340 Test tokenjuice tool result middleware adapter");
+    expect(result.inlineText).toContain("status checks: 66 ok, 2 attention");
+    expect(result.inlineText).toContain("check checks-node-core-support-boundary [FAILURE]");
+    expect(result.inlineText).toContain("check checks-node-core [FAILURE]");
+    expect(result.inlineText).toContain("url=https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73350109175");
+    expect(result.inlineText).not.toContain("check-success-0");
+    expect(result.inlineText).not.toContain("\"statusCheckRollup\"");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["github-status-check-rollup-omission"] });
+  });
+
   it("formats gh table output into compact list lines", async () => {
     const result = await reduceExecution({
       toolName: "exec",


### PR DESCRIPTION
Summary:
- summarize `statusCheckRollup` from `gh pr view --json` output instead of dropping it
- preserve failed, pending, and action-required checks with workflow, duration, and details URL
- compact successful checks into a deterministic count
- add regression coverage for buried OpenClaw-style CI failures in a long PR status payload

Why:
- tokenjuice currently reduces a real 68-check OpenClaw PR payload with two failures to only the PR title
- agents need the failed check names to decide whether the PR needs work or is blocked by unrelated CI

Tests:
- pnpm exec vitest run test/core/reduce.test.ts -t "gh"
- pnpm exec vitest run test/core/reduce.test.ts test/core/rules.test.ts
- pnpm typecheck
- pnpm build
- pnpm verify