### PR TITLE
feat(rules): add uv output reducer

### DIFF
--- a/src/core/builtin-rules.generated.ts
+++ b/src/core/builtin-rules.generated.ts
@@ -95,20 +95,21 @@ import rule90 from "../rules/system/file.json" with { type: "json" };
 import rule91 from "../rules/system/ps.json" with { type: "json" };
 import rule92 from "../rules/task/just.json" with { type: "json" };
 import rule93 from "../rules/task/make.json" with { type: "json" };
-import rule94 from "../rules/tests/bun-test.json" with { type: "json" };
-import rule95 from "../rules/tests/cargo-test.json" with { type: "json" };
-import rule96 from "../rules/tests/go-test.json" with { type: "json" };
-import rule97 from "../rules/tests/jest.json" with { type: "json" };
-import rule98 from "../rules/tests/mocha.json" with { type: "json" };
-import rule99 from "../rules/tests/npm-test.json" with { type: "json" };
-import rule100 from "../rules/tests/playwright.json" with { type: "json" };
-import rule101 from "../rules/tests/pnpm-test.json" with { type: "json" };
-import rule102 from "../rules/tests/pytest.json" with { type: "json" };
-import rule103 from "../rules/tests/swift-test.json" with { type: "json" };
-import rule104 from "../rules/tests/vitest.json" with { type: "json" };
-import rule105 from "../rules/tests/yarn-test.json" with { type: "json" };
-import rule106 from "../rules/transfer/rsync.json" with { type: "json" };
-import rule107 from "../rules/transfer/scp.json" with { type: "json" };
+import rule94 from "../rules/task/uv.json" with { type: "json" };
+import rule95 from "../rules/tests/bun-test.json" with { type: "json" };
+import rule96 from "../rules/tests/cargo-test.json" with { type: "json" };
+import rule97 from "../rules/tests/go-test.json" with { type: "json" };
+import rule98 from "../rules/tests/jest.json" with { type: "json" };
+import rule99 from "../rules/tests/mocha.json" with { type: "json" };
+import rule100 from "../rules/tests/npm-test.json" with { type: "json" };
+import rule101 from "../rules/tests/playwright.json" with { type: "json" };
+import rule102 from "../rules/tests/pnpm-test.json" with { type: "json" };
+import rule103 from "../rules/tests/pytest.json" with { type: "json" };
+import rule104 from "../rules/tests/swift-test.json" with { type: "json" };
+import rule105 from "../rules/tests/vitest.json" with { type: "json" };
+import rule106 from "../rules/tests/yarn-test.json" with { type: "json" };
+import rule107 from "../rules/transfer/rsync.json" with { type: "json" };
+import rule108 from "../rules/transfer/scp.json" with { type: "json" };
 
 export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule0 as JsonRule, // rules/archive/tar.json
@@ -205,18 +206,19 @@ export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule91 as JsonRule, // rules/system/ps.json
   rule92 as JsonRule, // rules/task/just.json
   rule93 as JsonRule, // rules/task/make.json
-  rule94 as JsonRule, // rules/tests/bun-test.json
-  rule95 as JsonRule, // rules/tests/cargo-test.json
-  rule96 as JsonRule, // rules/tests/go-test.json
-  rule97 as JsonRule, // rules/tests/jest.json
-  rule98 as JsonRule, // rules/tests/mocha.json
-  rule99 as JsonRule, // rules/tests/npm-test.json
-  rule100 as JsonRule, // rules/tests/playwright.json
-  rule101 as JsonRule, // rules/tests/pnpm-test.json
-  rule102 as JsonRule, // rules/tests/pytest.json
-  rule103 as JsonRule, // rules/tests/swift-test.json
-  rule104 as JsonRule, // rules/tests/vitest.json
-  rule105 as JsonRule, // rules/tests/yarn-test.json
-  rule106 as JsonRule, // rules/transfer/rsync.json
-  rule107 as JsonRule, // rules/transfer/scp.json
+  rule94 as JsonRule, // rules/task/uv.json
+  rule95 as JsonRule, // rules/tests/bun-test.json
+  rule96 as JsonRule, // rules/tests/cargo-test.json
+  rule97 as JsonRule, // rules/tests/go-test.json
+  rule98 as JsonRule, // rules/tests/jest.json
+  rule99 as JsonRule, // rules/tests/mocha.json
+  rule100 as JsonRule, // rules/tests/npm-test.json
+  rule101 as JsonRule, // rules/tests/playwright.json
+  rule102 as JsonRule, // rules/tests/pnpm-test.json
+  rule103 as JsonRule, // rules/tests/pytest.json
+  rule104 as JsonRule, // rules/tests/swift-test.json
+  rule105 as JsonRule, // rules/tests/vitest.json
+  rule106 as JsonRule, // rules/tests/yarn-test.json
+  rule107 as JsonRule, // rules/transfer/rsync.json
+  rule108 as JsonRule, // rules/transfer/scp.json
 ];

--- a/src/rules/fixtures/task/uv.fixture.json
+++ b/src/rules/fixtures/task/uv.fixture.json
@@ -1,0 +1,16 @@
+{
+  "id": "task-uv-run-failure",
+  "ruleId": "task/uv",
+  "input": {
+    "toolName": "exec",
+    "argv": ["uv", "run", "pytest", "tests/test_api.py"],
+    "command": "uv run pytest tests/test_api.py",
+    "combinedText": "Using CPython 3.12.8 interpreter at: /opt/homebrew/bin/python3.12\nCreating virtual environment at: .venv\nResolved 42 packages in 14ms\nInstalled 42 packages in 103ms\n============================= test session starts ==============================\nplatform darwin -- Python 3.12.8, pytest-8.3.4\ncollected 3 items\n\ntests/test_api.py ..F                                                     [100%]\n\n=================================== FAILURES ===================================\n____________________________ test_returns_session _____________________________\nE       AssertionError: expected session id\n\nFAILED tests/test_api.py::test_returns_session - AssertionError: expected session id\n=========================== 1 failed, 2 passed in 0.18s ===========================\n",
+    "exitCode": 1
+  },
+  "expect": {
+    "matchedReducer": "task/uv",
+    "family": "python-task-runner",
+    "contains": ["Resolved 42 packages", "FAILED tests/test_api.py::test_returns_session"]
+  }
+}

--- a/src/rules/task/uv.json
+++ b/src/rules/task/uv.json
@@ -1,0 +1,35 @@
+{
+  "id": "task/uv",
+  "family": "python-task-runner",
+  "description": "Compact uv output while preserving environment setup, package changes, and command failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["uv"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 12
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "package",
+      "pattern": "Resolved|Prepared|Installed|Uninstalled|Audited",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|Traceback|FAILED|exit code",
+      "flags": "i"
+    }
+  ]
+}

--- a/test/core/rules.test.ts
+++ b/test/core/rules.test.ts
@@ -135,6 +135,7 @@ describe("rules", () => {
       "system/ps",
       "task/just",
       "task/make",
+      "task/uv",
       "tests/bun-test",
       "tests/cargo-test",
       "tests/go-test",
@@ -164,7 +165,7 @@ describe("rules", () => {
 
   it("loads builtin fixtures successfully", async () => {
     const fixtures = await loadBuiltinFixtures();
-    expect(fixtures).toHaveLength(114);
+    expect(fixtures).toHaveLength(115);
   });
 
   it("keeps builtin fixture inventory aligned with builtin rules", async () => {


### PR DESCRIPTION
## Summary
- add a built-in `task/uv` reducer for `uv run`, `uv sync`, and related Python workflow output
- preserve package setup lines and command failures while compacting repeated environment noise
- add fixture coverage and refresh the bundled rules manifest

## Validation
- `pnpm exec vitest run test/core/rules.test.ts`
