### PR TITLE
fix(codex): support hooks feature flag and warn on legacy codex_hooks

### DIFF
--- a/scripts/local-host-e2e.mjs
+++ b/scripts/local-host-e2e.mjs
@@ -102,7 +102,7 @@ async function runCodexE2E() {
   const codexHome = join(tempRoot, "codex-home");
   const schemaDir = join(tempRoot, "codex-app-server-schema");
   await mkdir(codexHome, { recursive: true });
-  await writeFile(join(codexHome, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
+  await writeFile(join(codexHome, "config.toml"), "[features]\nhooks = true\n", "utf8");
 
   const version = await run("codex", ["--version"]);
   await run("codex", ["app-server", "generate-json-schema", "--experimental", "--out", schemaDir], {

--- a/src/cli/doctor-output.ts
+++ b/src/cli/doctor-output.ts
@@ -69,12 +69,12 @@ export function formatHookDoctorReport(report: HookDoctorReport): string {
     if ("featureFlag" in integrationReport && integrationReport.featureFlag) {
       const flag = integrationReport.featureFlag;
       if (flag.enabled) {
-        lines.push(`- feature flag: codex_hooks is enabled (${flag.configPath})`);
+        lines.push(`- feature flag: hooks is enabled (${flag.configPath})`);
       } else {
         const where = flag.configExists
           ? `${flag.configPath} (missing or disabled)`
           : `no ${flag.configPath}`;
-        lines.push(`- feature flag: codex_hooks not enabled — ${where}`);
+        lines.push(`- feature flag: hooks not enabled — ${where}`);
       }
     }
     lines.push(`- repair: ${integrationReport.fixCommand}`);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -505,12 +505,12 @@ async function runInstall(args: ParsedArgs): Promise<number> {
       { label: "Command", value: result.command },
     ];
     if (result.featureFlag.enabled) {
-      details.push({ label: "Feature flag", value: `codex_hooks is enabled (${result.featureFlag.configPath})` });
+      details.push({ label: "Feature flag", value: `hooks is enabled (${result.featureFlag.configPath})` });
     } else {
       const where = result.featureFlag.configExists
         ? `${result.featureFlag.configPath} (missing or disabled)`
         : `no ${result.featureFlag.configPath}`;
-      details.push({ label: "Feature flag", value: `codex_hooks not enabled - ${where}` });
+      details.push({ label: "Feature flag", value: `hooks not enabled - ${where}` });
       details.push({ label: "Enable", value: result.featureFlag.fixHint });
     }
     if (result.backupPath) {
@@ -1238,13 +1238,13 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     }
     if (report.featureFlag.enabled) {
       process.stdout.write(
-        `feature flag: codex_hooks is enabled (${report.featureFlag.configPath})\n`,
+        `feature flag: hooks is enabled (${report.featureFlag.configPath})\n`,
       );
     } else {
       const where = report.featureFlag.configExists
         ? `${report.featureFlag.configPath} (missing or disabled)`
         : `no ${report.featureFlag.configPath}`;
-      process.stdout.write(`feature flag: codex_hooks not enabled — ${where}\n`);
+      process.stdout.write(`feature flag: hooks not enabled — ${where}\n`);
       process.stdout.write(`   ${report.featureFlag.fixHint}\n`);
     }
     process.stdout.write(`repair: ${report.fixCommand}\n`);

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -66,15 +66,19 @@ export type CodexFeatureFlagStatus = {
   configPath: string;
   /** Whether the config file exists on disk. */
   configExists: boolean;
-  /** Whether a `codex_hooks` key was found anywhere in `[features]`. */
+  /** Whether a supported hooks feature key was found anywhere in `[features]`. */
   keyPresent: boolean;
   /** Parsed value when present, otherwise null. */
   value: boolean | null;
   /** Convenience: keyPresent && value === true. */
   enabled: boolean;
+  /** Which feature key was detected, if any. */
+  keyName?: string;
+  /** Whether the detected key is the deprecated legacy alias. */
+  deprecatedKeyUsed?: boolean;
   /**
    * One-line remediation the user can copy-paste. Empty when enabled.
-   * Currently a `codex exec --enable codex_hooks` hint rather than
+   * Currently a `codex exec --enable hooks` hint rather than
    * editing config.toml automatically (tokenjuice avoids silent
    * config rewrites).
    */
@@ -87,7 +91,7 @@ export type CodexHookCommandOptions = {
   nodePath?: string;
   /**
    * Override for the config.toml consulted when reporting the
-   * `codex_hooks` feature-flag state. Defaults to `~/.codex/config.toml`.
+   * hooks feature-flag state. Defaults to `~/.codex/config.toml`.
    * Exposed primarily for tests and tooling that manage a non-default
    * Codex home.
    */
@@ -127,11 +131,12 @@ function getDefaultCodexConfigPath(): string {
   return join(getCodexHome(), "config.toml");
 }
 
-const FEATURE_FLAG_NAME = "codex_hooks";
+const FEATURE_FLAG_NAME = "hooks";
+const LEGACY_FEATURE_FLAG_NAME = "codex_hooks";
 const FEATURE_FLAG_FIX_HINT =
-  "Codex requires the `codex_hooks` feature to load hooks.json. " +
-  "Enable per-invocation with `codex exec --enable codex_hooks ...`, " +
-  "or persistently by adding a `[features]` section with `codex_hooks = true` to ~/.codex/config.toml.";
+  "Codex requires the `hooks` feature to load hooks.json or inline [hooks]. " +
+  "Enable per-invocation with `codex exec --enable hooks ...`, " +
+  "or persistently by adding a `[features]` section with `hooks = true` to ~/.codex/config.toml.";
 
 function buildCodexFeatureFlagStatus(
   configPath: string,
@@ -148,7 +153,7 @@ function buildCodexFeatureFlagStatus(
 }
 
 /**
- * Read-only scan of ~/.codex/config.toml for `codex_hooks = <bool>` under
+ * Read-only scan of ~/.codex/config.toml for `hooks = <bool>` under
  * a `[features]` section (top-level or dotted form). Does NOT edit the
  * file — tokenjuice prefers to surface the state and let the user decide.
  *
@@ -173,20 +178,24 @@ export async function inspectCodexHooksFeatureFlag(
   }
 
   const parsed = parseCodexFeatureFlag(source, FEATURE_FLAG_NAME);
-  const enabled = parsed.keyPresent && parsed.value === true;
+  const legacyParsed = parsed.keyPresent ? { keyPresent: false, value: null } : parseCodexFeatureFlag(source, LEGACY_FEATURE_FLAG_NAME);
+  const selected = parsed.keyPresent ? parsed : legacyParsed;
+  const enabled = selected.keyPresent && selected.value === true;
   return {
     configPath,
     configExists: true,
-    keyPresent: parsed.keyPresent,
-    value: parsed.keyPresent ? parsed.value : null,
+    keyPresent: selected.keyPresent,
+    value: selected.keyPresent ? selected.value : null,
     enabled,
+    ...(selected.keyPresent ? { keyName: parsed.keyPresent ? FEATURE_FLAG_NAME : LEGACY_FEATURE_FLAG_NAME } : {}),
+    ...(legacyParsed.keyPresent ? { deprecatedKeyUsed: true } : {}),
     fixHint: enabled ? "" : FEATURE_FLAG_FIX_HINT,
   };
 }
 
 /**
- * Minimal TOML-ish scanner. Looks for `codex_hooks = <bool>` either under
- * a `[features]` header or as a dotted `features.codex_hooks = <bool>`
+ * Minimal TOML-ish scanner. Looks for `<key> = <bool>` either under
+ * a `[features]` header or as a dotted `features.<key> = <bool>`
  * assignment at any indent. Ignores comments and in-line comments.
  * Not a full TOML parser; only the shapes Codex itself documents.
  */
@@ -777,7 +786,12 @@ export async function doctorCodexHook(
   }
   if (!featureFlag.enabled) {
     issues.push(
-      "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
+      "Codex feature flag `hooks` is not enabled — the configured hook will not fire",
+    );
+  }
+  if (featureFlag.deprecatedKeyUsed) {
+    issues.push(
+      "Codex feature flag `codex_hooks` is deprecated — rename it to `hooks` in ~/.codex/config.toml",
     );
   }
   issues.push(...collectLowTimeoutWarnings(config));

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -471,7 +471,7 @@ describe("doctorInstalledHooks", () => {
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
-    await writeFile(join(home, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(join(home, "config.toml"), "[features]\nhooks = true\n", "utf8");
     await installCodexHook(join(home, "hooks.json"));
     await installClaudeCodeHook(join(home, "settings.json"));
     await installCodeBuddyHook();
@@ -557,7 +557,7 @@ describe("doctorInstalledHooks", () => {
     await writeFile(localBinaryPath, "console.log('tokenjuice');\n", "utf8");
     await writeFile(localNodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     await mkdir(codexHome, { recursive: true });
-    await writeFile(join(codexHome, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(join(codexHome, "config.toml"), "[features]\nhooks = true\n", "utf8");
 
     await installCodexHook(undefined, {
       local: true,

--- a/test/hosts/codebuddy.test.ts
+++ b/test/hosts/codebuddy.test.ts
@@ -571,7 +571,7 @@ describe("doctorInstalledHooks includes codebuddy", () => {
     process.env.PI_CODING_AGENT_DIR = join(home, "pi-agent");
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
-    await writeFile(join(home, "config.toml"), "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(join(home, "config.toml"), "[features]\nhooks = true\n", "utf8");
     await installCodexHook(join(home, "hooks.json"));
     await installClaudeCodeHook();
     await installCodeBuddyHook();

--- a/test/hosts/codex-feature-flag.test.ts
+++ b/test/hosts/codex-feature-flag.test.ts
@@ -27,55 +27,55 @@ async function withTempCodexHome<T>(
 
 describe("parseCodexFeatureFlag", () => {
   it("returns keyPresent=false when file has no features section", () => {
-    expect(parseCodexFeatureFlag("[other]\nfoo = 1\n", "codex_hooks")).toEqual({
+    expect(parseCodexFeatureFlag("[other]\nfoo = 1\n", "hooks")).toEqual({
       keyPresent: false,
       value: null,
     });
   });
 
   it("parses a scoped [features] section", () => {
-    const source = "[features]\ncodex_hooks = true\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+    const source = "[features]\nhooks = true\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: true,
       value: true,
     });
   });
 
   it("parses explicit false", () => {
-    const source = "[features]\ncodex_hooks = false\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+    const source = "[features]\nhooks = false\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: true,
       value: false,
     });
   });
 
-  it("parses dotted features.codex_hooks at top level", () => {
-    const source = "features.codex_hooks = true\n[other]\nfoo = 1\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+  it("parses dotted features.hooks at top level", () => {
+    const source = "features.hooks = true\n[other]\nfoo = 1\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: true,
       value: true,
     });
   });
 
   it("ignores the key when outside [features]", () => {
-    const source = "[other]\ncodex_hooks = true\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+    const source = "[other]\nhooks = true\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: false,
       value: null,
     });
   });
 
   it("ignores commented-out assignments", () => {
-    const source = "[features]\n# codex_hooks = true\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+    const source = "[features]\n# hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: false,
       value: null,
     });
   });
 
   it("ignores dotted assignments inside a non-root table", () => {
-    const source = "[profiles.default]\nfeatures.codex_hooks = true\n";
-    expect(parseCodexFeatureFlag(source, "codex_hooks")).toEqual({
+    const source = "[profiles.default]\nfeatures.hooks = true\n";
+    expect(parseCodexFeatureFlag(source, "hooks")).toEqual({
       keyPresent: false,
       value: null,
     });
@@ -90,13 +90,13 @@ describe("inspectCodexHooksFeatureFlag", () => {
       expect(status.keyPresent).toBe(false);
       expect(status.value).toBe(null);
       expect(status.enabled).toBe(false);
-      expect(status.fixHint).toContain("codex_hooks");
+      expect(status.fixHint).toContain("hooks");
     });
   });
 
-  it("reports enabled=true when [features] codex_hooks = true", async () => {
+  it("reports enabled=true when [features] hooks = true", async () => {
     await withTempCodexHome(async ({ configPath }) => {
-      await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");
+      await writeFile(configPath, "[features]\nhooks = true\n", "utf8");
       const status = await inspectCodexHooksFeatureFlag(configPath);
       expect(status.configExists).toBe(true);
       expect(status.keyPresent).toBe(true);
@@ -106,15 +106,26 @@ describe("inspectCodexHooksFeatureFlag", () => {
     });
   });
 
-  it("reports enabled=false when codex_hooks is explicitly disabled", async () => {
+  it("reports enabled=false when hooks is explicitly disabled", async () => {
     await withTempCodexHome(async ({ configPath }) => {
-      await writeFile(configPath, "[features]\ncodex_hooks = false\n", "utf8");
+      await writeFile(configPath, "[features]\nhooks = false\n", "utf8");
       const status = await inspectCodexHooksFeatureFlag(configPath);
       expect(status.configExists).toBe(true);
       expect(status.keyPresent).toBe(true);
       expect(status.value).toBe(false);
       expect(status.enabled).toBe(false);
-      expect(status.fixHint).toContain("codex_hooks");
+      expect(status.fixHint).toContain("hooks");
+    });
+  });
+
+
+  it("accepts legacy codex_hooks but marks it deprecated", async () => {
+    await withTempCodexHome(async ({ configPath }) => {
+      await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");
+      const status = await inspectCodexHooksFeatureFlag(configPath);
+      expect(status.enabled).toBe(true);
+      expect(status.keyName).toBe("codex_hooks");
+      expect(status.deprecatedKeyUsed).toBe(true);
     });
   });
 
@@ -128,7 +139,7 @@ describe("inspectCodexHooksFeatureFlag", () => {
     }
 
     await withTempCodexHome(async ({ configPath }) => {
-      await writeFile(configPath, "[features]\ncodex_hooks = true\n", "utf8");
+      await writeFile(configPath, "[features]\nhooks = true\n", "utf8");
       try {
         await chmod(configPath, 0o000);
         const status = await inspectCodexHooksFeatureFlag(configPath);
@@ -152,7 +163,7 @@ describe("installCodexHook feature-flag surface", () => {
         const result = await installCodexHook(hooksPath);
         expect(result.featureFlag.enabled).toBe(false);
         expect(result.featureFlag.configExists).toBe(false);
-        expect(result.featureFlag.fixHint).toContain("codex_hooks");
+        expect(result.featureFlag.fixHint).toContain("hooks");
         // sanity: hooks.json was still written as usual
         const hooks = JSON.parse(await readFile(hooksPath, "utf8"));
         expect(hooks.hooks.PostToolUse).toBeDefined();

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -226,7 +226,7 @@ describe("doctorCodexHook", () => {
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     const featureFlagConfigPath = join(home, "config.toml");
-    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(featureFlagConfigPath, "[features]\nhooks = true\n", "utf8");
     await installCodexHook(hooksPath, { featureFlagConfigPath });
 
     const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
@@ -251,7 +251,7 @@ describe("doctorCodexHook", () => {
     await mkdir(cellarBinDir, { recursive: true });
     await writeFile(resolvedLauncherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     await symlink(resolvedLauncherPath, launcherPath);
-    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(featureFlagConfigPath, "[features]\nhooks = true\n", "utf8");
     await installCodexHook(hooksPath, { featureFlagConfigPath });
 
     const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
@@ -265,7 +265,7 @@ describe("doctorCodexHook", () => {
     expect(report.issues).not.toContain("configured Codex hook command does not match the current recommended command");
   });
 
-  it("warns when codex_hooks feature flag is not enabled", async () => {
+  it("warns when hooks feature flag is not enabled", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");
     const binDir = join(home, "bin");
@@ -283,7 +283,7 @@ describe("doctorCodexHook", () => {
     expect(report.status).toBe("warn");
     expect(report.featureFlag.enabled).toBe(false);
     expect(report.issues).toContain(
-      "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
+      "Codex feature flag `hooks` is not enabled — the configured hook will not fire",
     );
   });
 
@@ -357,7 +357,7 @@ describe("doctorCodexHook", () => {
     process.env.PATH = binDir;
     await mkdir(binDir, { recursive: true });
     await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
-    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(featureFlagConfigPath, "[features]\nhooks = true\n", "utf8");
     await writeFile(
       hooksPath,
       `${JSON.stringify({
@@ -418,7 +418,7 @@ describe("doctorCodexHook", () => {
     await writeFile(localCliPath, "console.log('tokenjuice');\n", "utf8");
 
     const featureFlagConfigPath = join(home, "config.toml");
-    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(featureFlagConfigPath, "[features]\nhooks = true\n", "utf8");
     await installCodexHook(hooksPath, {
       local: true,
       binaryPath: localCliPath,


### PR DESCRIPTION
## Summary
- Codex 0.130.0 deprecated `features.codex_hooks` in favor of `features.hooks`. tokenjuice's `doctor`/`install` flow only recognized the legacy key, so users on current Codex saw misleading "feature flag not enabled" output and the install hint pointed them at the deprecated alias.
- This patch supports both keys, prefers `hooks`, warns when the legacy `codex_hooks` alias is used, and updates the user-facing strings/install hints to match Codex's current vocabulary.
- Existing `~/.codex/hooks.json` integration is unchanged; this PR is scoped to feature-flag detection and messaging.

## Behavior
- `[features] hooks = true` → doctor reports healthy, no warnings.
- `[features] codex_hooks = true` → doctor still works, status flips to `warn` with: `` Codex feature flag `codex_hooks` is deprecated — rename it to `hooks` in ~/.codex/config.toml ``.
- Neither set → doctor warns: `` Codex feature flag `hooks` is not enabled — the configured hook will not fire ``.
- Both set → `hooks` wins (legacy fully shadowed, no deprecation warning).
- Fix hint now reads: ``Codex requires the `hooks` feature to load hooks.json or inline [hooks]. Enable per-invocation with `codex exec --enable hooks ...`, or persistently by adding a `[features]` section with `hooks = true` to ~/.codex/config.toml.``

## Implementation
- `src/hosts/codex/index.ts`: `parseCodexFeatureFlag` + `inspectCodexHooksFeatureFlag` learn to look for `hooks` first and fall back to `codex_hooks`. `CodexFeatureFlagStatus` gains `keyName` (which alias matched) and `deprecatedKeyUsed` (set when only the legacy key is present). `doctorCodexHook` pushes the deprecation message into `issues[]` when `deprecatedKeyUsed` is set.
- `src/cli/main.ts` + `src/cli/doctor-output.ts`: user-facing strings updated from `codex_hooks` → `hooks`.
- Tests: `test/hosts/codex-feature-flag.test.ts` covers all 4 states (canonical, legacy/deprecated, none, both → canonical wins). `test/hosts/codex.test.ts` and `test/hosts/claude-code.test.ts` updated for the new wording.
- Knock-on: `test/hosts/codebuddy.test.ts` and `scripts/local-host-e2e.mjs` had fixtures using `codex_hooks = true`; updated to the canonical `hooks = true` so the tests/E2E continue to assert against `status === "ok"`. The legacy path is still exercised by the new dedicated unit tests.

## Refs
- Codex changelog: https://developers.openai.com/codex/changelog
- Codex feature flags: https://developers.openai.com/codex/config-basic#feature-flags
- Codex hooks: https://developers.openai.com/codex/hooks

## Test plan
- [x] `pnpm verify` (lint + lint:circular + typecheck + full vitest) — **728 passed across 42 files**
- [x] `pnpm contracts` (publint) — clean
- [x] `pnpm build` — clean dist
- [x] CLI doctor smoke against built dist with isolated `CODEX_HOME` for each of `{canonical, legacy, none, both}` — all 4 states match expected status/issues/keyName
- [x] Real-binary smoke against `codex 0.130.0` on a host with that codex installed — all 3 actionable states match expected output
- [x] Verified `codex 0.130.0` itself accepts the canonical `[features] hooks = true` (`codex app-server generate-json-schema` succeeds against a fresh `CODEX_HOME` configured this way)

### Known unrelated issue (not introduced by this PR)
`pnpm e2e:local` fails on a clean `upstream/main` checkout (no patch applied) — the `runCodexE2E` step asserts `codex-post-tool-use` exits with code 2 and writes feedback to stderr, but the current handler emits `hookSpecificOutput` JSON to stdout with exit 0. This pre-existing E2E breakage is out of scope for a feature-flag rename PR; reported separately.
