### PR TITLE
fix(gh): treat ghx as GitHub CLI

### DIFF
--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -657,7 +657,7 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
     }
   }
 
-  if ((input.argv ?? [])[0] === "gh") {
+  if (isGithubCliCommand((input.argv ?? [])[0])) {
     const formattedLines = lines.map(formatGhTableLine);
     if (isGhRunLogCommand(input)) {
       return filterGhRunLogSignalLines(formattedLines);
@@ -666,4 +666,8 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
   }
 
   return { lines };
+}
+
+function isGithubCliCommand(command: string | undefined): boolean {
+  return command === "gh" || command === "ghx";
 }

--- a/src/rules/cloud/gh.json
+++ b/src/rules/cloud/gh.json
@@ -4,7 +4,7 @@
   "description": "Compact GitHub CLI output while preserving issue, PR, and workflow result lines.",
   "match": {
     "toolNames": ["exec"],
-    "argv0": ["gh"]
+    "argv0": ["gh", "ghx"]
   },
   "transforms": {
     "stripAnsi": true,

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1224,6 +1224,24 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("\"number\":67473");
   });
 
+  it("treats ghx as a GitHub CLI drop-in replacement", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "ghx issue list -R openclaw/openclaw --limit 2 --json number,title,url,comments,updatedAt,labels --jq '.[] | {number,title,url,comments:(.comments|length),updatedAt,labels:[.labels[].name]}'",
+      argv: ["ghx", "issue", "list", "--json", "number,title,url,comments,updatedAt,labels"],
+      combinedText: [
+        "{\"number\":67473,\"title\":\"[Bug]: Auto-compaction (threshold-based) never fires in embedded runner\",\"url\":\"https://github.com/openclaw/openclaw/issues/67473\",\"comments\":0,\"updatedAt\":\"2026-04-16T01:52:50Z\",\"labels\":[\"bug\",\"bug:behavior\"]}",
+        "{\"number\":67469,\"title\":\"[Bug]: google-gemini-cli replies stop being persisted to OpenClaw session transcripts / WebUI history\",\"url\":\"https://github.com/openclaw/openclaw/issues/67469\",\"comments\":1,\"updatedAt\":\"2026-04-16T02:06:50Z\",\"labels\":[\"bug\",\"regression\"]}",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("#67473");
+    expect(result.inlineText).toContain("{bug, bug:behavior}");
+    expect(result.inlineText).not.toContain("\"number\":67473");
+  });
+
   it("formats gh json arrays without requiring jq line mode", async () => {
     const result = await reduceExecution({
       toolName: "exec",
@@ -1504,6 +1522,23 @@ describe("reduceExecution", () => {
       toolName: "exec",
       command: "gh pr list",
       argv: ["gh", "pr", "list"],
+      combinedText: [
+        "123  feat: add tokenjuice cloud reducers        vincentkoc:main   OPEN",
+        "122  fix: tighten fixture verification          vincentkoc:main   OPEN",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("#123 feat: add tokenjuice cloud reducers [OPEN] (vincentkoc:main)");
+    expect(result.inlineText).not.toContain("        ");
+  });
+
+  it("formats ghx table output like gh table output", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "ghx pr list",
+      argv: ["ghx", "pr", "list"],
       combinedText: [
         "123  feat: add tokenjuice cloud reducers        vincentkoc:main   OPEN",
         "122  fix: tighten fixture verification          vincentkoc:main   OPEN",


### PR DESCRIPTION
## Summary
- treat `ghx` as a GitHub CLI drop-in for the built-in `cloud/gh` reducer
- reuse the same compact table and JSON-line formatting paths for `ghx` output
- add regression coverage for both JSON issue output and table PR output

## Validation
- `pnpm exec vitest run test/core/reduce.test.ts`
