### PR TITLE
fix(hooks): add timeout safety cap to post-tool hooks

### DIFF
--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -57,6 +57,7 @@ export type ClaudeCodeHookCommandOptions = {
 
 const TOKENJUICE_CLAUDE_CODE_STATUS = "compacting bash output with tokenjuice";
 const TOKENJUICE_CLAUDE_CODE_FIX_COMMAND = "tokenjuice install claude-code";
+const TOKENJUICE_CLAUDE_CODE_HOOK_TIMEOUT_SECONDS = 10;
 
 function getClaudeCodeHome(): string {
   // Claude Code resolves its config directory from CLAUDE_CONFIG_DIR, so honor
@@ -167,40 +168,57 @@ function createTokenjuiceClaudeCodeHook(command: string): ClaudeCodeHookMatcherG
         type: "command",
         command,
         statusMessage: TOKENJUICE_CLAUDE_CODE_STATUS,
+        timeout: TOKENJUICE_CLAUDE_CODE_HOOK_TIMEOUT_SECONDS,
       },
     ],
   };
 }
 
-function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
-  return group.hooks.some((hook) =>
-    isRecord(hook) && (
-      hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
-      || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
-    ),
+function isTokenjuiceClaudeCodeHookEntry(hook: unknown): hook is ClaudeCodeHook {
+  return isRecord(hook) && (
+    hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
+    || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
   );
 }
 
+function isTokenjuiceClaudeCodeHook(group: ClaudeCodeHookMatcherGroup): boolean {
+  return group.hooks.some((hook) => isTokenjuiceClaudeCodeHookEntry(hook));
+}
+
 function findTokenjuiceClaudeCodeHookCommand(config: ClaudeCodeSettings): string | undefined {
+  const hook = findTokenjuiceClaudeCodeHook(config);
+  return typeof hook?.command === "string" && hook.command ? hook.command : undefined;
+}
+
+function findTokenjuiceClaudeCodeHook(config: ClaudeCodeSettings): ClaudeCodeHook | undefined {
   const postToolUse = Array.isArray(config.hooks.PostToolUse) ? config.hooks.PostToolUse : [];
   for (const group of postToolUse) {
     if (!(isRecord(group) && Array.isArray(group.hooks) && isTokenjuiceClaudeCodeHook(group as ClaudeCodeHookMatcherGroup))) {
       continue;
     }
 
-    const command = group.hooks.find((hook) =>
-      isRecord(hook)
-      && (
-        hook.statusMessage === TOKENJUICE_CLAUDE_CODE_STATUS
-        || (typeof hook.command === "string" && hook.command.includes("claude-code-post-tool-use"))
-      ),
-    )?.command;
-    if (typeof command === "string" && command) {
-      return command;
+    const hook = group.hooks.find((candidate) => isTokenjuiceClaudeCodeHookEntry(candidate));
+    if (hook) {
+      return hook;
     }
   }
 
   return undefined;
+}
+
+function collectTokenjuiceHookTimeoutWarnings(config: ClaudeCodeSettings, fixCommand: string): string[] {
+  const hook = findTokenjuiceClaudeCodeHook(config);
+  if (!hook) {
+    return [];
+  }
+
+  if (hook.timeout !== TOKENJUICE_CLAUDE_CODE_HOOK_TIMEOUT_SECONDS) {
+    return [
+      `configured Claude Code tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_CLAUDE_CODE_HOOK_TIMEOUT_SECONDS}s safety cap`,
+    ];
+  }
+
+  return [];
 }
 
 function sanitizeHooksSubtree(raw: unknown): Record<string, unknown> {
@@ -329,6 +347,7 @@ export async function doctorClaudeCodeHook(
   }
 
   const issues: string[] = [];
+  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, fixCommand));
   if (detectedCommand !== expectedCommand) {
     if (detectedCommand.includes("/Cellar/")) {
       issues.push("configured Claude Code hook is pinned to a versioned Homebrew Cellar path");

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -51,6 +51,7 @@ const CODEX_HOOK_HISTORY_LIMIT = 200;
 const CODEX_HOOK_HISTORY_LOCK_STALE_MS = 30_000;
 const CODEX_HOOK_HISTORY_LOCK_RETRY_MS = 25;
 const CODEX_HOOK_HISTORY_LOCK_RETRIES = 8;
+const TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS = 10;
 const LOW_NON_TOKENJUICE_TIMEOUT_SECONDS = 2;
 const RECOMMENDED_NON_TOKENJUICE_TIMEOUT_SECONDS = 6;
 
@@ -373,6 +374,7 @@ function createTokenjuiceCodexHook(command: string): CodexHookMatcherGroup {
         type: "command",
         command,
         statusMessage: TOKENJUICE_CODEX_STATUS,
+        timeout: TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS,
       },
     ],
   };
@@ -387,18 +389,22 @@ function isTokenjuiceCodexHook(group: CodexHookMatcherGroup): boolean {
 }
 
 function findTokenjuiceCodexHookCommand(config: CodexHooksConfig): string | undefined {
+  return findTokenjuiceCodexHook(config)?.command;
+}
+
+function findTokenjuiceCodexHook(config: CodexHooksConfig): CodexHookCommand | undefined {
   for (const group of config.hooks.PostToolUse ?? []) {
     if (!isTokenjuiceCodexHook(group)) {
       continue;
     }
 
-    const command = group.hooks.find((hook) =>
-      hook.statusMessage === TOKENJUICE_CODEX_STATUS
-      || hook.command.includes("codex-post-tool-use")
-      || hook.command.includes("post_tool_use_tokenjuice.py"),
-    )?.command;
-    if (command) {
-      return command;
+    const hook = group.hooks.find((candidate) =>
+      candidate.statusMessage === TOKENJUICE_CODEX_STATUS
+      || candidate.command.includes("codex-post-tool-use")
+      || candidate.command.includes("post_tool_use_tokenjuice.py"),
+    );
+    if (hook) {
+      return hook;
     }
   }
 
@@ -478,6 +484,21 @@ function collectLowTimeoutWarnings(config: CodexHooksConfig): string[] {
   }
 
   return issues;
+}
+
+function collectTokenjuiceHookTimeoutWarnings(config: CodexHooksConfig, fixCommand: string): string[] {
+  const hook = findTokenjuiceCodexHook(config);
+  if (!hook) {
+    return [];
+  }
+
+  if (hook.timeout !== TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS) {
+    return [
+      `configured Codex tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS}s safety cap`,
+    ];
+  }
+
+  return [];
 }
 
 function sanitizeHooksConfig(raw: unknown): CodexHooksConfig {
@@ -780,6 +801,7 @@ export async function doctorCodexHook(
       "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
     );
   }
+  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, fixCommand));
   issues.push(...collectLowTimeoutWarnings(config));
 
   return {

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -735,7 +735,8 @@ export async function doctorCodexHook(
   options: CodexHookCommandOptions = {},
 ): Promise<CodexDoctorReport> {
   const expectedCommand = await buildCodexHookCommand(options);
-  let fixCommand = getCodexFixCommand(options.local);
+  const installFixCommand = getCodexFixCommand(options.local);
+  let fixCommand = installFixCommand;
   const { config, exists } = await readHooksConfig(hooksPath);
   const detectedCommand = findTokenjuiceCodexHookCommand(config);
   const featureFlag = await inspectCodexHooksFeatureFlag(options.featureFlagConfigPath);
@@ -801,7 +802,7 @@ export async function doctorCodexHook(
       "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
     );
   }
-  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, fixCommand));
+  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, installFixCommand));
   issues.push(...collectLowTimeoutWarnings(config));
 
   return {

--- a/src/hosts/copilot-cli/index.ts
+++ b/src/hosts/copilot-cli/index.ts
@@ -69,6 +69,7 @@ const TOKENJUICE_COPILOT_CLI_FIX_COMMAND = "tokenjuice install copilot-cli";
 const TOKENJUICE_COPILOT_CLI_FILENAME = "tokenjuice-cli.json";
 const TOKENJUICE_COPILOT_CLI_MATCHER = "shell";
 const TOKENJUICE_COPILOT_CLI_SUBCOMMAND = "copilot-cli-post-tool-use";
+const TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS = 10;
 const TOKENJUICE_COPILOT_CLI_INSTRUCTIONS_ADVISORY =
   "paste the snippet from `tokenjuice doctor copilot-cli --print-instructions` into `.github/copilot-instructions.md` or `AGENTS.md` so the agent respects compacted output and knows when to prefix a command with `tokenjuice wrap --raw --`.";
 
@@ -200,22 +201,43 @@ function createTokenjuiceCopilotCliHook(command: string): Record<string, unknown
     type: "command",
     matcher: TOKENJUICE_COPILOT_CLI_MATCHER,
     command,
+    timeout: TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS,
   };
 }
 
 function findTokenjuiceCopilotCliHookCommand(config: CopilotCliHooksConfig): string | undefined {
+  const hook = findTokenjuiceCopilotCliHook(config);
+  return typeof hook?.command === "string" && hook.command ? hook.command : undefined;
+}
+
+function findTokenjuiceCopilotCliHook(config: CopilotCliHooksConfig): Record<string, unknown> | undefined {
   const postToolUse = config.hooks.postToolUse;
   if (!Array.isArray(postToolUse)) {
     return undefined;
   }
 
   for (const hook of postToolUse) {
-    if (isTokenjuiceCopilotCliHook(hook) && isRecord(hook) && typeof hook.command === "string") {
-      return hook.command;
+    if (isTokenjuiceCopilotCliHook(hook) && isRecord(hook)) {
+      return hook;
     }
   }
 
   return undefined;
+}
+
+function collectTokenjuiceHookTimeoutWarnings(config: CopilotCliHooksConfig, fixCommand: string): string[] {
+  const hook = findTokenjuiceCopilotCliHook(config);
+  if (!hook) {
+    return [];
+  }
+
+  if (hook.timeout !== TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS) {
+    return [
+      `configured copilot-cli tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS}s safety cap`,
+    ];
+  }
+
+  return [];
 }
 
 export async function installCopilotCliHook(
@@ -352,6 +374,7 @@ export async function doctorCopilotCliHook(
   }
 
   const issues: string[] = [];
+  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, fixCommand));
   if (detectedCommand !== expectedCommand) {
     if (detectedCommand.includes("/Cellar/")) {
       issues.push("configured copilot-cli hook is pinned to a versioned Homebrew Cellar path");

--- a/src/hosts/copilot-cli/index.ts
+++ b/src/hosts/copilot-cli/index.ts
@@ -201,7 +201,7 @@ function createTokenjuiceCopilotCliHook(command: string): Record<string, unknown
     type: "command",
     matcher: TOKENJUICE_COPILOT_CLI_MATCHER,
     command,
-    timeout: TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS,
+    timeoutSec: TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS,
   };
 }
 
@@ -231,7 +231,7 @@ function collectTokenjuiceHookTimeoutWarnings(config: CopilotCliHooksConfig, fix
     return [];
   }
 
-  if (hook.timeout !== TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS) {
+  if (hook.timeoutSec !== TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS) {
     return [
       `configured copilot-cli tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_COPILOT_CLI_HOOK_TIMEOUT_SECONDS}s safety cap`,
     ];

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -65,7 +65,7 @@ describe("installClaudeCodeHook", () => {
 
     const result = await installClaudeCodeHook(settingsPath);
     const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
-      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string; timeout?: number }> }>>;
     };
 
     expect(result.settingsPath).toBe(settingsPath);
@@ -74,6 +74,7 @@ describe("installClaudeCodeHook", () => {
     expect(parsed.hooks.PostToolUse[0]?.matcher).toBe("Bash");
     expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
     expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.statusMessage).toBe("compacting bash output with tokenjuice");
+    expect(parsed.hooks.PostToolUse[0]?.hooks[0]?.timeout).toBe(10);
   });
 
   it("preserves unrelated top-level settings keys across install", async () => {
@@ -300,7 +301,7 @@ describe("installClaudeCodeHook", () => {
     await installClaudeCodeHook(settingsPath);
 
     const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
-      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string; timeout?: number }> }>>;
     };
 
     const tokenjuiceHooks = parsed.hooks.PostToolUse.filter((group) =>
@@ -310,6 +311,7 @@ describe("installClaudeCodeHook", () => {
     expect(parsed.hooks.PostToolUse).toHaveLength(2);
     expect(tokenjuiceHooks).toHaveLength(1);
     expect(tokenjuiceHooks[0]?.hooks[0]?.command).toContain("claude-code-post-tool-use");
+    expect(tokenjuiceHooks[0]?.hooks[0]?.timeout).toBe(10);
   });
 
   it("preserves other PostToolUse matchers", async () => {
@@ -427,6 +429,42 @@ describe("doctorClaudeCodeHook", () => {
     expect(report.issues).toContain("configured Claude Code hook is pinned to a versioned Homebrew Cellar path");
     expect(report.missingPaths).toContain("/opt/homebrew/Cellar/tokenjuice/0.2.0/libexec/dist/cli/main.js");
     expect(report.fixCommand).toBe("tokenjuice install claude-code");
+  });
+
+  it("warns when the tokenjuice Claude Code hook is missing the timeout safety cap", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, "settings.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(
+      settingsPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{
+                type: "command",
+                command: `${launcherPath} claude-code-post-tool-use`,
+                statusMessage: "compacting bash output with tokenjuice",
+              }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorClaudeCodeHook(settingsPath);
+
+    expect(report.status).toBe("warn");
+    expect(report.issues).toContain(
+      "configured Claude Code tokenjuice hook timeout is missing or stale; run tokenjuice install claude-code to add the 10s safety cap",
+    );
   });
 });
 

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -359,6 +359,52 @@ describe("doctorCodexHook", () => {
     );
   });
 
+  it("uses the install fix command for the timeout warning when Homebrew also needs an upgrade", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "opt", "homebrew", "bin");
+    const cellarBinDir = join(home, "opt", "homebrew", "Cellar", "tokenjuice", "0.0.1", "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const resolvedLauncherPath = join(cellarBinDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(cellarBinDir, { recursive: true });
+    await writeFile(resolvedLauncherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(resolvedLauncherPath, launcherPath);
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [{
+                type: "command",
+                command: `${launcherPath} codex-post-tool-use`,
+                statusMessage: "compacting bash output with tokenjuice",
+              }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.fixCommand).toBe("brew upgrade tokenjuice");
+    expect(report.issues).toContain(
+      `configured Codex hook launcher resolves to Homebrew tokenjuice 0.0.1, but this tokenjuice is ${PACKAGE_VERSION}`,
+    );
+    expect(report.issues).toContain(
+      "configured Codex tokenjuice hook timeout is missing or stale; run tokenjuice install codex to add the 10s safety cap",
+    );
+  });
+
   it("proves a hanging Codex hook needs a configured timeout to terminate", async () => {
     const withoutTimeout = await runCommandWithOptionalTimeout(HANGING_HOOK_COMMAND);
     const withTimeout = await runCommandWithOptionalTimeout(HANGING_HOOK_COMMAND, 0.05);

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -11,6 +12,7 @@ const tempDirs: string[] = [];
 const PACKAGE_VERSION = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).version as string;
 const originalHome = process.env.HOME;
 const originalPath = process.env.PATH;
+const HANGING_HOOK_COMMAND = `${process.execPath} -e "setInterval(() => {}, 1000)"`;
 
 afterEach(async () => {
   delete process.env.CODEX_HOME;
@@ -78,6 +80,37 @@ function parseCodexReplacementOutput(stdout: string): {
   };
 }
 
+function runCommandWithOptionalTimeout(command: string, timeoutSeconds?: number): Promise<"completed" | "still-running" | "timed-out"> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: "ignore",
+    });
+    let settled = false;
+
+    const settle = (result: "completed" | "still-running" | "timed-out"): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (!child.killed) {
+        child.kill("SIGTERM");
+      }
+      resolvePromise(result);
+    };
+
+    child.once("error", reject);
+    child.once("exit", () => settle("completed"));
+
+    if (typeof timeoutSeconds === "number") {
+      setTimeout(() => settle("timed-out"), timeoutSeconds * 1000);
+      return;
+    }
+
+    setTimeout(() => settle("still-running"), 200);
+  });
+}
+
 describe("installCodexHook", () => {
   it("installs a single tokenjuice PostToolUse hook and preserves unrelated hooks", async () => {
     const home = await createTempDir();
@@ -109,7 +142,7 @@ describe("installCodexHook", () => {
 
     const result = await installCodexHook(hooksPath);
     const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
-      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> }>>;
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; statusMessage?: string; timeout?: number }> }>>;
     };
 
     expect(result.hooksPath).toBe(hooksPath);
@@ -120,6 +153,7 @@ describe("installCodexHook", () => {
     expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("^Bash$");
     expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("codex-post-tool-use");
     expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.statusMessage).toBe("compacting bash output with tokenjuice");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.timeout).toBe(10);
   });
 
   it("prefers a stable tokenjuice launcher from PATH when installing the hook", async () => {
@@ -285,6 +319,52 @@ describe("doctorCodexHook", () => {
     expect(report.issues).toContain(
       "Codex feature flag `codex_hooks` is not enabled — the configured hook will not fire",
     );
+  });
+
+  it("warns when the tokenjuice Codex hook is missing the timeout safety cap", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [{
+                type: "command",
+                command: `${launcherPath} codex-post-tool-use`,
+                statusMessage: "compacting bash output with tokenjuice",
+              }],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.issues).toContain(
+      "configured Codex tokenjuice hook timeout is missing or stale; run tokenjuice install codex to add the 10s safety cap",
+    );
+  });
+
+  it("proves a hanging Codex hook needs a configured timeout to terminate", async () => {
+    const withoutTimeout = await runCommandWithOptionalTimeout(HANGING_HOOK_COMMAND);
+    const withTimeout = await runCommandWithOptionalTimeout(HANGING_HOOK_COMMAND, 0.05);
+
+    expect(withoutTimeout).toBe("still-running");
+    expect(withTimeout).toBe("timed-out");
   });
 
   it("reports disabled when the tokenjuice Codex hook is not installed", async () => {

--- a/test/hosts/copilot-cli.test.ts
+++ b/test/hosts/copilot-cli.test.ts
@@ -82,7 +82,7 @@ describe("installCopilotCliHook", () => {
     const result = await installCopilotCliHook(hooksPath);
     const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
       version?: number;
-      hooks: { postToolUse: Array<{ command: string; matcher?: string; type?: string; timeout?: number }> };
+      hooks: { postToolUse: Array<{ command: string; matcher?: string; type?: string; timeoutSec?: number }> };
     };
 
     expect(result.hooksPath).toBe(hooksPath);
@@ -91,7 +91,7 @@ describe("installCopilotCliHook", () => {
     expect(parsed.hooks.postToolUse[0]?.matcher).toBe("shell");
     expect(parsed.hooks.postToolUse[0]?.type).toBe("command");
     expect(parsed.hooks.postToolUse[0]?.command).toContain("copilot-cli-post-tool-use");
-    expect(parsed.hooks.postToolUse[0]?.timeout).toBe(10);
+    expect(parsed.hooks.postToolUse[0]?.timeoutSec).toBe(10);
   });
 
   it("resolves the install directory from COPILOT_HOME when set", async () => {
@@ -411,6 +411,40 @@ describe("doctorCopilotCliHook", () => {
     expect(report.issues).toContain(
       "configured copilot-cli tokenjuice hook timeout is missing or stale; run tokenjuice install copilot-cli to add the 10s safety cap",
     );
+  });
+
+  it("accepts the documented timeoutSec safety cap for Copilot CLI hooks", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, ".copilot", "hooks", "tokenjuice-cli.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await mkdir(join(home, ".copilot", "hooks"), { recursive: true });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            {
+              type: "command",
+              matcher: "shell",
+              command: `${launcherPath} copilot-cli-post-tool-use`,
+              timeoutSec: 10,
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCopilotCliHook(hooksPath);
+
+    expect(report.status).toBe("ok");
+    expect(report.issues).toEqual([]);
   });
 
   it("reports disabled when disableAllHooks is true", async () => {

--- a/test/hosts/copilot-cli.test.ts
+++ b/test/hosts/copilot-cli.test.ts
@@ -82,7 +82,7 @@ describe("installCopilotCliHook", () => {
     const result = await installCopilotCliHook(hooksPath);
     const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
       version?: number;
-      hooks: { postToolUse: Array<{ command: string; matcher?: string; type?: string }> };
+      hooks: { postToolUse: Array<{ command: string; matcher?: string; type?: string; timeout?: number }> };
     };
 
     expect(result.hooksPath).toBe(hooksPath);
@@ -91,6 +91,7 @@ describe("installCopilotCliHook", () => {
     expect(parsed.hooks.postToolUse[0]?.matcher).toBe("shell");
     expect(parsed.hooks.postToolUse[0]?.type).toBe("command");
     expect(parsed.hooks.postToolUse[0]?.command).toContain("copilot-cli-post-tool-use");
+    expect(parsed.hooks.postToolUse[0]?.timeout).toBe(10);
   });
 
   it("resolves the install directory from COPILOT_HOME when set", async () => {
@@ -375,6 +376,41 @@ describe("doctorCopilotCliHook", () => {
 
     expect(report.status).toBe("broken");
     expect(report.missingPaths.length).toBeGreaterThan(0);
+  });
+
+  it("warns when the tokenjuice Copilot CLI hook is missing the timeout safety cap", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, ".copilot", "hooks", "tokenjuice-cli.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await mkdir(join(home, ".copilot", "hooks"), { recursive: true });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            {
+              type: "command",
+              matcher: "shell",
+              command: `${launcherPath} copilot-cli-post-tool-use`,
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCopilotCliHook(hooksPath);
+
+    expect(report.status).toBe("warn");
+    expect(report.issues).toContain(
+      "configured copilot-cli tokenjuice hook timeout is missing or stale; run tokenjuice install copilot-cli to add the 10s safety cap",
+    );
   });
 
   it("reports disabled when disableAllHooks is true", async () => {


### PR DESCRIPTION
## Summary

- Problem: Codex/Claude Code tokenjuice PostToolUse hooks could hang if the hook process never exits.
- Why it matters: A stuck post-tool hook can block the CLI after tool execution.
- What changed: Codex, Claude Code, and Copilot CLI tokenjuice hooks now install with `timeout: 10`; doctor warns on old no-timeout configs.
- What did NOT change: Hook compaction behavior, command parsing, and unrelated host integrations.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations
- [x] CLI / DX

## User-visible / Behavior Changes

Fresh installs for Codex, Claude Code, and Copilot CLI now include a 10s hook timeout. Existing installs missing the timeout are reported by doctor with a repair command.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No

Risk + mitigation: command-backed hooks now have a bounded runtime, reducing hang impact without changing what command is executed.

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js v24.14.0
- Integrations: Codex CLI 0.130.0, Claude Code 2.1.143, GitHub Copilot CLI 1.0.48

### Steps

1. Confirm old Codex/Claude Code tokenjuice hook configs had no timeout.
2. Simulate a hook command that never exits.
3. Install Codex, Claude Code, and Copilot CLI hooks into temp homes.
4. Remove timeout fields and re-run doctor checks.

### Expected

Hooks are bounded by a timeout, and stale configs are detected.

### Actual

Fresh installs emit `timeout: 10`; stale no-timeout configs report `health: warn`.

## Evidence

- [x] Failing behavior proof: hanging hook stays running without timeout and terminates with timeout.
- [x] Passing after: temp-home installs for all three hosts emit `timeout: 10`.
- [x] Doctor proof: removing timeout from each config returns `health: warn`.

## Human Verification

- Verified scenarios:
  - `pnpm exec vitest run test/hosts/codex.test.ts test/hosts/claude-code.test.ts test/hosts/copilot-cli.test.ts`
  - `pnpm verify`
  - `pnpm build`
  - temp-home CLI install/doctor simulation for Codex, Claude Code, and Copilot CLI
- Edge cases checked:
  - old no-timeout tokenjuice hook configs
  - local-mode repair commands
  - Copilot CLI hook timeout format
- What I did not verify:
  - Live config mutation; tests used temp homes only.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes, generated hook config now includes `timeout: 10`
- Migration needed? No; run `tokenjuice install <host>` to refresh old configs.

## Failure Recovery

- Disable/revert by removing the generated tokenjuice hook or rerunning the previous release installer.
- Files/config to restore:
  - `~/.codex/hooks.json`
  - `~/.claude/settings.json`
  - `~/.copilot/hooks/tokenjuice-cli.json`
- Known bad symptoms reviewers should watch for:
  - host rejects `timeout` field
  - doctor incorrectly warns on fresh installs

## Risks and Mitigations

- Risk: Hook timeout field format differs by host.
  - Mitigation: Codex/Claude Code use the same hook shape; local Copilot CLI package confirms `timeout` is accepted as an alias for `timeoutSec`.