### PR TITLE
[codex] Compact JSON hook context

### DIFF
--- a/src/core/reduce-utils.ts
+++ b/src/core/reduce-utils.ts
@@ -3,13 +3,9 @@ import { createHash } from "node:crypto";
 import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { countTextChars, sliceTextChars } from "./text.js";
 
-export function compactWhitespace(text: string): string {
-  return text.replace(/\s+/gu, " ").trim();
-}
+export const compactWhitespace = (text: string): string => text.replace(/\s+/gu, " ").trim();
 
-function shortHash(text: string): string {
-  return createHash("sha256").update(text).digest("hex").slice(0, 12);
-}
+const shortHash = (text: string): string => createHash("sha256").update(text).digest("hex").slice(0, 12);
 
 export function clipMiddleWithHash(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
@@ -22,6 +18,71 @@ export function clipMiddleWithHash(text: string, maxChars: number): { text: stri
     text: `${sliceTextChars(text, 0, headChars)} ...[${omitted} chars omitted, sha256:${shortHash(text)}]... ${sliceTextChars(text, -tailChars)}`,
     compaction: createCompactionMetadata("hashed-middle-clip"),
   };
+}
+
+function clipMiddleWithHashStrict(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+  if (countTextChars(text) <= maxChars) {
+    return { text };
+  }
+
+  const omitted = countTextChars(text) - maxChars;
+  const marker = `...[${omitted} chars omitted, sha256:${shortHash(text)}]...`;
+  const markerChars = countTextChars(marker);
+  if (maxChars <= markerChars) {
+    return {
+      text: sliceTextChars(marker, 0, maxChars),
+      compaction: createCompactionMetadata("hashed-middle-clip"),
+    };
+  }
+
+  const bodyChars = maxChars - markerChars;
+  const headChars = Math.ceil(bodyChars * 0.7);
+  const tailChars = Math.max(0, bodyChars - headChars);
+  return {
+    text: `${sliceTextChars(text, 0, headChars)}${marker}${tailChars > 0 ? sliceTextChars(text, -tailChars) : ""}`,
+    compaction: createCompactionMetadata("hashed-middle-clip"),
+  };
+}
+
+function minifyJsonLexically(rawText: string): string {
+  const text = rawText.trim();
+  let output = "";
+  let inString = false;
+  let escaped = false;
+
+  for (const char of text) {
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (/\s/u.test(char)) {
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+export function compactWholeJsonText(rawText: string, maxChars: number): { text: string; compaction?: CompactionMetadata } | null {
+  return parseJsonValue(rawText) === null
+    ? null
+    : clipMiddleWithHashStrict(minifyJsonLexically(rawText), maxChars);
 }
 
 export function parseJsonObjectLine(line: string): Record<string, unknown> | null {

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -6,10 +6,11 @@ import { clampTextMiddleWithMetadata, clampTextWithMetadata, countTextChars, ded
 import { storeArtifact, storeArtifactMetadata } from "./artifacts.js";
 import { NO_COMPACTION_METADATA, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { buildGithubActionsFailureSummary } from "./github-actions-summary.js";
+import { compactWholeJsonText } from "./reduce-utils.js";
 import { rewriteGhLines, rewriteGitDiffLines, rewriteGitStatusLines, rewriteSearchLines } from "./reduce-formatters.js";
 import { buildInspectionSummary } from "./reduce-inspection-summary.js";
 
-import type { CompactResult, CompiledRule, ReduceOptions, ToolExecutionInput } from "../types.js";
+import type { ClassificationResult, CompactResult, CompiledRule, ReduceOptions, ToolExecutionInput } from "../types.js";
 
 const TINY_OUTPUT_MAX_CHARS = 240;
 const SMALL_OUTPUT_PASSTHROUGH_MIN_SAVED_CHARS = 120;
@@ -154,28 +155,20 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
 
 function buildPassthroughText(input: ToolExecutionInput, rawText: string): string {
   const normalized = trimEmptyEdges(normalizeLines(stripAnsi(rawText))).join("\n").trim();
-  if (!normalized) {
-    return "(no output)";
-  }
-
-  if (input.exitCode && input.exitCode !== 0) {
-    return `exit ${input.exitCode}\n${normalized}`;
-  }
-
-  return normalized;
+  return !normalized
+    ? "(no output)"
+    : input.exitCode && input.exitCode !== 0
+      ? `exit ${input.exitCode}\n${normalized}`
+      : normalized;
 }
 
 function buildLiteralPassthroughText(input: ToolExecutionInput, rawText: string): string {
   const normalized = stripAnsi(rawText).trimEnd();
-  if (!normalized) {
-    return buildPassthroughText(input, rawText);
-  }
-
-  if (input.exitCode && input.exitCode !== 0) {
-    return `exit ${input.exitCode}\n${normalized}`;
-  }
-
-  return normalized;
+  return !normalized
+    ? buildPassthroughText(input, rawText)
+    : input.exitCode && input.exitCode !== 0
+      ? `exit ${input.exitCode}\n${normalized}`
+      : normalized;
 }
 
 function shouldKeepSmallOutput(
@@ -210,6 +203,40 @@ function isTerseDiscoveryCommand(classification: { family: string }, input: Tool
     return argv.includes("--porcelain");
   }
   return false;
+}
+
+async function storeReducedOutputIfRequested(
+  input: ToolExecutionInput,
+  rawText: string,
+  classification: ClassificationResult,
+  stats: CompactResult["stats"],
+  opts: ReduceOptions,
+) {
+  const rawRef = opts.store
+    ? await storeArtifact(
+        {
+          input,
+          rawText,
+          classification,
+          stats,
+        },
+        opts.storeDir,
+      )
+    : undefined;
+
+  if (!opts.store && opts.recordStats) {
+    await storeArtifactMetadata(
+      {
+        input,
+        rawText,
+        classification,
+        stats,
+      },
+      opts.storeDir,
+    );
+  }
+
+  return rawRef;
 }
 
 function formatInline(
@@ -303,6 +330,12 @@ export async function reduceExecutionWithRules(
   const normalizedInput = normalizeExecutionInput(input);
   const rawText = buildRawText(normalizedInput);
   const measuredRawChars = countTextChars(stripAnsi(rawText));
+  const maxInlineChars = opts.maxInlineChars ?? 1200;
+  const buildStats = (reducedChars: number): CompactResult["stats"] => ({
+    rawChars: measuredRawChars,
+    reducedChars,
+    ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
+  });
   const resolvedMatch = opts.classifier
     ? undefined
     : resolveRuleMatch(input, rules);
@@ -325,47 +358,15 @@ export async function reduceExecutionWithRules(
     : undefined;
 
   if (opts.raw) {
-    const rawRef = opts.store
-      ? await storeArtifact(
-          {
-            input: normalizedInput,
-            rawText,
-            classification,
-            stats: {
-              rawChars: measuredRawChars,
-              reducedChars: measuredRawChars,
-              ratio: 1,
-            },
-          },
-          opts.storeDir,
-        )
-      : undefined;
-    if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
-        {
-          input: normalizedInput,
-          rawText,
-          classification,
-          stats: {
-            rawChars: measuredRawChars,
-            reducedChars: measuredRawChars,
-            ratio: 1,
-          },
-        },
-        opts.storeDir,
-      );
-    }
+    const stats = buildStats(measuredRawChars);
+    const rawRef = await storeReducedOutputIfRequested(normalizedInput, rawText, classification, stats, opts);
 
     return {
       inlineText: rawText,
       compaction: NO_COMPACTION_METADATA,
       ...(trace ? { trace } : {}),
       ...(rawRef ? { rawRef } : {}),
-      stats: {
-        rawChars: measuredRawChars,
-        reducedChars: measuredRawChars,
-        ratio: 1,
-      },
+      stats,
       classification,
     };
   }
@@ -373,41 +374,15 @@ export async function reduceExecutionWithRules(
   const inspectionSummary = buildInspectionSummary(normalizedInput, rawText);
   if (inspectionSummary) {
     const summaryText = inspectionSummary.lines.join("\n").trim();
-    const selectedText = clampTextMiddleWithMetadata(summaryText, opts.maxInlineChars ?? 1200);
+    const selectedText = clampTextMiddleWithMetadata(summaryText, maxInlineChars);
     const reducedChars = countTextChars(selectedText.text);
     const summaryClassification = {
       family: "structured-summary",
       confidence: 0.9,
       matchedReducer: inspectionSummary.matchedReducer,
     };
-    const stats = {
-      rawChars: measuredRawChars,
-      reducedChars,
-      ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
-    };
-    const rawRef = opts.store
-      ? await storeArtifact(
-          {
-            input: normalizedInput,
-            rawText,
-            classification: summaryClassification,
-            stats,
-          },
-          opts.storeDir,
-        )
-      : undefined;
-
-    if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
-        {
-          input: normalizedInput,
-          rawText,
-          classification: summaryClassification,
-          stats,
-        },
-        opts.storeDir,
-      );
-    }
+    const stats = buildStats(reducedChars);
+    const rawRef = await storeReducedOutputIfRequested(normalizedInput, rawText, summaryClassification, stats, opts);
 
     return {
       inlineText: selectedText.text,
@@ -421,17 +396,14 @@ export async function reduceExecutionWithRules(
   }
 
   if (classification.matchedReducer === "generic/fallback" && isFileContentInspectionCommand(normalizedInput)) {
+    const stats = buildStats(measuredRawChars);
     if (!opts.store && opts.recordStats) {
       await storeArtifactMetadata(
         {
           input: normalizedInput,
           rawText,
           classification,
-          stats: {
-            rawChars: measuredRawChars,
-            reducedChars: measuredRawChars,
-            ratio: 1,
-          },
+          stats,
         },
         opts.storeDir,
       );
@@ -441,11 +413,7 @@ export async function reduceExecutionWithRules(
       inlineText: rawText,
       compaction: NO_COMPACTION_METADATA,
       ...(trace ? { trace } : {}),
-      stats: {
-        rawChars: measuredRawChars,
-        reducedChars: measuredRawChars,
-        ratio: 1,
-      },
+      stats,
       classification,
     };
   }
@@ -461,37 +429,10 @@ export async function reduceExecutionWithRules(
     ? buildGithubActionsFailureSummary(reducerInput, rawText)
     : null;
   if (githubActionsFailureSummary) {
-    const maxInlineChars = opts.maxInlineChars ?? 1200;
     const inlineText = clampTextMiddleWithMetadata(githubActionsFailureSummary.text, maxInlineChars);
     const reducedChars = countTextChars(inlineText.text);
-    const stats = {
-      rawChars: measuredRawChars,
-      reducedChars,
-      ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
-    };
-    const rawRef = opts.store
-      ? await storeArtifact(
-          {
-            input: normalizedInput,
-            rawText,
-            classification,
-            stats,
-          },
-          opts.storeDir,
-        )
-      : undefined;
-
-    if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
-        {
-          input: normalizedInput,
-          rawText,
-          classification,
-          stats,
-        },
-        opts.storeDir,
-      );
-    }
+    const stats = buildStats(reducedChars);
+    const rawRef = await storeReducedOutputIfRequested(normalizedInput, rawText, classification, stats, opts);
 
     return {
       inlineText: inlineText.text,
@@ -504,18 +445,37 @@ export async function reduceExecutionWithRules(
     };
   }
 
+  if (classification.matchedReducer === "generic/fallback") {
+    const jsonOutput = compactWholeJsonText(rawText, maxInlineChars);
+    if (jsonOutput) {
+      const reducedChars = countTextChars(jsonOutput.text);
+      const jsonClassification = {
+        family: "structured-json",
+        confidence: 0.9,
+        matchedReducer: "generic/json",
+        ...(classification.matchedVia ? { matchedVia: classification.matchedVia } : {}),
+        ...(classification.matchedCommand ? { matchedCommand: classification.matchedCommand } : {}),
+      };
+      const stats = buildStats(reducedChars);
+      const rawRef = await storeReducedOutputIfRequested(normalizedInput, rawText, jsonClassification, stats, opts);
+
+      return {
+        inlineText: jsonOutput.text,
+        ...(jsonOutput.compaction ? { compaction: jsonOutput.compaction } : {}),
+        ...(trace ? { trace: { ...trace, matchedReducer: jsonClassification.matchedReducer, family: jsonClassification.family } } : {}),
+        ...(rawRef ? { rawRef } : {}),
+        stats,
+        classification: jsonClassification,
+      };
+    }
+  }
+
   const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText);
   const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts);
-  const maxInlineChars = opts.maxInlineChars ?? 1200;
   const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars, compaction);
   const clamp = classification.family === "help" || selectedText.text.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
-  const provisionalInlineText = clamp(selectedText.text, maxInlineChars);
-  const provisionalReducedChars = countTextChars(provisionalInlineText.text);
-  const provisionalStats = {
-    rawChars: measuredRawChars,
-    reducedChars: provisionalReducedChars,
-    ratio: measuredRawChars === 0 ? 1 : provisionalReducedChars / measuredRawChars,
-  };
+  const inlineText = clamp(selectedText.text, maxInlineChars);
+  const stats = buildStats(countTextChars(inlineText.text));
   const rawRef = opts.store
     ? await storeArtifact(
         {
@@ -523,21 +483,14 @@ export async function reduceExecutionWithRules(
           rawText,
           classification,
           stats: {
-            rawChars: provisionalStats.rawChars,
-            reducedChars: provisionalStats.reducedChars,
-            ratio: provisionalStats.ratio,
+            rawChars: stats.rawChars,
+            reducedChars: stats.reducedChars,
+            ratio: stats.ratio,
           },
         },
         opts.storeDir,
       )
     : undefined;
-  const inlineText = clamp(selectedText.text, maxInlineChars);
-  const reducedChars = countTextChars(inlineText.text);
-  const stats = {
-    rawChars: measuredRawChars,
-    reducedChars,
-    ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
-  };
 
   if (!opts.store && opts.recordStats) {
     await storeArtifactMetadata(

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -29,6 +29,27 @@ async function createTempDir(): Promise<string> {
   return dir;
 }
 
+const prettyJson = (value: unknown): string => JSON.stringify(value, null, 2);
+
+const buildJsonItemsOutput = (count: number, payloadLength: number): string =>
+  prettyJson({
+    items: Array.from({ length: count }, (_, index) => ({
+      id: `item-${index + 1}`,
+      payload: "x".repeat(payloadLength),
+    })),
+  });
+
+const reduceJsonOutput = (rawText: string, options?: Parameters<typeof reduceExecution>[1]) =>
+  reduceExecution(
+    {
+      toolName: "exec",
+      command: "custom-tool --json",
+      combinedText: rawText,
+      exitCode: 0,
+    },
+    options,
+  );
+
 describe("reduceExecution", () => {
   it("uses the git status rule when argv matches", async () => {
     const result = await reduceExecution({
@@ -285,6 +306,155 @@ describe("reduceExecution", () => {
 
     expect(result.classification.family).toBe("generic");
     expect(result.inlineText).toContain("lines omitted");
+  });
+
+  it("minifies whole JSON object output before generic fallback", async () => {
+    const rawText = prettyJson({
+      runtimeVersion: "2026.5.7",
+      heartbeat: {
+        defaultAgentId: "main",
+        agents: [
+          {
+            agentId: "main",
+            enabled: true,
+            lastActiveAgeMs: null,
+          },
+        ],
+        totalSessions: 622,
+        bootstrapPendingCount: 2,
+      },
+      secretDiagnostics: [],
+    });
+    const result = await reduceJsonOutput(rawText);
+
+    expect(result.classification.family).toBe("structured-json");
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.inlineText).toBe(JSON.stringify(JSON.parse(rawText) as unknown));
+    expect(result.inlineText).not.toContain("\n");
+    expect(result.inlineText).not.toContain("lines omitted");
+    expect(result.facts).toBeUndefined();
+    expect(result.stats.reducedChars).toBeLessThan(result.stats.rawChars);
+  });
+
+  it("minifies whole JSON array output before generic fallback", async () => {
+    const rawText = prettyJson([
+      { id: "first", warning: false },
+      { id: "second", error: null },
+    ]);
+    const result = await reduceJsonOutput(rawText);
+
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.inlineText).toBe(JSON.stringify(JSON.parse(rawText) as unknown));
+    expect(result.facts).toBeUndefined();
+  });
+
+  it("preserves duplicate keys and escaped string tokens when minifying JSON", async () => {
+    const rawText = [
+      "{",
+      "  \"a\": 1,",
+      "  \"a\": 2,",
+      "  \"escaped\": \"\\u0041\",",
+      "  \"path\": \"C:\\\\tmp\\\\file\"",
+      "}",
+    ].join("\n");
+
+    const result = await reduceJsonOutput(rawText);
+
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.inlineText).toBe("{\"a\":1,\"a\":2,\"escaped\":\"\\u0041\",\"path\":\"C:\\\\tmp\\\\file\"}");
+  });
+
+  it("clips large whole JSON output after minifying it", async () => {
+    const rawText = buildJsonItemsOutput(40, 60);
+    const result = await reduceJsonOutput(rawText, {
+      maxInlineChars: 360,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.inlineText).toContain("sha256:");
+    expect(result.stats.reducedChars).toBeLessThanOrEqual(360);
+    expect(result.stats.reducedChars).toBeLessThan(result.stats.rawChars);
+  });
+
+  it("honors small inline budgets when clipping minified JSON", async () => {
+    const rawText = buildJsonItemsOutput(20, 40);
+    const result = await reduceJsonOutput(rawText, {
+      maxInlineChars: 60,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.inlineText).toContain("sha256:");
+    expect(result.inlineText).toContain("chars omitted");
+    expect(result.stats.reducedChars).toBeLessThanOrEqual(60);
+  });
+
+  it("hard-caps tiny inline budgets when clipping minified JSON", async () => {
+    const rawText = buildJsonItemsOutput(20, 40);
+    const result = await reduceJsonOutput(rawText, {
+      maxInlineChars: 10,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/json");
+    expect(result.stats.reducedChars).toBeLessThanOrEqual(10);
+    expect(result.compaction?.kinds).toContain("hashed-middle-clip");
+    expect(result.inlineText).not.toContain("truncated");
+  });
+
+  it("stores raw JSON output with generic JSON classification when requested", async () => {
+    const storeDir = await createTempDir();
+    const rawText = prettyJson({
+      runtimeVersion: "2026.5.7",
+      heartbeat: {
+        totalSessions: 622,
+      },
+    });
+    const result = await reduceJsonOutput(rawText, {
+      store: true,
+      storeDir,
+    });
+
+    expect(result.rawRef?.id).toMatch(/^tj_/u);
+    expect(result.classification.matchedReducer).toBe("generic/json");
+
+    const artifact = await getArtifact(result.rawRef!.id, storeDir);
+    expect(artifact?.rawText).toBe(rawText);
+    expect(artifact?.metadata.classification.matchedReducer).toBe("generic/json");
+    expect(artifact?.metadata.rawChars).toBe(result.stats.rawChars);
+    expect(artifact?.metadata.reducedChars).toBe(result.stats.reducedChars);
+  });
+
+  it("records stats metadata for JSON output without storing raw output", async () => {
+    const storeDir = await createTempDir();
+    const rawText = prettyJson({
+      runtimeVersion: "2026.5.7",
+      heartbeat: {
+        totalSessions: 622,
+      },
+    });
+    await reduceJsonOutput(rawText, {
+      recordStats: true,
+      storeDir,
+    });
+
+    const metadata = await listArtifactMetadata(storeDir);
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]?.path).toBeUndefined();
+    expect(metadata[0]?.metadata.classification.matchedReducer).toBe("generic/json");
+    expect(metadata[0]?.metadata.reducedChars).toBeLessThan(metadata[0]?.metadata.rawChars ?? 0);
+  });
+
+  it("leaves malformed JSON output on the generic fallback path", async () => {
+    const result = await reduceJsonOutput(
+      [
+        "{",
+        "  \"runtimeVersion\": \"2026.5.7\",",
+        "  \"heartbeat\": {",
+        "    \"defaultAgentId\": \"main\"",
+      ].join("\n"),
+    );
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.classification.family).toBe("generic");
   });
 
   it("does not generic-compact file inspection output", async () => {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -64,19 +64,18 @@ async function captureStdio(run: () => Promise<number>): Promise<{ code: number;
   }
 }
 
-function parseCodexReplacementOutput(stdout: string): {
+const parseCodexReplacementOutput = (stdout: string): {
   hookSpecificOutput?: {
     hookEventName?: string;
     additionalContext?: string;
   };
-} {
-  return JSON.parse(stdout) as {
+} =>
+  JSON.parse(stdout) as {
     hookSpecificOutput?: {
       hookEventName?: string;
       additionalContext?: string;
     };
   };
-}
 
 describe("installCodexHook", () => {
   it("installs a single tokenjuice PostToolUse hook and preserves unrelated hooks", async () => {
@@ -580,6 +579,61 @@ describe("runCodexPostToolUseHook", () => {
     expect(debug.rewrote).toBe(false);
     expect(debug.skipped).toBe("generic-weak-compaction");
     expect(debug.matchedReducer).toBe("generic/fallback");
+  });
+
+  it("returns minified JSON feedback for whole JSON hook output", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+    const toolResponse = JSON.stringify(
+      {
+        runtimeVersion: "2026.5.7",
+        heartbeat: {
+          defaultAgentId: "main",
+          agents: Array.from({ length: 24 }, (_, index) => ({
+            agentId: index === 0 ? "main" : `worker-${index}`,
+            enabled: index % 2 === 0,
+            warnings: [],
+            errors: [],
+            lastActiveAgeMs: index === 0 ? null : index * 1000,
+          })),
+          totalSessions: 622,
+          bootstrapPendingCount: 2,
+        },
+        secretDiagnostics: [],
+      },
+      null,
+      2,
+    );
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "custom-tool --json",
+      },
+      tool_response: toolResponse,
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+      matchedReducer?: string;
+    };
+    const response = parseCodexReplacementOutput(stdout);
+    const additionalContext = response.hookSpecificOutput?.additionalContext ?? "";
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(response.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
+    expect(additionalContext).toContain("\"runtimeVersion\":\"2026.5.7\"");
+    expect(additionalContext).toContain("\"totalSessions\":622");
+    expect(additionalContext).not.toMatch(/^\d+ errors?, \d+ warnings?/u);
+    expect(additionalContext).not.toContain("lines omitted");
+    expect(additionalContext).toContain("tokenjuice wrap --raw -- <command>");
+    expect(debug.rewrote).toBe(true);
+    expect(debug.skipped).toBeUndefined();
+    expect(debug.matchedReducer).toBe("generic/json");
   });
 
   it("skips rewriting low-savings compaction even for non-generic reducers", async () => {


### PR DESCRIPTION
## Summary
- add a structured generic JSON fallback that lexically minifies whole JSON output after higher-signal reducers run
- preserve duplicate keys and escaped string tokens while avoiding generic error/warning counters from JSON keys
- cap large JSON hook context with hashed middle clipping while keeping raw-output recovery available
- cover JSON reducer storage and metadata-only stats paths, plus Codex PostToolUse hook output

## Why
Codex PostToolUse hook context could show pretty-printed JSON through the generic fallback, producing noisy multi-line output and misleading error/warning counters from JSON keys. This keeps JSON output compact without changing command semantics or losing raw recovery.

## Validation
- pnpm exec vitest run test/core/reduce.test.ts test/hosts/codex.test.ts
- pnpm typecheck
- pnpm verify