### PR TITLE
fix(gh): prefer workflow conclusions

### DIFF
--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -197,10 +197,9 @@ function formatGhJsonRecord(record: Record<string, unknown>): { line: string; co
   const branch = typeof record.headBranch === "string" ? record.headBranch
     : typeof record.headRefName === "string" ? record.headRefName
       : null;
-  const status = typeof record.state === "string" ? record.state
-    : typeof record.conclusion === "string" ? record.conclusion
-      : typeof record.status === "string" ? record.status
-      : null;
+  const status = getGhString(record, "state")
+    ?? getGhString(record, "conclusion")
+    ?? getGhString(record, "status");
   const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt.slice(0, 10) : null;
   const duration = extractGhDuration(record);
 

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -198,8 +198,8 @@ function formatGhJsonRecord(record: Record<string, unknown>): { line: string; co
     : typeof record.headRefName === "string" ? record.headRefName
       : null;
   const status = typeof record.state === "string" ? record.state
-    : typeof record.status === "string" ? record.status
-      : typeof record.conclusion === "string" ? record.conclusion
+    : typeof record.conclusion === "string" ? record.conclusion
+      : typeof record.status === "string" ? record.status
       : null;
   const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt.slice(0, 10) : null;
   const duration = extractGhDuration(record);

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1421,6 +1421,40 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("\"jobs\"");
   });
 
+  it("prefers gh run conclusions over completed statuses", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 24524437739 --repo openclaw/openclaw --json status,conclusion,jobs,displayTitle",
+      argv: ["gh", "run", "view", "24524437739", "--json", "status,conclusion,jobs,displayTitle"],
+      combinedText: JSON.stringify({
+        displayTitle: "checks: tokenjuice reducer failure",
+        status: "completed",
+        conclusion: "failure",
+        jobs: [
+          {
+            databaseId: 71690896188,
+            name: "checks-node-core-security",
+            status: "completed",
+            conclusion: "success",
+          },
+          {
+            databaseId: 71690896311,
+            name: "checks-node-core-runtime",
+            status: "completed",
+            conclusion: "failure",
+          },
+        ],
+      }),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("checks: tokenjuice reducer failure [failure]");
+    expect(result.inlineText).toContain("#71690896188 checks-node-core-security [success]");
+    expect(result.inlineText).toContain("#71690896311 checks-node-core-runtime [failure]");
+    expect(result.inlineText).not.toContain("checks-node-core-runtime [completed]");
+  });
+
   it("preserves gh pr status check failures from long statusCheckRollup payloads", async () => {
     const statusCheckRollup = Array.from({ length: 68 }, (_, index) => ({
       __typename: "CheckRun",

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1455,6 +1455,23 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("checks-node-core-runtime [completed]");
   });
 
+  it("falls back to gh run statuses when conclusions are empty", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 24524437739 --repo openclaw/openclaw --json status,conclusion,displayTitle",
+      argv: ["gh", "run", "view", "24524437739", "--json", "status,conclusion,displayTitle"],
+      combinedText: JSON.stringify({
+        displayTitle: "checks still running",
+        status: "in_progress",
+        conclusion: "",
+      }),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("checks still running [in_progress]");
+  });
+
   it("preserves gh pr status check failures from long statusCheckRollup payloads", async () => {
     const statusCheckRollup = Array.from({ length: 68 }, (_, index) => ({
       __typename: "CheckRun",


### PR DESCRIPTION
## Summary
- prefer `conclusion` over `status` for generic GitHub JSON records when no `state` is present
- keep failed/cancelled/timed-out `gh run view --json` workflow and job records from collapsing to `[completed]`
- add a reducer regression covering failed workflow and job conclusions

## Why
`gh run view --json` emits both `status: completed` and `conclusion: failure` for failed runs/jobs. Showing `completed` loses the actionable CI signal the reducer is supposed to preserve.

## Verification
- pnpm exec vitest run test/core/reduce.test.ts -t "prefers gh run conclusions"
- pnpm exec vitest run test/core/reduce.test.ts
- pnpm verify