### PR TITLE
feat(hosts/claude-code): pivot to PreToolUse wrap (mirrors cursor/codebuddy)

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,7 +15,7 @@ import { runWrappedCommand } from "../core/wrap.js";
 import type { WrapResult } from "../types.js";
 import { doctorAiderConvention, installAiderConvention, uninstallAiderConvention } from "../hosts/aider/index.js";
 import { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "../hosts/avante/index.js";
-import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook } from "../hosts/claude-code/index.js";
+import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "../hosts/claude-code/index.js";
 import { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "../hosts/cline/index.js";
 import { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook } from "../hosts/codebuddy/index.js";
 import { doctorContinueRule, installContinueRule, uninstallContinueRule } from "../hosts/continue/index.js";
@@ -1848,6 +1848,8 @@ async function main(): Promise<number> {
       return await runCodexPostToolUseHook(await readStdin(args.maxInputBytes));
     case "claude-code-post-tool-use":
       return await runClaudeCodePostToolUseHook(await readStdin(args.maxInputBytes));
+    case "claude-code-pre-tool-use":
+      return await runClaudeCodePreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "cline-post-tool-use":
       return await runClinePostToolUseHook(await readStdin(args.maxInputBytes));
     case "codebuddy-pre-tool-use":

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -7,6 +7,11 @@ import { stripLeadingCdPrefix } from "../../core/command.js";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
 import { buildCompactionHint } from "../shared/hook-output.js";
+import {
+  buildWrappedCommand,
+  commandAlreadyWrapped,
+  resolveHostShell,
+} from "../shared/pre-tool-wrap.js";
 
 type ClaudeCodeHook = Record<string, unknown>;
 
@@ -499,4 +504,71 @@ export async function runClaudeCodePostToolUseHook(rawText: string): Promise<num
     });
     return 0;
   }
+}
+
+type ClaudeCodePreToolUsePayload = {
+  hook_event_name?: unknown;
+  tool_name?: unknown;
+  tool_input?: unknown;
+};
+
+type ClaudeCodeBashToolInput = {
+  command?: unknown;
+  description?: unknown;
+  run_in_background?: unknown;
+  timeout?: unknown;
+} & Record<string, unknown>;
+
+async function resolveClaudeCodeHostShell(): Promise<string | undefined> {
+  return resolveHostShell([
+    process.env.TOKENJUICE_CLAUDE_CODE_SHELL,
+    process.env.SHELL,
+    "bash",
+    "sh",
+  ]);
+}
+
+export async function runClaudeCodePreToolUseHook(rawText: string, wrapLauncher = "tokenjuice"): Promise<number> {
+  let payload: ClaudeCodePreToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as ClaudeCodePreToolUsePayload;
+  } catch {
+    return 0;
+  }
+
+  if (payload.hook_event_name !== "PreToolUse") {
+    return 0;
+  }
+  if (payload.tool_name !== "Bash" || !isRecord(payload.tool_input)) {
+    return 0;
+  }
+
+  const toolInput = payload.tool_input as ClaudeCodeBashToolInput;
+  const command = typeof toolInput.command === "string" ? toolInput.command : undefined;
+  if (!command || !command.trim()) {
+    return 0;
+  }
+  if (commandAlreadyWrapped(command)) {
+    return 0;
+  }
+
+  const shellPath = await resolveClaudeCodeHostShell();
+  if (!shellPath) {
+    return 0;
+  }
+
+  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "claude-code" });
+
+  const response = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: {
+        ...toolInput,
+        command: wrappedCommand,
+      },
+    },
+  };
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+  return 0;
 }

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -424,6 +424,13 @@ export async function runClaudeCodePreToolUseHook(rawText: string, wrapLauncher 
 
   const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "claude-code" });
 
+  // `permissionDecision: "allow"` matches the wrap-pattern used by the
+  // sibling `codebuddy` and `cursor` hosts in this repo. The user has already
+  // opted into letting tokenjuice transform their bash commands by running
+  // `tokenjuice install claude-code`; the wrapped invocation runs the same
+  // command they asked for, just routed through `tokenjuice wrap` for output
+  // compaction. Returning `"ask"` here would surface a permission prompt on
+  // every Bash call, defeating the transparent compaction contract.
   const response = {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -1,13 +1,14 @@
 import { constants as fsConstants } from "node:fs";
 import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
 import { stripLeadingCdPrefix } from "../../core/command.js";
 import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
-import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
+import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords } from "../shared/hook-command.js";
 import { buildCompactionHint } from "../shared/hook-output.js";
 import {
+  buildWrapLauncherHookCommand,
   buildWrappedCommand,
   commandAlreadyWrapped,
   resolveHostShell,
@@ -60,8 +61,11 @@ export type ClaudeCodeHookCommandOptions = {
   nodePath?: string;
 };
 
-const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
+const TOKENJUICE_CLAUDE_CODE_STATUS = "wrapping bash through tokenjuice for compaction";
+const TOKENJUICE_CLAUDE_CODE_LEGACY_STATUS = "compacting bash output with tokenjuice";
 const TOKENJUICE_CLAUDE_CODE_FIX_COMMAND = "tokenjuice install claude-code";
+const TOKENJUICE_CLAUDE_CODE_HOOK_SUBCOMMAND = "claude-code-pre-tool-use";
+const TOKENJUICE_CLAUDE_CODE_LEGACY_HOOK_SUBCOMMAND = "claude-code-post-tool-use";
 
 function getClaudeCodeHome(): string {
   // Claude Code resolves its config directory from CLAUDE_CONFIG_DIR, so honor
@@ -83,52 +87,12 @@ async function isExecutableFile(path: string): Promise<boolean> {
   }
 }
 
-async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
-  const pathValue = process.env.PATH;
-  if (!pathValue) {
-    return undefined;
-  }
-
-  const candidateNames = process.platform === "win32"
-    ? ["tokenjuice.exe", "tokenjuice.cmd", "tokenjuice.bat", "tokenjuice"]
-    : ["tokenjuice"];
-
-  for (const segment of pathValue.split(delimiter)) {
-    if (!segment) {
-      continue;
-    }
-
-    for (const candidateName of candidateNames) {
-      const candidatePath = join(segment, candidateName);
-      if (await isExecutableFile(candidatePath)) {
-        return candidatePath;
-      }
-    }
-  }
-
-  return undefined;
-}
-
 async function buildClaudeCodeHookCommand(options: ClaudeCodeHookCommandOptions = {}): Promise<string> {
-  const rawBinaryPath = options.binaryPath ?? process.argv[1];
-  const binaryPath = rawBinaryPath && !isAbsolute(rawBinaryPath) ? resolve(rawBinaryPath) : rawBinaryPath;
-  const nodePath = options.nodePath ?? process.execPath;
-  if (!binaryPath) {
-    throw new Error("unable to resolve tokenjuice binary path for claude code install");
-  }
-
-  if (!options.local) {
-    const installedBinaryPath = await resolveInstalledTokenjuicePath();
-    if (installedBinaryPath) {
-      return `${shellQuote(installedBinaryPath)} claude-code-post-tool-use`;
-    }
-  }
-
-  if (binaryPath.endsWith(".js")) {
-    return `${shellQuote(nodePath)} ${shellQuote(binaryPath)} claude-code-post-tool-use`;
-  }
-
-  return `${shellQuote(binaryPath)} claude-code-post-tool-use`;
+  return buildWrapLauncherHookCommand({
+    ...options,
+    subcommand: TOKENJUICE_CLAUDE_CODE_HOOK_SUBCOMMAND,
+    hostName: "claude-code",
+  });
 }
 
 function getClaudeCodeFixCommand(local = false): string {
@@ -177,31 +141,44 @@ function createTokenjuiceClaudeCodeHook(command: string): ClaudeCodeHookMatcherG
   };
 }
 
-function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
-  return group.hooks.some((hook) =>
-    isRecord(hook) && (
-      hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
-      || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
-    ),
+function isTokenjuiceClaudeCodeHookEntry(hook: unknown): boolean {
+  if (!isRecord(hook)) {
+    return false;
+  }
+  if (
+    hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
+    || hook.statusMessage === TOKENJUICE_CLAUDE_CODE_LEGACY_STATUS
+  ) {
+    return true;
+  }
+  if (typeof hook.command !== "string") {
+    return false;
+  }
+  return (
+    hook.command.includes(TOKENJUICE_CLAUDE_CODE_HOOK_SUBCOMMAND)
+    || hook.command.includes(TOKENJUICE_CLAUDE_CODE_LEGACY_HOOK_SUBCOMMAND)
   );
 }
 
-function findTokenjuiceClaudeCodeHookCommand(config: ClaudeCodeSettings): string | undefined {
-  const postToolUse = Array.isArray(config.hooks.PostToolUse) ? config.hooks.PostToolUse : [];
-  for (const group of postToolUse) {
-    if (!(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup))) {
-      continue;
-    }
+function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
+  return group.hooks.some(isTokenjuiceClaudeCodeHookEntry);
+}
 
-    const command = group.hooks.find((hook) =>
-      isRecord(hook)
-      && (
-        hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
-        || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
-      ),
-    )?.command;
-    if (typeof command === "string" && command) {
-      return command;
+function findTokenjuiceClaudeCodeHookCommand(
+  config: ClaudeCodeSettings,
+): { command: string; hookEvent: "PreToolUse" | "PostToolUse" } | undefined {
+  // Prefer the current PreToolUse shape; fall back to legacy PostToolUse so
+  // doctor can detect stale installs and report a migration hint.
+  for (const hookEvent of ["PreToolUse", "PostToolUse"] as const) {
+    const groups = Array.isArray(config.hooks[hookEvent]) ? (config.hooks[hookEvent] as unknown[]) : [];
+    for (const group of groups) {
+      if (!(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup))) {
+        continue;
+      }
+      const matched = group.hooks.find(isTokenjuiceClaudeCodeHookEntry);
+      if (isRecord(matched) && typeof matched.command === "string" && matched.command) {
+        return { command: matched.command, hookEvent };
+      }
     }
   }
 
@@ -267,18 +244,59 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Return `groups` with every tokenjuice hook entry removed from each group's
+ * `.hooks[]`. Unrelated hooks are preserved; groups that end up empty are
+ * dropped. This is the surgical counterpart to a simple group-level filter:
+ * dropping a whole group would silently delete any user-authored hook that
+ * happens to share a matcher group with the tokenjuice entry.
+ */
+function pruneTokenjuiceHookEntries(groups: unknown[]): unknown[] {
+  const pruned: unknown[] = [];
+  for (const group of groups) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      pruned.push(group);
+      continue;
+    }
+    const retainedHooks = group.hooks.filter((hook) => !isTokenjuiceClaudeCodeHookEntry(hook));
+    if (retainedHooks.length === 0) {
+      continue;
+    }
+    if (retainedHooks.length === group.hooks.length) {
+      pruned.push(group);
+      continue;
+    }
+    pruned.push({ ...group, hooks: retainedHooks });
+  }
+  return pruned;
+}
+
 export async function installClaudeCodeHook(
   settingsPath = getDefaultSettingsPath(),
   options: ClaudeCodeHookCommandOptions = {},
 ): Promise<InstallClaudeCodeHookResult> {
   const { config, backupPath } = await loadClaudeCodeSettings(settingsPath);
   const command = await buildClaudeCodeHookCommand(options);
-  const postToolUse = Array.isArray(config.hooks.PostToolUse) ? config.hooks.PostToolUse : [];
-  const retained = postToolUse.filter((group) =>
-    !(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup)),
-  );
+
+  // Drop any legacy PostToolUse tokenjuice entries left behind by a prior
+  // version of this host, but preserve unrelated hooks that happen to live in
+  // the same matcher group. This is the silent migration path: rerunning
+  // `tokenjuice install claude-code` after the PreToolUse pivot leaves the
+  // user with the new hook and zero legacy entries, no separate uninstall
+  // step required.
+  if (Array.isArray(config.hooks.PostToolUse)) {
+    const prunedPost = pruneTokenjuiceHookEntries(config.hooks.PostToolUse);
+    if (prunedPost.length === 0) {
+      delete config.hooks.PostToolUse;
+    } else {
+      config.hooks.PostToolUse = prunedPost;
+    }
+  }
+
+  const preToolUse = Array.isArray(config.hooks.PreToolUse) ? config.hooks.PreToolUse : [];
+  const retained = pruneTokenjuiceHookEntries(preToolUse);
   retained.push(createTokenjuiceClaudeCodeHook(command));
-  config.hooks.PostToolUse = retained;
+  config.hooks.PreToolUse = retained;
 
   await mkdir(dirname(settingsPath), { recursive: true });
   const tempPath = `${settingsPath}.tmp`;
@@ -299,7 +317,7 @@ export async function doctorClaudeCodeHook(
   const expectedCommand = await buildClaudeCodeHookCommand(options);
   const fixCommand = getClaudeCodeFixCommand(options.local);
   const { config, exists } = await readClaudeCodeSettings(settingsPath);
-  const detectedCommand = findTokenjuiceClaudeCodeHookCommand(config);
+  const detected = findTokenjuiceClaudeCodeHookCommand(config);
 
   if (!exists) {
     return {
@@ -313,11 +331,11 @@ export async function doctorClaudeCodeHook(
     };
   }
 
-  if (!detectedCommand) {
+  if (!detected) {
     return {
       settingsPath,
       status: "warn",
-      issues: ["tokenjuice PostToolUse hook is not installed for Claude Code"],
+      issues: ["tokenjuice PreToolUse hook is not installed for Claude Code"],
       fixCommand,
       expectedCommand,
       checkedPaths: [],
@@ -325,6 +343,26 @@ export async function doctorClaudeCodeHook(
     };
   }
 
+  // A legacy PostToolUse tokenjuice entry — wrong contract on Claude Code,
+  // additive context only, not a token reduction. Surface as a warn with a
+  // migration hint so users notice on the next `tokenjuice doctor` run.
+  if (detected.hookEvent === "PostToolUse") {
+    const legacyChecked = extractHookCommandPaths(detected.command);
+    return {
+      settingsPath,
+      status: "warn",
+      issues: [
+        "legacy PostToolUse tokenjuice hook detected; rerun `tokenjuice install claude-code` to migrate to PreToolUse",
+      ],
+      fixCommand,
+      expectedCommand,
+      detectedCommand: detected.command,
+      checkedPaths: legacyChecked,
+      missingPaths: [],
+    };
+  }
+
+  const detectedCommand = detected.command;
   const checkedPaths = extractHookCommandPaths(detectedCommand);
   const missingPaths: string[] = [];
   for (const path of checkedPaths) {

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -3,10 +3,7 @@ import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
-import { stripLeadingCdPrefix } from "../../core/command.js";
-import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
-import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords } from "../shared/hook-command.js";
-import { buildCompactionHint } from "../shared/hook-output.js";
+import { extractHookCommandPaths } from "../shared/hook-command.js";
 import {
   buildWrapLauncherHookCommand,
   buildWrappedCommand,
@@ -24,19 +21,6 @@ type ClaudeCodeHookMatcherGroup = Record<string, unknown> & {
 type ClaudeCodeSettings = Record<string, unknown> & {
   hooks: Record<string, unknown>;
 };
-
-type ClaudeCodePostToolUsePayload = {
-  hook_event_name?: unknown;
-  tool_name?: unknown;
-  cwd?: unknown;
-  tool_input?: {
-    command?: unknown;
-  };
-  tool_response?: unknown;
-};
-
-const GENERIC_FALLBACK_MIN_SAVED_CHARS = 120;
-const GENERIC_FALLBACK_MAX_RATIO = 0.75;
 
 export type InstallClaudeCodeHookResult = {
   settingsPath: string;
@@ -101,31 +85,6 @@ function getClaudeCodeFixCommand(local = false): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringifyToolResponse(value: unknown): string {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value
-      .map((entry) => stringifyToolResponse(entry))
-      .filter(Boolean)
-      .join("\n");
-  }
-  if (isRecord(value)) {
-    for (const key of ["output", "text", "stdout", "stderr", "combinedText"]) {
-      const text = value[key];
-      if (typeof text === "string" && text) {
-        return text;
-      }
-    }
-    return JSON.stringify(value);
-  }
-  return String(value);
 }
 
 function createTokenjuiceClaudeCodeHook(command: string): ClaudeCodeHookMatcherGroup {
@@ -395,153 +354,21 @@ export async function doctorClaudeCodeHook(
   };
 }
 
-function readPositiveIntegerEnv(name: string): number | undefined {
-  const value = process.env[name];
-  if (!value) {
-    return undefined;
-  }
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function shouldStoreFromEnv(): boolean {
-  const value = process.env.TOKENJUICE_CLAUDE_CODE_STORE;
-  return value === "1" || value === "true" || value === "TRUE" || value === "yes" || value === "YES";
-}
-
-function commandRequestsTokenjuiceRawBypass(command: string): boolean {
-  const argv = parseShellWords(stripLeadingCdPrefix(command));
-  if (argv.length < 3) {
-    return false;
-  }
-
-  const first = argv[0];
-  const second = argv[1];
-  let wrapIndex = -1;
-  if (first === "tokenjuice") {
-    wrapIndex = 1;
-  } else if (
-    typeof first === "string"
-    && isNodeExecutablePath(first)
-    && typeof second === "string"
-    && second.endsWith(".js")
-    && argv.slice(1).some((part) => part.includes("tokenjuice"))
-  ) {
-    wrapIndex = 2;
-  }
-
-  if (wrapIndex === -1 || argv[wrapIndex] !== "wrap") {
-    return false;
-  }
-
-  const optionEndIndex = argv.indexOf("--", wrapIndex + 1);
-  const optionArgs = argv.slice(wrapIndex + 1, optionEndIndex === -1 ? undefined : optionEndIndex);
-  return optionArgs.includes("--raw") || optionArgs.includes("--full");
-}
-
-function buildClaudeCodeAdditionalContext(inlineText: string, rawRefId?: string): string {
-  return `${inlineText}\n\n${buildCompactionHint(rawRefId)}`;
-}
-
-async function writeHookDebug(record: Record<string, unknown>): Promise<void> {
-  const debugPath = join(getClaudeCodeHome(), "tokenjuice-hook.last.json");
-  await mkdir(dirname(debugPath), { recursive: true });
-  await writeFile(debugPath, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-}
-
-export async function runClaudeCodePostToolUseHook(rawText: string): Promise<number> {
-  let payload: ClaudeCodePostToolUsePayload;
-  try {
-    payload = JSON.parse(rawText) as ClaudeCodePostToolUsePayload;
-  } catch {
-    return 0;
-  }
-
-  const command = payload.tool_input?.command;
-  const debug: Record<string, unknown> = {
-    hookEvent: payload.hook_event_name,
-    toolName: payload.tool_name,
-    command,
-    rewrote: false,
-  };
-
-  if (payload.hook_event_name !== "PostToolUse") {
-    await writeHookDebug({ ...debug, skipped: "non-post-tool-use" });
-    return 0;
-  }
-  if (payload.tool_name !== "Bash") {
-    await writeHookDebug({ ...debug, skipped: "non-bash" });
-    return 0;
-  }
-  if (typeof command !== "string" || !command.trim()) {
-    await writeHookDebug({ ...debug, skipped: "missing-command" });
-    return 0;
-  }
-
-  const combinedText = stringifyToolResponse(payload.tool_response);
-  if (!combinedText.trim()) {
-    await writeHookDebug({ ...debug, skipped: "empty-tool-response" });
-    return 0;
-  }
-
-  if (commandRequestsTokenjuiceRawBypass(command)) {
-    await writeHookDebug({ ...debug, skipped: "explicit-raw-bypass" });
-    return 0;
-  }
-
-  const maxInlineChars = readPositiveIntegerEnv("TOKENJUICE_CLAUDE_CODE_MAX_INLINE_CHARS");
-
-  try {
-    const outcome = await compactBashResult({
-      source: "claude-code",
-      command,
-      visibleText: combinedText,
-      ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
-      ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
-      inspectionPolicy: "allow-safe-inventory",
-      storeRaw: shouldStoreFromEnv(),
-      metadata: {
-        source: "claude-code-post-tool-use",
-      },
-      genericFallbackMinSavedChars: GENERIC_FALLBACK_MIN_SAVED_CHARS,
-      genericFallbackMaxRatio: GENERIC_FALLBACK_MAX_RATIO,
-      skipGenericFallbackForCompoundCommands: true,
-    });
-
-    const result = outcome.action === "rewrite" ? outcome.result : outcome.result;
-    if (result) {
-      debug.rawChars = result.stats.rawChars;
-      debug.reducedChars = result.stats.reducedChars;
-      debug.matchedReducer = result.classification.matchedReducer;
-    }
-
-    if (outcome.action === "keep") {
-      await writeHookDebug({ ...debug, skipped: outcome.reason });
-      return 0;
-    }
-
-    const hookOutput: Record<string, unknown> = {
-      suppressOutput: true,
-      hookSpecificOutput: {
-        hookEventName: "PostToolUse",
-        additionalContext: buildClaudeCodeAdditionalContext(
-          outcome.result.inlineText,
-          outcome.result.rawRef?.id,
-        ),
-      },
-    };
-
-    process.stdout.write(`${JSON.stringify(hookOutput)}\n`);
-    await writeHookDebug({ ...debug, rewrote: true });
-    return 0;
-  } catch (error) {
-    await writeHookDebug({
-      ...debug,
-      skipped: "hook-error",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return 0;
-  }
+/**
+ * Deprecation shim. The legacy `claude-code-post-tool-use` hook contract
+ * (additive `hookSpecificOutput.additionalContext`) does not substitute the
+ * underlying `tool_result` on Claude Code, so the unreduced bash output still
+ * reaches the model and the inline hint is appended on top — net additive,
+ * not compacting. The host pivoted to a PreToolUse "wrap" entrypoint in this
+ * version (`runClaudeCodePreToolUseHook`); this shim lets settings.json files
+ * left over from the old install fail soft instead of erroring per Bash call
+ * until the user reruns `tokenjuice install claude-code`.
+ */
+export async function runClaudeCodePostToolUseHook(_rawText: string): Promise<number> {
+  process.stderr.write(
+    "[tokenjuice] claude-code-post-tool-use is deprecated; rerun `tokenjuice install claude-code` to migrate to the PreToolUse hook.\n",
+  );
+  return 0;
 }
 
 type ClaudeCodePreToolUsePayload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";
 export { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "./hosts/avante/index.js";
 export { doctorAiderConvention, installAiderConvention, uninstallAiderConvention } from "./hosts/aider/index.js";
-export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook } from "./hosts/claude-code/index.js";
+export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "./hosts/claude-code/index.js";
 export { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "./hosts/cline/index.js";
 export { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook } from "./hosts/codebuddy/index.js";
 export { doctorContinueRule, installContinueRule, uninstallContinueRule } from "./hosts/continue/index.js";

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { doctorClaudeCodeHook, doctorInstalledHooks, installClaudeCodeHook, installCodeBuddyHook, installCodexHook, installCursorHook, installPiExtension, runClaudeCodePostToolUseHook } from "../../src/index.js";
+import { doctorClaudeCodeHook, doctorInstalledHooks, installClaudeCodeHook, installCodeBuddyHook, installCodexHook, installCursorHook, installPiExtension, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "../../src/index.js";
 import { getInstalledHookIntegrations } from "../../src/hosts/shared/hook-doctor.js";
 
 const tempDirs: string[] = [];
@@ -924,5 +924,87 @@ describe("claude code config directory discovery", () => {
     const report = await doctorClaudeCodeHook();
 
     expect(report.settingsPath).toBe(join(configDir, "settings.json"));
+  });
+});
+
+describe("runClaudeCodePreToolUseHook", () => {
+  it("rewrites a Bash command into a tokenjuice-wrapped invocation", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "find /etc -maxdepth 2 -type f" },
+    });
+
+    const { code, output } = await captureStdout(() =>
+      runClaudeCodePreToolUseHook(payload, "/usr/local/bin/tokenjuice"),
+    );
+
+    expect(code).toBe(0);
+    const response = JSON.parse(output) as {
+      hookSpecificOutput: {
+        hookEventName: string;
+        permissionDecision: string;
+        updatedInput: { command: string };
+      };
+    };
+    expect(response.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(response.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(response.hookSpecificOutput.updatedInput.command).toContain("tokenjuice");
+    expect(response.hookSpecificOutput.updatedInput.command).toContain(" wrap ");
+    expect(response.hookSpecificOutput.updatedInput.command).toContain("find /etc -maxdepth 2 -type f");
+  });
+
+  it("no-ops on non-Bash tool names", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: "/etc/hostname" },
+    });
+
+    const { code, output } = await captureStdout(() =>
+      runClaudeCodePreToolUseHook(payload, "/usr/local/bin/tokenjuice"),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
+  it("no-ops on already-wrapped commands to prevent double-wrap", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "tokenjuice wrap -- bash -lc 'ls /tmp'" },
+    });
+
+    const { code, output } = await captureStdout(() =>
+      runClaudeCodePreToolUseHook(payload, "/usr/local/bin/tokenjuice"),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
+  it("no-ops on non-PreToolUse events", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    });
+
+    const { code, output } = await captureStdout(() =>
+      runClaudeCodePreToolUseHook(payload, "/usr/local/bin/tokenjuice"),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
+  });
+
+  it("no-ops on malformed JSON instead of crashing", async () => {
+    const { code, output } = await captureStdout(() =>
+      runClaudeCodePreToolUseHook("{not valid json", "/usr/local/bin/tokenjuice"),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("");
   });
 });

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -663,267 +663,49 @@ describe("doctorInstalledHooks", () => {
   });
 });
 
-describe("runClaudeCodePostToolUseHook", () => {
-  it("adds compacted bash output as context without a block decision", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
+describe("runClaudeCodePostToolUseHook (legacy shim)", () => {
+  it("returns 0 and writes a deprecation notice to stderr without rewriting output", async () => {
+    const stderrChunks: string[] = [];
+    const originalStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write;
 
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "git status",
-      },
-      tool_response: [
-        "On branch pr-65478-security-fix",
-        "Your branch and 'origin/pr-65478-security-fix' have diverged,",
-        "and have 8 and 642 different commits each, respectively.",
-        "",
-        "Changes not staged for commit:",
-        "\tmodified:   src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts",
-        "\tmodified:   src/agents/pi-embedded-runner/run/attempt.test.ts",
-        "",
-        "no changes added to commit",
-      ].join("\n"),
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const response = JSON.parse(output) as {
-      decision?: string;
-      reason?: string;
-      suppressOutput?: boolean;
-      hookSpecificOutput?: { additionalContext?: string };
-    };
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      matchedReducer?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(response).not.toHaveProperty("decision");
-    expect(response).not.toHaveProperty("reason");
-    expect(response.suppressOutput).toBe(true);
-    expect(response.hookSpecificOutput?.additionalContext).toContain("Changes not staged:");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
-    expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("need raw?");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
-    expect(response.hookSpecificOutput?.additionalContext).not.toContain("tokenjuice wrap --full -- <command>");
-    expect(debug.rewrote).toBe(true);
-    expect(debug.matchedReducer).toBe("git/status");
+    try {
+      const { code, output } = await captureStdout(() =>
+        runClaudeCodePostToolUseHook(
+          JSON.stringify({
+            hook_event_name: "PostToolUse",
+            tool_name: "Bash",
+            tool_input: { command: "ls" },
+            tool_response: "x",
+          }),
+        ),
+      );
+      expect(code).toBe(0);
+      expect(output).toBe("");
+      expect(stderrChunks.join("")).toContain("deprecated");
+    } finally {
+      process.stderr.write = originalStderr;
+    }
   });
 
-  it("skips file-content inspection commands", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
+  it("returns 0 even on malformed JSON (no crash on stale settings.json)", async () => {
+    const stderrChunks: string[] = [];
+    const originalStderr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stderr.write;
 
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "cat src/core/reduce.ts",
-      },
-      tool_response: "export function reduceExecution() {}\n",
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("file-content-inspection-command");
-  });
-
-  it("rewrites safe repository inventory commands", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "rg --files src/rules",
-      },
-      tool_response: Array.from({ length: 30 }, (_, index) => `src/rules/example-${index + 1}.json`).join("\n"),
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const response = JSON.parse(output) as {
-      decision?: string;
-      reason?: string;
-      hookSpecificOutput?: { additionalContext?: string };
-    };
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      matchedReducer?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(response).not.toHaveProperty("decision");
-    expect(response).not.toHaveProperty("reason");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("30 paths");
-    expect(debug.rewrote).toBe(true);
-    expect(debug.matchedReducer).toBe("filesystem/rg-files");
-  });
-
-  it("skips non-PostToolUse events", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "Stop",
-      tool_name: "Bash",
-      tool_input: {
-        command: "git status",
-      },
-      tool_response: "output",
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("non-post-tool-use");
-  });
-
-  it("skips non-Bash tools", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Read",
-      tool_input: {
-        command: "cat README.md",
-      },
-      tool_response: "output",
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("non-bash");
-  });
-
-  it("honors tokenjuice raw bypass commands without re-compacting them", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "tokenjuice wrap --raw -- bash -lc 'git show HEAD --stat'",
-      },
-      tool_response: [
-        "commit abcdef",
-        "Author: Example",
-        "",
-        " README.md | 10 +++++-----",
-        " src/hosts/claude-code/index.ts | 12 +++++++-----",
-      ].join("\n"),
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("explicit-raw-bypass");
-  });
-
-  it("honors tokenjuice raw bypass commands with leading cd prefixes", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "cd /data/code/lighthouse/helper && tokenjuice wrap --raw -- python scripts/query_cls_log.py --limit 500",
-      },
-      tool_response: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n"),
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("explicit-raw-bypass");
-  });
-
-  it("honors tokenjuice full bypass commands without re-compacting them", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "tokenjuice wrap --full -- git log --oneline -50",
-      },
-      tool_response: Array.from({ length: 50 }, (_, i) => `${String(i).padStart(7, "0")} commit ${i}`).join("\n"),
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("explicit-raw-bypass");
-  });
-
-  it("skips empty tool_response", async () => {
-    const home = await createTempDir();
-    process.env.CLAUDE_HOME = home;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: {
-        command: "git status",
-      },
-      tool_response: "",
-    });
-
-    const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
-      rewrote: boolean;
-      skipped?: string;
-    };
-
-    expect(code).toBe(0);
-    expect(output).toBe("");
-    expect(debug.rewrote).toBe(false);
-    expect(debug.skipped).toBe("empty-tool-response");
+    try {
+      const { code, output } = await captureStdout(() => runClaudeCodePostToolUseHook("{not-json"));
+      expect(code).toBe(0);
+      expect(output).toBe("");
+    } finally {
+      process.stderr.write = originalStderr;
+    }
   });
 });
 
@@ -955,26 +737,6 @@ describe("claude code config directory discovery", () => {
     const result = await installClaudeCodeHook();
 
     expect(result.settingsPath).toBe(join(legacyHome, "settings.json"));
-  });
-
-  it("writes hook debug log under CLAUDE_CONFIG_DIR when set", async () => {
-    const configDir = await createTempDir();
-    const legacyHome = await createTempDir();
-    process.env.CLAUDE_CONFIG_DIR = configDir;
-    process.env.CLAUDE_HOME = legacyHome;
-
-    const payload = JSON.stringify({
-      hook_event_name: "PostToolUse",
-      tool_name: "Bash",
-      tool_input: { command: "git status" },
-      tool_response: "",
-    });
-
-    await captureStdout(() => runClaudeCodePostToolUseHook(payload));
-
-    const debugPath = join(configDir, "tokenjuice-hook.last.json");
-    const debug = JSON.parse(await readFile(debugPath, "utf8")) as { skipped?: string };
-    expect(debug.skipped).toBe("empty-tool-response");
   });
 
   it("doctor reads settings.json from CLAUDE_CONFIG_DIR when no path is provided", async () => {

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -59,7 +59,7 @@ async function captureStdout(run: () => Promise<number>): Promise<{ code: number
 }
 
 describe("installClaudeCodeHook", () => {
-  it("installs a single tokenjuice PostToolUse hook on an empty settings file", async () => {
+  it("installs a single tokenjuice PreToolUse hook on an empty settings file", async () => {
     const home = await createTempDir();
     const settingsPath = join(home, "settings.json");
 
@@ -70,10 +70,51 @@ describe("installClaudeCodeHook", () => {
 
     expect(result.settingsPath).toBe(settingsPath);
     expect(result.backupPath).toBeUndefined();
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("claude-code-pre-tool-use");
+    expect(parsed.hooks.PostToolUse ?? []).toHaveLength(0);
+  });
+
+  it("removes legacy PostToolUse tokenjuice entries when installing the new PreToolUse hook", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                {
+                  type: "command",
+                  command: "/usr/local/bin/tokenjuice claude-code-post-tool-use",
+                  statusMessage: "compacting bash output with tokenjuice",
+                },
+              ],
+            },
+            {
+              matcher: "Edit",
+              hooks: [{ type: "command", command: "echo unrelated-keep" }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installClaudeCodeHook(settingsPath);
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("claude-code-pre-tool-use");
+    // Legacy tokenjuice PostToolUse entry is removed; unrelated PostToolUse entry is preserved.
     expect(parsed.hooks.PostToolUse).toHaveLength(1);
-    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Bash");
-    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
-    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.statusMessage).toBe("compacting bash output with tokenjuice");
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Edit");
   });
 
   it("preserves unrelated top-level settings keys across install", async () => {
@@ -148,7 +189,11 @@ describe("installClaudeCodeHook", () => {
       },
     });
     expect(parsed.hooks.SessionStart).toHaveLength(1);
-    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    // Existing unrelated PostToolUse[Edit] is preserved; PreToolUse gets the new tokenjuice entry.
+    expect(parsed.hooks.PostToolUse).toHaveLength(1);
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Edit");
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.matcher).toBe("Bash");
   });
 
   it("preserves non-command Claude Code hooks and extra handler fields", async () => {
@@ -204,11 +249,14 @@ describe("installClaudeCodeHook", () => {
       { type: "prompt", prompt: "session prompt" },
       { type: "http", url: "https://example.com/hooks" },
     ]);
-    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    // The legacy tokenjuice PostToolUse[Bash] entry is migrated out; the
+    // unrelated PostToolUse[Edit] agent hook is kept untouched.
+    expect(parsed.hooks.PostToolUse).toHaveLength(1);
     expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Edit");
     expect(parsed.hooks.PostToolUse[0]?.hooks).toEqual([{ type: "agent", prompt: "summarize the edit" }]);
-    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("Bash");
-    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("claude-code-pre-tool-use");
   });
 
   it("prefers a stable tokenjuice launcher from PATH when installing the hook", async () => {
@@ -230,8 +278,9 @@ describe("installClaudeCodeHook", () => {
       hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
     };
 
-    expect(result.command).toBe(`${launcherPath} claude-code-post-tool-use`);
-    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(`${launcherPath} claude-code-post-tool-use`);
+    const expectedCommand = `${launcherPath} claude-code-pre-tool-use --wrap-launcher ${launcherPath}`;
+    expect(result.command).toBe(expectedCommand);
+    expect(parsed.hooks.PreToolUse?.[0]?.hooks[0]?.command).toBe(expectedCommand);
   });
 
   it("can force local repo routing instead of the PATH launcher", async () => {
@@ -262,9 +311,9 @@ describe("installClaudeCodeHook", () => {
       hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
     };
 
-    const expectedCommand = `${localNodePath} ${resolve(localCliPath)} claude-code-post-tool-use`;
+    const expectedCommand = `${localNodePath} ${resolve(localCliPath)} claude-code-pre-tool-use --wrap-launcher ${resolve(localCliPath)}`;
     expect(result.command).toBe(expectedCommand);
-    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(expectedCommand);
+    expect(parsed.hooks.PreToolUse?.[0]?.hooks[0]?.command).toBe(expectedCommand);
   });
 
   it("is idempotent and replaces old tokenjuice entries", async () => {
@@ -303,13 +352,15 @@ describe("installClaudeCodeHook", () => {
       hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
     };
 
-    const tokenjuiceHooks = parsed.hooks.PostToolUse.filter((group) =>
-      group.hooks.some((hook) => hook.statusMessage === "compacting bash output with tokenjuice" || hook.command.includes("claude-code-post-tool-use")),
-    );
-
-    expect(parsed.hooks.PostToolUse).toHaveLength(2);
-    expect(tokenjuiceHooks).toHaveLength(1);
-    expect(tokenjuiceHooks[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+    // After the pivot, the legacy PostToolUse[Bash] tokenjuice entry is
+    // migrated out and the new PreToolUse[Bash] entry is the single tokenjuice
+    // hook. Unrelated PostToolUse[Read] is preserved.
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("claude-code-pre-tool-use");
+    expect(parsed.hooks.PostToolUse).toHaveLength(1);
+    expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Read");
+    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toBe("echo keep-read");
   });
 
   it("preserves other PostToolUse matchers", async () => {
@@ -336,11 +387,14 @@ describe("installClaudeCodeHook", () => {
       hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
     };
 
-    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    // Unrelated PostToolUse entries are preserved in place; the new PreToolUse
+    // entry is added separately.
+    expect(parsed.hooks.PostToolUse).toHaveLength(1);
     expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Write");
     expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toBe("echo keep-write");
-    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("Bash");
-    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+    expect(parsed.hooks.PreToolUse).toHaveLength(1);
+    expect(parsed.hooks.PreToolUse[0]?.matcher).toBe("Bash");
+    expect(parsed.hooks.PreToolUse[0]?.hooks[0]?.command).toContain("claude-code-pre-tool-use");
   });
 });
 
@@ -359,7 +413,7 @@ describe("doctorClaudeCodeHook", () => {
     const report = await doctorClaudeCodeHook(settingsPath);
 
     expect(report.status).toBe("ok");
-    expect(report.detectedCommand).toBe(`${launcherPath} claude-code-post-tool-use`);
+    expect(report.detectedCommand).toBe(`${launcherPath} claude-code-pre-tool-use --wrap-launcher ${launcherPath}`);
     expect(report.issues).toEqual([]);
   });
 
@@ -390,21 +444,14 @@ describe("doctorClaudeCodeHook", () => {
     });
 
     expect(report.status).toBe("ok");
-    expect(report.expectedCommand).toBe(`${localNodePath} ${resolve(localCliPath)} claude-code-post-tool-use`);
+    expect(report.expectedCommand).toBe(`${localNodePath} ${resolve(localCliPath)} claude-code-pre-tool-use --wrap-launcher ${resolve(localCliPath)}`);
     expect(report.detectedCommand).toBe(report.expectedCommand);
     expect(report.fixCommand).toBe("tokenjuice install claude-code --local");
   });
 
-  it("flags stale Homebrew Cellar hook commands as broken", async () => {
+  it("warns when only a legacy PostToolUse tokenjuice hook is present", async () => {
     const home = await createTempDir();
     const settingsPath = join(home, "settings.json");
-    const binDir = join(home, "bin");
-    const launcherPath = join(binDir, "tokenjuice");
-    const staleCommand = `${process.execPath} /opt/homebrew/Cellar/tokenjuice/0.2.0/libexec/dist/cli/main.js claude-code-post-tool-use`;
-
-    process.env.PATH = binDir;
-    await mkdir(binDir, { recursive: true });
-    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     await writeFile(
       settingsPath,
       `${JSON.stringify({
@@ -412,7 +459,11 @@ describe("doctorClaudeCodeHook", () => {
           PostToolUse: [
             {
               matcher: "Bash",
-              hooks: [{ type: "command", command: staleCommand, statusMessage: "compacting bash output with tokenjuice" }],
+              hooks: [{
+                type: "command",
+                command: "/usr/local/bin/tokenjuice claude-code-post-tool-use",
+                statusMessage: "compacting bash output with tokenjuice",
+              }],
             },
           ],
         },
@@ -422,11 +473,21 @@ describe("doctorClaudeCodeHook", () => {
 
     const report = await doctorClaudeCodeHook(settingsPath);
 
-    expect(report.status).toBe("broken");
-    expect(report.detectedCommand).toBe(staleCommand);
-    expect(report.issues).toContain("configured Claude Code hook is pinned to a versioned Homebrew Cellar path");
-    expect(report.missingPaths).toContain("/opt/homebrew/Cellar/tokenjuice/0.2.0/libexec/dist/cli/main.js");
+    expect(report.status).toBe("warn");
+    expect(report.issues.join(" ")).toMatch(/legacy PostToolUse|migrate/i);
+    expect(report.detectedCommand).toContain("claude-code-post-tool-use");
     expect(report.fixCommand).toBe("tokenjuice install claude-code");
+  });
+
+  it("warns when no tokenjuice hook is installed", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+    await writeFile(settingsPath, JSON.stringify({}), "utf8");
+
+    const report = await doctorClaudeCodeHook(settingsPath);
+
+    expect(report.status).toBe("warn");
+    expect(report.issues.join(" ")).toMatch(/PreToolUse|not installed/i);
   });
 });
 


### PR DESCRIPTION
Refs #98.

## What

Pivots the `claude-code` host adapter from PostToolUse to the PreToolUse "wrap" pattern, mirroring the existing cursor / codebuddy / vscode-copilot / copilot-cli adapters.

- `runClaudeCodePreToolUseHook` reads the PreToolUse payload and emits `hookSpecificOutput.permissionDecision: "allow"` with `updatedInput.command` rewritten to `tokenjuice wrap --source claude-code -- <shell> -lc '<original>'`.
- `installClaudeCodeHook` writes a `hooks.PreToolUse[Bash]` entry. Same pass filters out any pre-existing tokenjuice `PostToolUse` entries (surgical hook-level pruning, preserves unrelated hooks in the same matcher group) so users running `tokenjuice install claude-code` after the pivot get a clean migration without a separate `uninstall + install` step.
- `doctorClaudeCodeHook` reports `warn` when only legacy PostToolUse entries are present, with a message pointing at `tokenjuice install claude-code` for migration.
- The legacy `claude-code-post-tool-use` CLI subcommand becomes a deprecation shim that returns 0 and writes a one-line stderr notice. This keeps stale settings.json from spewing errors until users reinstall.
- `buildClaudeCodeHookCommand` now delegates to the shared `buildWrapLauncherHookCommand` helper, identical to the codebuddy / cursor / vscode-copilot pattern.

## Why

`hookSpecificOutput.additionalContext` does not replace `tool_result` content on Claude Code (verified through 2.1.137). The unreduced output still reaches the model and the additionalContext hint is appended on top. Trial data: -7.8% input tokens with PreToolUse rewrite vs +1.1% with the current PostToolUse install. See #98 for the full evidence.

## Test plan

- [x] `pnpm test` (full suite, 726 passing across 42 files)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] End-to-end smoke: `install claude-code --local` against a temp `CLAUDE_CONFIG_DIR`, then fire a synthetic PreToolUse payload through the dist binary; output contains `permissionDecision:"allow"` and `updatedInput.command` includes `tokenjuice wrap --source claude-code`.
- [x] Migration smoke: install against a settings.json that already has a tokenjuice PostToolUse entry; result has only the new PreToolUse entry, unrelated PostToolUse entries (e.g. an `Edit` matcher) are kept.

## Notes

- `permissionDecision: "allow"` follows the established convention in this repo for the wrap pattern (`src/hosts/codebuddy/index.ts` and `src/hosts/cursor/index.ts` use the same value). The user has already opted into letting tokenjuice transform their bash commands by running `tokenjuice install claude-code`; returning `"ask"` would surface a prompt on every Bash call. Inline comment in the adapter documents this.
- **Upgrade trade-off (worth your attention):** users who upgrade tokenjuice without rerunning `install claude-code` will silently lose compaction — the legacy `claude-code-post-tool-use` runtime becomes a deprecation shim that emits a stderr notice but no longer compacts. Doctor catches this on next run with a `warn` + migration hint. Open to alternative migration shapes if you'd rather have automatic rewrite-on-upgrade or a longer compatibility window.
- Drafting because I'm open to a different shape if you'd prefer a flag-gated rollout (`--strategy=pretool` opt-in) over the default pivot. The trial data made me lean default-pivot but happy to revise.
- The legacy `runClaudeCodePostToolUseHook` shim is intentionally inert. It could also be hard-removed if you'd rather not carry deprecation surface — let me know which you prefer.
- Anthropic's #18653 (tool_result-substitute hook) would let us move back to PostToolUse cleanly when it lands. This PR does not preclude that.
