### PR TITLE
fix(gh): preserve reducer failure signals

### DIFF
--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -7,7 +7,8 @@ export type CompactionKind =
   | "inspection-package-lock-summary"
   | "inspection-large-document-summary"
   | "github-actions-command-list-omission"
-  | "github-actions-log-signal-filter";
+  | "github-actions-log-signal-filter"
+  | "github-status-check-rollup-omission";
 
 export type CompactionMetadata = {
   authoritative: boolean;

--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -6,7 +6,8 @@ export type CompactionKind =
   | "git-diff-hunk-clip"
   | "inspection-package-lock-summary"
   | "inspection-large-document-summary"
-  | "github-actions-command-list-omission";
+  | "github-actions-command-list-omission"
+  | "github-actions-log-signal-filter";
 
 export type CompactionMetadata = {
   authoritative: boolean;

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -6,6 +6,9 @@ import type { ToolExecutionInput } from "../types.js";
 const LONG_SEARCH_LINE_MAX_CHARS = 420;
 const LONG_CHANGED_LINE_MAX_CHARS = 260;
 const GIT_DIFF_CHANGED_LINES_PER_HUNK = 8;
+const GH_RUN_LOG_SIGNAL_CONTEXT_LINES = 1;
+const GH_RUN_LOG_SIGNAL_PATTERN =
+  /(?:##\[error\]|::error|(?:^|[\s|])(?:FAIL|FAILED|FAILURE)(?:[\s|:]|$)|\bAssertionError\b|\bError:\s+Process completed with exit code\b|\berror\s+TS\d+\b|\bELIFECYCLE\b|\bCommand failed\b|\bfailed with exit code\b|\bfailed in build-artifacts\b|\bERR_[A-Z0-9_]+\b)/iu;
 
 function rewriteGitStatusLine(line: string): string | null {
   const trimmed = line.trim();
@@ -469,6 +472,65 @@ function formatGhTableLine(line: string): string {
   return compactWhitespace(trimmed);
 }
 
+function isGhRunLogCommand(input: ToolExecutionInput): boolean {
+  const argv = input.argv ?? [];
+  return argv[0] === "gh"
+    && argv.includes("run")
+    && argv.includes("view")
+    && argv.some((arg) => arg === "--log" || arg === "--log-failed" || arg.startsWith("--log="));
+}
+
+function formatOmittedGhLogLines(count: number): string {
+  return `... ${count} non-signal log lines omitted ...`;
+}
+
+function filterGhRunLogSignalLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+  const signalIndexes = lines
+    .map((line, index) => GH_RUN_LOG_SIGNAL_PATTERN.test(line) ? index : -1)
+    .filter((index) => index >= 0);
+
+  if (signalIndexes.length === 0) {
+    return { lines };
+  }
+
+  const ranges: Array<{ start: number; end: number }> = [];
+  for (const index of signalIndexes) {
+    const start = Math.max(0, index - GH_RUN_LOG_SIGNAL_CONTEXT_LINES);
+    const end = Math.min(lines.length - 1, index + GH_RUN_LOG_SIGNAL_CONTEXT_LINES);
+    const previous = ranges.at(-1);
+    if (previous && start <= previous.end + 1) {
+      previous.end = Math.max(previous.end, end);
+      continue;
+    }
+    ranges.push({ start, end });
+  }
+
+  const rewritten: string[] = [];
+  let cursor = 0;
+  for (const range of ranges) {
+    const omittedBefore = range.start - cursor;
+    if (omittedBefore > 0) {
+      rewritten.push(formatOmittedGhLogLines(omittedBefore));
+    }
+    rewritten.push(...lines.slice(range.start, range.end + 1));
+    cursor = range.end + 1;
+  }
+
+  const omittedAfter = lines.length - cursor;
+  if (omittedAfter > 0) {
+    rewritten.push(formatOmittedGhLogLines(omittedAfter));
+  }
+
+  if (rewritten.length >= lines.length) {
+    return { lines };
+  }
+
+  return {
+    lines: rewritten,
+    compaction: createCompactionMetadata("github-actions-log-signal-filter"),
+  };
+}
+
 export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { lines: string[]; compaction?: CompactionMetadata } {
   const nonEmpty = lines.filter((line) => line.trim() !== "");
   if (nonEmpty.length === 0) {
@@ -506,7 +568,11 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
   }
 
   if ((input.argv ?? [])[0] === "gh") {
-    return { lines: lines.map(formatGhTableLine) };
+    const formattedLines = lines.map(formatGhTableLine);
+    if (isGhRunLogCommand(input)) {
+      return filterGhRunLogSignalLines(formattedLines);
+    }
+    return { lines: formattedLines };
   }
 
   return { lines };

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -9,6 +9,7 @@ const GIT_DIFF_CHANGED_LINES_PER_HUNK = 8;
 const GH_RUN_LOG_SIGNAL_CONTEXT_LINES = 1;
 const GH_RUN_LOG_SIGNAL_PATTERN =
   /(?:##\[error\]|::error|(?:^|[\s|])(?:FAIL|FAILED|FAILURE)(?:[\s|:]|$)|\bAssertionError\b|\bError:\s+Process completed with exit code\b|\berror\s+TS\d+\b|\bELIFECYCLE\b|\bCommand failed\b|\bfailed with exit code\b|\bfailed in build-artifacts\b|\bERR_[A-Z0-9_]+\b)/iu;
+const MAX_GH_STATUS_CHECK_ATTENTION_LINES = 12;
 
 function rewriteGitStatusLine(line: string): string | null {
   const trimmed = line.trim();
@@ -292,6 +293,87 @@ function getGhCollection(value: unknown): unknown[] {
   return [];
 }
 
+function getGhString(record: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function normalizeGhStatus(value: string | null): string | null {
+  return value ? value.trim().toUpperCase().replace(/-/gu, "_") : null;
+}
+
+function isGhStatusCheckOk(record: Record<string, unknown>): boolean {
+  const conclusion = normalizeGhStatus(getGhString(record, "conclusion"));
+  if (conclusion) {
+    return conclusion === "SUCCESS" || conclusion === "SKIPPED" || conclusion === "NEUTRAL";
+  }
+
+  const state = normalizeGhStatus(getGhString(record, "state"));
+  if (state) {
+    return state === "SUCCESS";
+  }
+
+  return false;
+}
+
+function formatGhStatusCheckLine(record: Record<string, unknown>): string | null {
+  const name = getGhString(record, "name", "context", "workflowName");
+  if (!name) {
+    return null;
+  }
+
+  const conclusion = normalizeGhStatus(getGhString(record, "conclusion", "state"));
+  const status = normalizeGhStatus(getGhString(record, "status"));
+  const workflow = getGhString(record, "workflowName");
+  const duration = extractGhDuration(record);
+  const detailsUrl = getGhString(record, "detailsUrl", "targetUrl");
+  const parts = [
+    "check",
+    compactWhitespace(name),
+    conclusion ? `[${conclusion}]` : status ? `[${status}]` : null,
+    workflow && workflow !== name ? `workflow=${compactWhitespace(workflow)}` : null,
+    duration ? `duration=${duration}` : null,
+    detailsUrl ? `url=${detailsUrl}` : null,
+  ].filter((part): part is string => Boolean(part));
+  return parts.join(" ");
+}
+
+function formatGhStatusCheckRollup(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
+  const records = getGhCollection(value)
+    .filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry));
+  if (records.length === 0) {
+    return { lines: [] };
+  }
+
+  const attention = records.filter((record) => !isGhStatusCheckOk(record));
+  const okCount = records.length - attention.length;
+  const lines = [`status checks: ${okCount} ok, ${attention.length} attention`];
+  const listed = attention.slice(0, MAX_GH_STATUS_CHECK_ATTENTION_LINES);
+  for (const record of listed) {
+    const line = formatGhStatusCheckLine(record);
+    if (line) {
+      lines.push(line);
+    }
+  }
+
+  const omittedAttention = attention.length - listed.length;
+  if (omittedAttention > 0) {
+    lines.push(`... ${omittedAttention} attention checks omitted ...`);
+  }
+
+  return {
+    lines,
+    ...(okCount > 0 || omittedAttention > 0
+      ? { compaction: createCompactionMetadata("github-status-check-rollup-omission") }
+      : {}),
+  };
+}
+
 function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
   const compactions: CompactionMetadata[] = [];
   if (Array.isArray(value)) {
@@ -326,6 +408,14 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
     lines.push(header.line);
     if (header.compaction) {
       compactions.push(header.compaction);
+    }
+  }
+
+  const statusCheckRollup = formatGhStatusCheckRollup(record.statusCheckRollup);
+  if (statusCheckRollup.lines.length > 0) {
+    lines.push(...statusCheckRollup.lines);
+    if (statusCheckRollup.compaction) {
+      compactions.push(statusCheckRollup.compaction);
     }
   }
 

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1470,6 +1470,33 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("2026-04-20T19:00:10.000Z");
   });
 
+  it("keeps middle gh actions error signals from long run logs", async () => {
+    const filler = Array.from(
+      { length: 80 },
+      (_, index) =>
+        `check-test-types\tRun check shard\t2026-04-28T06:34:${String(index % 60).padStart(2, "0")}.000Z\tprogress line ${index}`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 25037757449 --repo openclaw/openclaw --log",
+      argv: ["gh", "run", "view", "25037757449", "--log"],
+      combinedText: [
+        ...filler.slice(0, 40),
+        "check-test-types\tRun check shard\t2026-04-28T06:35:06.000Z\t##[error]extensions/tokenjuice/tool-result-middleware.test.ts(89,19): error TS2345: Argument of type Mock is not assignable",
+        "check-test-types\tRun check shard\t2026-04-28T06:35:07.000Z\tELIFECYCLE Command failed with exit code 2",
+        ...filler.slice(40),
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("error TS2345");
+    expect(result.inlineText).toContain("ELIFECYCLE Command failed with exit code 2");
+    expect(result.inlineText).toContain("non-signal log lines omitted");
+    expect(result.inlineText).not.toContain("progress line 0");
+    expect(result.inlineText).not.toContain("2026-04-28T06:35:06.000Z");
+  });
+
   it("preserves emoji and CJK while stripping ANSI from user-facing output and stats", async () => {
     const visibleText = ["错误🔥", "修复🙂", "完了✅"].join("\n");
     const coloredText = [

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1403,6 +1403,102 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("\"jobs\"");
   });
 
+  it("preserves gh pr status check failures from long statusCheckRollup payloads", async () => {
+    const statusCheckRollup = Array.from({ length: 68 }, (_, index) => ({
+      __typename: "CheckRun",
+      name: `check-success-${index}`,
+      workflowName: "CI",
+      status: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-04-28T08:38:00Z",
+      completedAt: "2026-04-28T08:38:05Z",
+      detailsUrl: `https://github.com/openclaw/openclaw/actions/runs/25042683853/job/${index}`,
+    }));
+    statusCheckRollup[61] = {
+      ...statusCheckRollup[61]!,
+      name: "checks-node-core-support-boundary",
+      conclusion: "FAILURE",
+      detailsUrl: "https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73349995139",
+    };
+    statusCheckRollup[67] = {
+      ...statusCheckRollup[67]!,
+      name: "checks-node-core",
+      conclusion: "FAILURE",
+      detailsUrl: "https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73350109175",
+    };
+
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh pr view 73340 --repo openclaw/openclaw --json number,title,statusCheckRollup,url",
+      argv: ["gh", "pr", "view", "73340", "--json", "number,title,statusCheckRollup,url"],
+      combinedText: JSON.stringify({
+        number: 73340,
+        title: "Test tokenjuice tool result middleware adapter",
+        url: "https://github.com/openclaw/openclaw/pull/73340",
+        statusCheckRollup,
+      }),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("#73340 Test tokenjuice tool result middleware adapter");
+    expect(result.inlineText).toContain("status checks: 66 ok, 2 attention");
+    expect(result.inlineText).toContain("check checks-node-core-support-boundary [FAILURE]");
+    expect(result.inlineText).toContain("check checks-node-core [FAILURE]");
+    expect(result.inlineText).toContain("url=https://github.com/openclaw/openclaw/actions/runs/25042683853/job/73350109175");
+    expect(result.inlineText).not.toContain("check-success-0");
+    expect(result.inlineText).not.toContain("\"statusCheckRollup\"");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["github-status-check-rollup-omission"] });
+  });
+
+  it("keeps pending and action-required status checks from statusCheckRollup payloads", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh pr view 73341 --repo openclaw/openclaw --json number,title,statusCheckRollup,url",
+      argv: ["gh", "pr", "view", "73341", "--json", "number,title,statusCheckRollup,url"],
+      combinedText: JSON.stringify({
+        number: 73341,
+        title: "Keep status checks visible",
+        url: "https://github.com/openclaw/openclaw/pull/73341",
+        statusCheckRollup: [
+          {
+            __typename: "CheckRun",
+            name: "quality",
+            workflowName: "CI",
+            status: "COMPLETED",
+            conclusion: "SUCCESS",
+          },
+          {
+            __typename: "CheckRun",
+            name: "package",
+            workflowName: "CI",
+            status: "IN_PROGRESS",
+            conclusion: "",
+          },
+          {
+            __typename: "StatusContext",
+            context: "release approval",
+            state: "ACTION_REQUIRED",
+            targetUrl: "https://github.com/vincentkoc/tokenjuice/actions/runs/25055506314",
+          },
+          {
+            __typename: "StatusContext",
+            context: "external gate",
+            state: "PENDING",
+          },
+        ],
+      }),
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toContain("status checks: 1 ok, 3 attention");
+    expect(result.inlineText).toContain("check package [IN_PROGRESS]");
+    expect(result.inlineText).toContain("check release approval [ACTION_REQUIRED]");
+    expect(result.inlineText).toContain("url=https://github.com/vincentkoc/tokenjuice/actions/runs/25055506314");
+    expect(result.inlineText).toContain("check external gate [PENDING]");
+    expect(result.inlineText).not.toContain("check quality");
+  });
+
   it("formats gh table output into compact list lines", async () => {
     const result = await reduceExecution({
       toolName: "exec",
@@ -1495,6 +1591,30 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("non-signal log lines omitted");
     expect(result.inlineText).not.toContain("progress line 0");
     expect(result.inlineText).not.toContain("2026-04-28T06:35:06.000Z");
+  });
+
+  it("filters gh run --log-failed output around explicit error annotations", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 25037757449 --repo openclaw/openclaw --log-failed",
+      argv: ["gh", "run", "view", "25037757449", "--log-failed"],
+      combinedText: [
+        "checks-node-core\tInstall\t2026-04-28T06:34:00.000Z\tRestoring cache",
+        "checks-node-core\tInstall\t2026-04-28T06:34:01.000Z\tDownloading packages",
+        "checks-node-core\tTest\t2026-04-28T06:35:00.000Z\tRunning shard 1",
+        "checks-node-core\tTest\t2026-04-28T06:35:01.000Z\t::error file=src/core/reduce.ts,line=41::expected statusCheckRollup signal",
+        "checks-node-core\tPost Test\t2026-04-28T06:35:02.000Z\tUploading artifacts",
+        "checks-node-core\tPost Test\t2026-04-28T06:35:03.000Z\tCleanup complete",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toContain("checks-node-core | Test | Running shard 1");
+    expect(result.inlineText).toContain("::error file=src/core/reduce.ts,line=41::expected statusCheckRollup signal");
+    expect(result.inlineText).toContain("checks-node-core | Post Test | Uploading artifacts");
+    expect(result.inlineText).toContain("non-signal log lines omitted");
+    expect(result.inlineText).not.toContain("Restoring cache");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["github-actions-log-signal-filter"] });
   });
 
   it("preserves emoji and CJK while stripping ANSI from user-facing output and stats", async () => {


### PR DESCRIPTION
## Summary
- combine the GitHub reducer signal fixes from #88 and #89 on a maintainer branch
- preserve failure signals from `gh run view --log` / `--log-failed` while omitting low-signal log noise
- preserve `statusCheckRollup` failures, pending checks, and action-required checks from `gh pr view --json`

## Why
The two contributor PRs fixed adjacent parts of the same reducer surface but conflicted with each other. This keeps both behaviors and adds the missing edge-case tests before landing.

Supersedes https://github.com/vincentkoc/tokenjuice/pull/88 and https://github.com/vincentkoc/tokenjuice/pull/89.

## Test Plan
- `pnpm exec vitest run test/core/reduce.test.ts -t "gh|statusCheckRollup|log-failed"`
- `pnpm verify`
