### PR TITLE
fix(ghx): filter actions log signals

### DIFF
--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -564,7 +564,7 @@ function formatGhTableLine(line: string): string {
 
 function isGhRunLogCommand(input: ToolExecutionInput): boolean {
   const argv = input.argv ?? [];
-  return argv[0] === "gh"
+  return isGithubCliCommand(argv[0])
     && argv.includes("run")
     && argv.includes("view")
     && argv.some((arg) => arg === "--log" || arg === "--log-failed" || arg.startsWith("--log="));

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1628,6 +1628,33 @@ describe("reduceExecution", () => {
     expect(result.inlineText).not.toContain("2026-04-28T06:35:06.000Z");
   });
 
+  it("filters ghx run logs like gh run logs", async () => {
+    const filler = Array.from(
+      { length: 80 },
+      (_, index) =>
+        `checks-node-core\tRun test shard\t2026-04-28T06:34:${String(index % 60).padStart(2, "0")}.000Z\tprogress line ${index}`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "ghx run view 25037757449 --repo openclaw/openclaw --log",
+      argv: ["ghx", "run", "view", "25037757449", "--log"],
+      combinedText: [
+        ...filler.slice(0, 40),
+        "checks-node-core\tRun test shard\t2026-04-28T06:35:06.000Z\t##[error]test/core/reduce.test.ts(41,7): expected ghx log filtering",
+        "checks-node-core\tRun test shard\t2026-04-28T06:35:07.000Z\tELIFECYCLE Command failed with exit code 2",
+        ...filler.slice(40),
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("expected ghx log filtering");
+    expect(result.inlineText).toContain("ELIFECYCLE Command failed with exit code 2");
+    expect(result.inlineText).toContain("non-signal log lines omitted");
+    expect(result.inlineText).not.toContain("progress line 0");
+    expect(result.compaction).toEqual({ authoritative: true, kinds: ["github-actions-log-signal-filter"] });
+  });
+
   it("filters gh run --log-failed output around explicit error annotations", async () => {
     const result = await reduceExecution({
       toolName: "exec",


### PR DESCRIPTION
## Summary
- treat `ghx run view --log` / `--log-failed` as GitHub Actions log commands
- reuse the existing Actions log signal filter for `ghx` output
- add regression coverage that keeps middle error lines while omitting noisy progress logs

## Why
#91 made `ghx` a GitHub CLI drop-in for JSON and table reducers, but the Actions log signal filter still checked only `gh`. That means long `ghx run view --log` output can keep noisy logs instead of preserving the actionable error context.

## Verification
- pnpm exec vitest run test/core/reduce.test.ts -t "filters ghx run logs"
- pnpm exec vitest run test/core/reduce.test.ts
- pnpm verify