### PR TITLE
feat(rules): add mise output reducer

### DIFF
--- a/src/core/builtin-rules.generated.ts
+++ b/src/core/builtin-rules.generated.ts
@@ -95,21 +95,22 @@ import rule90 from "../rules/system/file.json" with { type: "json" };
 import rule91 from "../rules/system/ps.json" with { type: "json" };
 import rule92 from "../rules/task/just.json" with { type: "json" };
 import rule93 from "../rules/task/make.json" with { type: "json" };
-import rule94 from "../rules/task/uv.json" with { type: "json" };
-import rule95 from "../rules/tests/bun-test.json" with { type: "json" };
-import rule96 from "../rules/tests/cargo-test.json" with { type: "json" };
-import rule97 from "../rules/tests/go-test.json" with { type: "json" };
-import rule98 from "../rules/tests/jest.json" with { type: "json" };
-import rule99 from "../rules/tests/mocha.json" with { type: "json" };
-import rule100 from "../rules/tests/npm-test.json" with { type: "json" };
-import rule101 from "../rules/tests/playwright.json" with { type: "json" };
-import rule102 from "../rules/tests/pnpm-test.json" with { type: "json" };
-import rule103 from "../rules/tests/pytest.json" with { type: "json" };
-import rule104 from "../rules/tests/swift-test.json" with { type: "json" };
-import rule105 from "../rules/tests/vitest.json" with { type: "json" };
-import rule106 from "../rules/tests/yarn-test.json" with { type: "json" };
-import rule107 from "../rules/transfer/rsync.json" with { type: "json" };
-import rule108 from "../rules/transfer/scp.json" with { type: "json" };
+import rule94 from "../rules/task/mise.json" with { type: "json" };
+import rule95 from "../rules/task/uv.json" with { type: "json" };
+import rule96 from "../rules/tests/bun-test.json" with { type: "json" };
+import rule97 from "../rules/tests/cargo-test.json" with { type: "json" };
+import rule98 from "../rules/tests/go-test.json" with { type: "json" };
+import rule99 from "../rules/tests/jest.json" with { type: "json" };
+import rule100 from "../rules/tests/mocha.json" with { type: "json" };
+import rule101 from "../rules/tests/npm-test.json" with { type: "json" };
+import rule102 from "../rules/tests/playwright.json" with { type: "json" };
+import rule103 from "../rules/tests/pnpm-test.json" with { type: "json" };
+import rule104 from "../rules/tests/pytest.json" with { type: "json" };
+import rule105 from "../rules/tests/swift-test.json" with { type: "json" };
+import rule106 from "../rules/tests/vitest.json" with { type: "json" };
+import rule107 from "../rules/tests/yarn-test.json" with { type: "json" };
+import rule108 from "../rules/transfer/rsync.json" with { type: "json" };
+import rule109 from "../rules/transfer/scp.json" with { type: "json" };
 
 export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule0 as JsonRule, // rules/archive/tar.json
@@ -206,19 +207,20 @@ export const BUNDLED_BUILTIN_RULES: JsonRule[] = [
   rule91 as JsonRule, // rules/system/ps.json
   rule92 as JsonRule, // rules/task/just.json
   rule93 as JsonRule, // rules/task/make.json
-  rule94 as JsonRule, // rules/task/uv.json
-  rule95 as JsonRule, // rules/tests/bun-test.json
-  rule96 as JsonRule, // rules/tests/cargo-test.json
-  rule97 as JsonRule, // rules/tests/go-test.json
-  rule98 as JsonRule, // rules/tests/jest.json
-  rule99 as JsonRule, // rules/tests/mocha.json
-  rule100 as JsonRule, // rules/tests/npm-test.json
-  rule101 as JsonRule, // rules/tests/playwright.json
-  rule102 as JsonRule, // rules/tests/pnpm-test.json
-  rule103 as JsonRule, // rules/tests/pytest.json
-  rule104 as JsonRule, // rules/tests/swift-test.json
-  rule105 as JsonRule, // rules/tests/vitest.json
-  rule106 as JsonRule, // rules/tests/yarn-test.json
-  rule107 as JsonRule, // rules/transfer/rsync.json
-  rule108 as JsonRule, // rules/transfer/scp.json
+  rule94 as JsonRule, // rules/task/mise.json
+  rule95 as JsonRule, // rules/task/uv.json
+  rule96 as JsonRule, // rules/tests/bun-test.json
+  rule97 as JsonRule, // rules/tests/cargo-test.json
+  rule98 as JsonRule, // rules/tests/go-test.json
+  rule99 as JsonRule, // rules/tests/jest.json
+  rule100 as JsonRule, // rules/tests/mocha.json
+  rule101 as JsonRule, // rules/tests/npm-test.json
+  rule102 as JsonRule, // rules/tests/playwright.json
+  rule103 as JsonRule, // rules/tests/pnpm-test.json
+  rule104 as JsonRule, // rules/tests/pytest.json
+  rule105 as JsonRule, // rules/tests/swift-test.json
+  rule106 as JsonRule, // rules/tests/vitest.json
+  rule107 as JsonRule, // rules/tests/yarn-test.json
+  rule108 as JsonRule, // rules/transfer/rsync.json
+  rule109 as JsonRule, // rules/transfer/scp.json
 ];

--- a/src/rules/fixtures/task/mise.fixture.json
+++ b/src/rules/fixtures/task/mise.fixture.json
@@ -1,0 +1,16 @@
+{
+  "id": "task-mise-run-basic",
+  "ruleId": "task/mise",
+  "input": {
+    "toolName": "exec",
+    "argv": ["mise", "run", "check"],
+    "command": "mise run check",
+    "combinedText": "mise node@22.14.0 Downloading node-v22.14.0-darwin-arm64.tar.gz\nmise node@22.14.0 Extracting node-v22.14.0-darwin-arm64.tar.gz\nmise node@22.14.0 Installing node@22.14.0\nmise run check\n$ pnpm lint && pnpm test\n\n> tokenjuice@0.6.5 lint /repo\n> oxlint .\n\nFound 0 warnings and 0 errors.\n\n> tokenjuice@0.6.5 test /repo\n> vitest run\n\nTest Files  42 passed (42)\nTests       612 passed (612)\n",
+    "exitCode": 0
+  },
+  "expect": {
+    "matchedReducer": "task/mise",
+    "family": "task-runner",
+    "contains": ["Installing node@22.14.0", "Test Files  42 passed"]
+  }
+}

--- a/src/rules/task/mise.json
+++ b/src/rules/task/mise.json
@@ -1,0 +1,35 @@
+{
+  "id": "task/mise",
+  "family": "task-runner",
+  "description": "Compact mise output while preserving task results, tool installs, and failures.",
+  "match": {
+    "toolNames": ["exec"],
+    "argv0": ["mise"]
+  },
+  "transforms": {
+    "stripAnsi": true,
+    "dedupeAdjacent": true,
+    "trimEmptyEdges": true
+  },
+  "summarize": {
+    "head": 12,
+    "tail": 10
+  },
+  "failure": {
+    "preserveOnFailure": true,
+    "head": 18,
+    "tail": 18
+  },
+  "counters": [
+    {
+      "name": "install",
+      "pattern": "Downloading|Extracting|Installing|Installed",
+      "flags": "i"
+    },
+    {
+      "name": "error",
+      "pattern": "error|failed|not found|exit status",
+      "flags": "i"
+    }
+  ]
+}

--- a/test/core/rules.test.ts
+++ b/test/core/rules.test.ts
@@ -135,6 +135,7 @@ describe("rules", () => {
       "system/ps",
       "task/just",
       "task/make",
+      "task/mise",
       "task/uv",
       "tests/bun-test",
       "tests/cargo-test",
@@ -165,7 +166,7 @@ describe("rules", () => {
 
   it("loads builtin fixtures successfully", async () => {
     const fixtures = await loadBuiltinFixtures();
-    expect(fixtures).toHaveLength(115);
+    expect(fixtures).toHaveLength(116);
   });
 
   it("keeps builtin fixture inventory aligned with builtin rules", async () => {


### PR DESCRIPTION
## Summary
- add a built-in `task/mise` reducer for `mise run` and tool-install output
- preserve install progress, task output, and failure language while compacting repeated setup noise
- add fixture coverage and refresh the bundled rules manifest

## Validation
- `pnpm exec vitest run test/core/rules.test.ts`
