### PR TITLE
fix(core): skip terminal setup preludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Route `node scripts/run-vitest.mjs` output through the Vitest reducer so Rolldown plugin-timing warnings do not drown out passing test summaries.
 - Add `--help`/`-h` output to the Codex log analysis script.
+- Match the real command after harmless terminal setup preludes such as `tt title` or `tmux select-pane -T`.
 - Route Claude Code through a `PreToolUse` Bash wrapper so Tokenjuice compacts the actual command result without appending duplicate `PostToolUse` context or bypassing Claude Code approvals.
 - Preserve CodeBuddy's native Bash approval flow when wrapping `PreToolUse` commands, and cover Claude Code plus CodeBuddy pre-tool rewrites in local host e2e.
 - Keep Tokenjuice's Codex hook compatible with current Codex hook and approval surfaces, including `hooks`, `PermissionRequest`, Windows commands, async hooks, and approval/sandbox doctor reporting.

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -59,6 +59,15 @@ function getJsonRule(rule: RuleLike): JsonRule {
   return "rule" in rule ? rule.rule : rule;
 }
 
+function usesCommandTextMatcher(ruleLike: RuleLike): boolean {
+  const rule = getJsonRule(ruleLike);
+  return Boolean(rule.match.commandIncludes || rule.match.commandIncludesAny);
+}
+
+function isBuiltinRule(ruleLike: RuleLike): boolean {
+  return "source" in ruleLike && ruleLike.source === "builtin";
+}
+
 function getCandidatePriority(candidate: CommandMatchCandidate): number {
   switch (candidate.source) {
     case "effective":
@@ -150,6 +159,7 @@ export function findBestRuleMatch<T extends RuleLike>(
   rules: T[],
 ): RuleMatchSelection<T> | undefined {
   const candidates = deriveCommandMatchCandidates(input);
+  const highestCandidatePriority = Math.max(...candidates.map(getCandidatePriority));
   const specificMatches: Array<RuleMatchSelection<T>> = [];
   let fallbackSelection: RuleMatchSelection<T> | undefined;
 
@@ -163,6 +173,10 @@ export function findBestRuleMatch<T extends RuleLike>(
 
       if (getJsonRule(rule).id === "generic/fallback") {
         fallbackSelection ??= { rule, candidate };
+        continue;
+      }
+
+      if (isBuiltinRule(rule) && usesCommandTextMatcher(rule) && getCandidatePriority(candidate) < highestCandidatePriority) {
         continue;
       }
 

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -19,6 +19,70 @@ const SHELL_COMMAND_LAUNCHERS = new Set(["bash", "sh", "zsh", "fish"]);
 const ENV_FLAGS_WITH_VALUES = new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]);
 const ENV_FLAGS = new Set(["-i", "--ignore-environment", "-0", "--null", "--debug"]);
 
+function splitTopLevelOrChain(command: string): string[] {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const segments: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index]!;
+
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      current += char;
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      current += char;
+      quote = char;
+      continue;
+    }
+
+    if (char === "|" && trimmed[index + 1] === "|") {
+      const segment = current.trim();
+      if (segment) {
+        segments.push(segment);
+      }
+      current = "";
+      index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote || escaping) {
+    return [trimmed];
+  }
+
+  const segment = current.trim();
+  if (segment) {
+    segments.push(segment);
+  }
+  return segments;
+}
+
 function getArgv0Name(argv: string[]): string | null {
   const first = argv[0];
   if (!first) {
@@ -204,7 +268,7 @@ export function stripLeadingEnvAssignments(argv: string[]): string[] {
   return argv.slice(index);
 }
 
-export function isSetupWrapperSegment(argv: string[]): boolean {
+function isSimpleSetupWrapperSegment(argv: string[]): boolean {
   if (argv.length === 0) {
     return true;
   }
@@ -227,13 +291,48 @@ export function isSetupWrapperSegment(argv: string[]): boolean {
   return SETUP_WRAPPER_COMMANDS.has(argv0);
 }
 
+export function isSetupWrapperSegment(argv: string[], command?: string): boolean {
+  const orSegments = command ? splitTopLevelOrChain(command) : [];
+  if (orSegments.length > 1) {
+    return orSegments.every((segment) => isSimpleSetupWrapperSegment(tokenizeCommand(segment)));
+  }
+
+  return isSimpleSetupWrapperSegment(argv);
+}
+
+function isSetupWrapperCommand(command: string): boolean {
+  const segments = splitTopLevelCommandChain(command);
+  return segments.length > 0
+    && segments.every((segment) => isSetupWrapperSegment(tokenizeCommand(segment), segment));
+}
+
+function stripLeadingSetupIfBlock(command: string): string | null {
+  const match = /^if\s+(.+?);\s*then\s+(.+?)(?:;\s*else\s+(.+?))?;\s*fi\s*(?:;|&&|\n)\s*(.+)$/su.exec(command.trim());
+  if (!match) {
+    return null;
+  }
+
+  const [, condition, thenCommand, elseCommand, tail] = match;
+  if (!condition || !thenCommand || !tail) {
+    return null;
+  }
+  if (!isSetupWrapperCommand(condition) || !isSetupWrapperCommand(thenCommand)) {
+    return null;
+  }
+  if (elseCommand && !isSetupWrapperCommand(elseCommand)) {
+    return null;
+  }
+
+  return tail.trim() || null;
+}
+
 export function buildEffectiveCandidate(
   argv: string[],
   transformed: boolean,
   command?: string,
 ): CommandMatchCandidate | null {
   const strippedArgv = stripLeadingEnvAssignments(argv);
-  if (strippedArgv.length === 0 || isSetupWrapperSegment(strippedArgv)) {
+  if (strippedArgv.length === 0 || isSetupWrapperSegment(strippedArgv, command)) {
     return null;
   }
 
@@ -258,6 +357,11 @@ export function resolveEffectiveCommand(input: Pick<ToolExecutionInput, "argv" |
 
   if (!command) {
     return buildEffectiveCandidate(argv, false);
+  }
+
+  const setupIfTail = stripLeadingSetupIfBlock(command);
+  if (setupIfTail) {
+    return resolveEffectiveCommand({ command: setupIfTail }) ?? buildEffectiveCandidate(tokenizeCommand(setupIfTail), true, setupIfTail);
   }
 
   const segments = splitTopLevelCommandChain(command);

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -307,7 +307,7 @@ function isSetupWrapperCommand(command: string): boolean {
 }
 
 function stripLeadingSetupIfBlock(command: string): string | null {
-  const match = /^if\s+(.+?);\s*then\s+(.+?)(?:;\s*else\s+(.+?))?;\s*fi\s*(?:;|&&|\n)\s*(.+)$/su.exec(command.trim());
+  const match = /^if\s+([\s\S]+?)(?:;|\n)\s*then\s+([\s\S]+?)(?:(?:;|\n)\s*else\s+([\s\S]+?))?(?:;|\n)\s*fi\s*(?:;|&&|\n)\s*(.+)$/u.exec(command.trim());
   if (!match) {
     return null;
   }
@@ -324,6 +324,32 @@ function stripLeadingSetupIfBlock(command: string): string | null {
   }
 
   return tail.trim() || null;
+}
+
+function stripLeadingSetupSegment(command: string): string | null {
+  const trimmed = command.trim();
+  const segments = splitTopLevelCommandChain(trimmed);
+  const first = segments[0]?.trim();
+  if (!first || segments.length < 2 || !isSetupWrapperSegment(tokenizeCommand(first), first)) {
+    return null;
+  }
+  if (!trimmed.startsWith(first)) {
+    return null;
+  }
+
+  let index = first.length;
+  while (/\s/u.test(trimmed[index] ?? "")) {
+    index += 1;
+  }
+  if (trimmed[index] === "&" && trimmed[index + 1] === "&") {
+    index += 2;
+  } else if (trimmed[index] === ";" || trimmed[index] === "\n") {
+    index += 1;
+  } else {
+    return null;
+  }
+
+  return trimmed.slice(index).trim() || null;
 }
 
 export function buildEffectiveCandidate(
@@ -359,12 +385,21 @@ export function resolveEffectiveCommand(input: Pick<ToolExecutionInput, "argv" |
     return buildEffectiveCandidate(argv, false);
   }
 
-  const setupIfTail = stripLeadingSetupIfBlock(command);
-  if (setupIfTail) {
-    return resolveEffectiveCommand({ command: setupIfTail }) ?? buildEffectiveCandidate(tokenizeCommand(setupIfTail), true, setupIfTail);
+  let effectiveCommand = command;
+  for (let iteration = 0; iteration < 16; iteration += 1) {
+    const setupIfTail = stripLeadingSetupIfBlock(effectiveCommand);
+    const setupSegmentTail = setupIfTail ?? stripLeadingSetupSegment(effectiveCommand);
+    if (!setupSegmentTail) {
+      break;
+    }
+    effectiveCommand = setupSegmentTail;
+  }
+  if (effectiveCommand !== command) {
+    return resolveEffectiveCommand({ command: effectiveCommand })
+      ?? buildEffectiveCandidate(tokenizeCommand(effectiveCommand), true, effectiveCommand);
   }
 
-  const segments = splitTopLevelCommandChain(command);
+  const segments = splitTopLevelCommandChain(effectiveCommand);
   const transformedByChain = segments.length > 1;
 
   for (const segment of segments) {

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -83,6 +83,59 @@ function splitTopLevelOrChain(command: string): string[] {
   return segments;
 }
 
+function isFullyParenthesized(command: string): boolean {
+  if (!command.startsWith("(") || !command.endsWith(")")) {
+    return false;
+  }
+
+  let quote: "'" | "\"" | null = null;
+  let escaping = false;
+  let depth = 0;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+
+    if (escaping) {
+      escaping = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0 && index < command.length - 1) {
+        return false;
+      }
+    }
+  }
+
+  return depth === 0 && !quote && !escaping;
+}
+
+function stripSetupShellDecorators(command: string): string {
+  let trimmed = command.trim();
+  while (isFullyParenthesized(trimmed)) {
+    trimmed = trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
 function getArgv0Name(argv: string[]): string | null {
   const first = argv[0];
   if (!first) {
@@ -278,7 +331,7 @@ function isSimpleSetupWrapperSegment(argv: string[]): boolean {
     return true;
   }
 
-  if (argv0 === "command" && (argv[1] === "-v" || argv[1] === "-V")) {
+  if (isQuietCommandProbe(argv)) {
     return true;
   }
   if (argv0 === "tt" && (argv[1] === "title" || argv[1] === "sync")) {
@@ -291,19 +344,70 @@ function isSimpleSetupWrapperSegment(argv: string[]): boolean {
   return SETUP_WRAPPER_COMMANDS.has(argv0);
 }
 
+function isQuietCommandProbe(argv: string[]): boolean {
+  const argv0 = getArgv0Name(argv);
+  return argv0 === "command"
+    && (argv[1] === "-v" || argv[1] === "-V")
+    && argv.slice(2).some(redirectsStdout);
+}
+
+function redirectsStdout(arg: string): boolean {
+  return arg === ">"
+    || arg === ">>"
+    || arg === "1>"
+    || arg === "1>>"
+    || arg === "&>"
+    || arg === "&>>"
+    || /^(?:>|>>|1>|1>>|&>|&>>)\S/u.test(arg);
+}
+
+function isFailFastSetupGuard(argv: string[]): boolean {
+  const argv0 = getArgv0Name(argv);
+  return argv0 === "exit" || argv0 === "return";
+}
+
 export function isSetupWrapperSegment(argv: string[], command?: string): boolean {
-  const orSegments = command ? splitTopLevelOrChain(command) : [];
+  const normalizedCommand = command ? stripSetupShellDecorators(command) : "";
+  const orSegments = normalizedCommand ? splitTopLevelOrChain(normalizedCommand) : [];
   if (orSegments.length > 1) {
-    return orSegments.every((segment) => isSimpleSetupWrapperSegment(tokenizeCommand(segment)));
+    return orSegments.every((segment) => {
+      const segmentArgv = tokenizeCommand(stripSetupShellDecorators(segment));
+      return isSimpleSetupWrapperSegment(segmentArgv) || isFailFastSetupGuard(segmentArgv);
+    });
   }
 
-  return isSimpleSetupWrapperSegment(argv);
+  return isSimpleSetupWrapperSegment(normalizedCommand ? tokenizeCommand(normalizedCommand) : argv);
 }
 
 function isSetupWrapperCommand(command: string): boolean {
   const segments = splitTopLevelCommandChain(command);
   return segments.length > 0
     && segments.every((segment) => isSetupWrapperSegment(tokenizeCommand(segment), segment));
+}
+
+function isSingleSetupConditionSegment(argv: string[], command: string): boolean {
+  const argv0 = getArgv0Name(argv);
+  return argv0 === "[" || argv0 === "[[" || argv0 === "test" || isSetupWrapperSegment(argv, command);
+}
+
+function isSetupConditionSegment(argv: string[], command: string): boolean {
+  const normalizedCommand = command ? stripSetupShellDecorators(command) : "";
+  const orSegments = normalizedCommand ? splitTopLevelOrChain(normalizedCommand) : [];
+  if (orSegments.length > 1) {
+    return orSegments.every((segment) => {
+      const segmentCommand = stripSetupShellDecorators(segment);
+      const segmentArgv = tokenizeCommand(segmentCommand);
+      return isSingleSetupConditionSegment(segmentArgv, segmentCommand) || isFailFastSetupGuard(segmentArgv);
+    });
+  }
+
+  return isSingleSetupConditionSegment(normalizedCommand ? tokenizeCommand(normalizedCommand) : argv, normalizedCommand || command);
+}
+
+function isSetupConditionCommand(command: string): boolean {
+  const segments = splitTopLevelCommandChain(command);
+  return segments.length > 0
+    && segments.every((segment) => isSetupConditionSegment(tokenizeCommand(segment), segment));
 }
 
 function stripLeadingSetupIfBlock(command: string): string | null {
@@ -316,7 +420,7 @@ function stripLeadingSetupIfBlock(command: string): string | null {
   if (!condition || !thenCommand || !tail) {
     return null;
   }
-  if (!isSetupWrapperCommand(condition) || !isSetupWrapperCommand(thenCommand)) {
+  if (!isSetupConditionCommand(condition) || !isSetupWrapperCommand(thenCommand)) {
     return null;
   }
   if (elseCommand && !isSetupWrapperCommand(elseCommand)) {

--- a/src/core/command-match.ts
+++ b/src/core/command-match.ts
@@ -14,7 +14,7 @@ export type CommandMatchCandidate = {
   command?: string;
 };
 
-const SETUP_WRAPPER_COMMANDS = new Set(["cd", "pwd", "set", "source", ".", "export", "unset", "trap"]);
+const SETUP_WRAPPER_COMMANDS = new Set(["cd", "pwd", "set", "source", ".", "export", "unset", "trap", "true"]);
 const SHELL_COMMAND_LAUNCHERS = new Set(["bash", "sh", "zsh", "fish"]);
 const ENV_FLAGS_WITH_VALUES = new Set(["-u", "--unset", "-C", "--chdir", "-S", "--split-string"]);
 const ENV_FLAGS = new Set(["-i", "--ignore-environment", "-0", "--null", "--debug"]);
@@ -211,6 +211,16 @@ export function isSetupWrapperSegment(argv: string[]): boolean {
 
   const argv0 = getArgv0Name(argv);
   if (!argv0) {
+    return true;
+  }
+
+  if (argv0 === "command" && (argv[1] === "-v" || argv[1] === "-V")) {
+    return true;
+  }
+  if (argv0 === "tt" && (argv[1] === "title" || argv[1] === "sync")) {
+    return true;
+  }
+  if (argv0 === "tmux" && argv[1] === "select-pane" && argv.includes("-T")) {
     return true;
   }
 

--- a/test/core/classify.test.ts
+++ b/test/core/classify.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { matchesRule } from "../../src/core/classify.js";
-import type { JsonRule, ToolExecutionInput } from "../../src/types.js";
+import { matchesRule, resolveRuleMatch } from "../../src/core/classify.js";
+import type { CompiledRule, JsonRule, ToolExecutionInput } from "../../src/types.js";
 
 function buildRule(commandIncludes: string[]): JsonRule {
   return {
@@ -21,6 +21,20 @@ function buildAnyRule(commandIncludesAny: string[]): JsonRule {
     match: {
       toolNames: ["exec"],
       commandIncludesAny,
+    },
+  };
+}
+
+function compileForTest(rule: JsonRule, source: CompiledRule["source"] = "project"): CompiledRule {
+  return {
+    rule,
+    source,
+    path: `test:${rule.id}`,
+    compiled: {
+      skipPatterns: [],
+      keepPatterns: [],
+      counters: [],
+      outputMatches: [],
     },
   };
 }
@@ -54,5 +68,20 @@ describe("matchesRule commandIncludes", () => {
     };
 
     expect(matchesRule(rule, input)).toBe(false);
+  });
+});
+
+describe("resolveRuleMatch candidate selection", () => {
+  it("keeps project commandIncludes rules that target wrapper command text", () => {
+    const wrapperRule = compileForTest(buildRule(["bash -lc"]));
+    const match = resolveRuleMatch({
+      toolName: "exec",
+      command: "bash -lc 'echo hi'",
+      combinedText: "hi\n",
+      exitCode: 0,
+    }, [wrapperRule]);
+
+    expect(match?.rule.rule.id).toBe("test/rule");
+    expect(match?.candidate.source).toBe("original");
   });
 });

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -71,12 +71,66 @@ describe("resolveEffectiveCommand", () => {
     });
   });
 
+  it("keeps visible command probes as the effective command", () => {
+    expect(resolveEffectiveCommand({ command: "command -v git; git diff --stat" })).toEqual({
+      command: "command -v git",
+      argv: ["command", "-v", "git"],
+      source: "effective",
+    });
+    expect(resolveEffectiveCommand({ command: "command -v rg || true; rg --files" })).toEqual({
+      command: "command -v rg || true",
+      argv: ["command", "-v", "rg", "||", "true"],
+      source: "effective",
+    });
+    expect(resolveEffectiveCommand({ command: "command -v git 2>/dev/null; git diff --stat" })).toEqual({
+      command: "command -v git 2>/dev/null",
+      argv: ["command", "-v", "git", "2>/dev/null"],
+      source: "effective",
+    });
+  });
+
+  it("skips fail-fast setup guards before matching the real command", () => {
+    expect(resolveEffectiveCommand({ command: "cd repo || exit 1; pnpm test" })).toEqual({
+      command: "pnpm test",
+      argv: ["pnpm", "test"],
+      source: "effective",
+    });
+  });
+
   it("skips guarded terminal setup preludes before matching the real command", () => {
     expect(resolveEffectiveCommand({
       command: "if command -v tt >/dev/null 2>&1; then tt title 'code review'; else tmux select-pane -T 'code review' 2>/dev/null || true; fi; git diff --stat",
     })).toEqual({
       command: "git diff --stat",
       argv: ["git", "diff", "--stat"],
+      source: "effective",
+    });
+  });
+
+  it("skips tmux-guarded terminal setup preludes before matching the real command", () => {
+    expect(resolveEffectiveCommand({
+      command: "if [ -n \"$TMUX\" ]; then tt title 'code review'; fi; git diff --stat",
+    })).toEqual({
+      command: "git diff --stat",
+      argv: ["git", "diff", "--stat"],
+      source: "effective",
+    });
+  });
+
+  it("skips bash-style tmux guards before matching the real command", () => {
+    expect(resolveEffectiveCommand({
+      command: "if [[ -n \"$TMUX\" ]]; then tt title 'code review'; fi; git diff --stat",
+    })).toEqual({
+      command: "git diff --stat",
+      argv: ["git", "diff", "--stat"],
+      source: "effective",
+    });
+  });
+
+  it("does not strip setup commands from partial parenthesized groups", () => {
+    expect(resolveEffectiveCommand({ command: "(cd repo && pnpm test); git status" })).toEqual({
+      command: "(cd repo",
+      argv: ["(cd", "repo"],
       source: "effective",
     });
   });
@@ -107,6 +161,15 @@ describe("resolveEffectiveCommand", () => {
     })).toEqual({
       command: "command -v rg >/dev/null || cargo install ripgrep",
       argv: ["command", "-v", "rg", ">/dev/null", "||", "cargo", "install", "ripgrep"],
+      source: "effective",
+    });
+  });
+
+  it("keeps test guards with substantive fallbacks as the effective command", () => {
+    expect(resolveEffectiveCommand({
+      command: "if [ -x \"$(command -v tt)\" ] || cargo install tt; then tt title 'tests'; fi; pnpm test",
+    })).toMatchObject({
+      command: "if [ -x \"$(command -v tt)\" ] || cargo install tt",
       source: "effective",
     });
   });

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -71,6 +71,26 @@ describe("resolveEffectiveCommand", () => {
     });
   });
 
+  it("skips guarded terminal setup preludes before matching the real command", () => {
+    expect(resolveEffectiveCommand({
+      command: "if command -v tt >/dev/null 2>&1; then tt title 'code review'; else tmux select-pane -T 'code review' 2>/dev/null || true; fi; git diff --stat",
+    })).toEqual({
+      command: "git diff --stat",
+      argv: ["git", "diff", "--stat"],
+      source: "effective",
+    });
+  });
+
+  it("keeps command probes with substantive fallbacks as the effective command", () => {
+    expect(resolveEffectiveCommand({
+      command: "command -v rg >/dev/null || cargo install ripgrep; rg --files",
+    })).toEqual({
+      command: "command -v rg >/dev/null || cargo install ripgrep",
+      argv: ["command", "-v", "rg", ">/dev/null", "||", "cargo", "install", "ripgrep"],
+      source: "effective",
+    });
+  });
+
   it("strips env assignments before matching", () => {
     expect(resolveEffectiveCommand({ command: "FOO='a b' swift build" })).toEqual({
       command: "swift build",

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -61,6 +61,16 @@ describe("resolveEffectiveCommand", () => {
     });
   });
 
+  it("skips terminal setup preludes before matching the real command", () => {
+    expect(resolveEffectiveCommand({
+      command: "command -v tt >/dev/null 2>&1 && tt title 'code review' || tmux select-pane -T 'code review' 2>/dev/null || true; git diff --stat",
+    })).toEqual({
+      command: "git diff --stat",
+      argv: ["git", "diff", "--stat"],
+      source: "effective",
+    });
+  });
+
   it("strips env assignments before matching", () => {
     expect(resolveEffectiveCommand({ command: "FOO='a b' swift build" })).toEqual({
       command: "swift build",

--- a/test/core/command.test.ts
+++ b/test/core/command.test.ts
@@ -81,6 +81,26 @@ describe("resolveEffectiveCommand", () => {
     });
   });
 
+  it("skips setup segments before guarded terminal setup preludes", () => {
+    expect(resolveEffectiveCommand({
+      command: "cd repo && if command -v tt >/dev/null 2>&1; then tt title 'tests'; else tmux select-pane -T 'tests' 2>/dev/null || true; fi; pnpm test",
+    })).toEqual({
+      command: "pnpm test",
+      argv: ["pnpm", "test"],
+      source: "effective",
+    });
+  });
+
+  it("skips newline-form guarded terminal setup preludes", () => {
+    expect(resolveEffectiveCommand({
+      command: "if command -v tt >/dev/null 2>&1\nthen tt title 'tests'\nelse tmux select-pane -T 'tests' 2>/dev/null || true\nfi\npnpm test",
+    })).toEqual({
+      command: "pnpm test",
+      argv: ["pnpm", "test"],
+      source: "effective",
+    });
+  });
+
   it("keeps command probes with substantive fallbacks as the effective command", () => {
     expect(resolveEffectiveCommand({
       command: "command -v rg >/dev/null || cargo install ripgrep; rg --files",

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1419,6 +1419,81 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("2 files changed");
   });
 
+  it("preserves visible command probe output", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "command -v git; git diff --stat",
+      combinedText: "/usr/bin/git\n src/index.ts | 4 ++--\n 1 file changed, 2 insertions(+), 2 deletions(-)",
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toContain("/usr/bin/git");
+  });
+
+  it("preserves stderr-only command probe output", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "command -v git 2>/dev/null; git diff --stat",
+      combinedText: "/usr/bin/git\n src/index.ts | 4 ++--\n 1 file changed, 2 insertions(+), 2 deletions(-)",
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toContain("/usr/bin/git");
+  });
+
+  it("matches commands after fail-fast setup guards", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "cd repo || exit 1; pnpm test",
+      combinedText: [
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("tests/pnpm-test");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("Test Files  1 failed");
+  });
+
+  it("matches commands after tmux-guarded terminal setup preludes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "if [ -n \"$TMUX\" ]; then tt title 'tests'; fi; pnpm test",
+      combinedText: [
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("tests/pnpm-test");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("Test Files  1 failed");
+  });
+
+  it("matches commands after bash-style tmux guards", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "if [[ -n \"$TMUX\" ]]; then tt title 'tests'; fi; pnpm test",
+      combinedText: [
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("tests/pnpm-test");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("Test Files  1 failed");
+  });
+
   it("matches git diff after guarded terminal setup preludes", async () => {
     const result = await reduceExecution({
       toolName: "exec",
@@ -1434,6 +1509,24 @@ describe("reduceExecution", () => {
     expect(result.classification.matchedReducer).toBe("git/diff-stat");
     expect(result.classification.matchedVia).toBe("effective");
     expect(result.inlineText).toContain("2 files changed");
+  });
+
+  it("preserves test guard output from substantive fallbacks", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "if [ -x \"$(command -v tt)\" ] || cargo install tt; then tt title 'tests'; fi; pnpm test",
+      combinedText: [
+        "Compiling tt v1.0.0",
+        "Installing /tmp/bin/tt",
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toContain("Compiling tt v1.0.0");
   });
 
   it("matches commands after earlier setup and guarded terminal setup preludes", async () => {

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1436,6 +1436,40 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("2 files changed");
   });
 
+  it("matches commands after earlier setup and guarded terminal setup preludes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "cd repo && if command -v tt >/dev/null 2>&1; then tt title 'tests'; else tmux select-pane -T 'tests' 2>/dev/null || true; fi; pnpm test",
+      combinedText: [
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("tests/pnpm-test");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("Test Files  1 failed");
+  });
+
+  it("matches commands after newline-form guarded terminal setup preludes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "if command -v tt >/dev/null 2>&1\nthen tt title 'tests'\nelse tmux select-pane -T 'tests' 2>/dev/null || true\nfi\npnpm test",
+      combinedText: [
+        "FAIL test/example.test.ts > example",
+        "AssertionError: expected 1 to be 2",
+        "Test Files  1 failed (1)",
+      ].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("tests/pnpm-test");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("Test Files  1 failed");
+  });
+
   it("summarizes package-lock JSON file inspection instead of replaying the whole lockfile", async () => {
     const result = await reduceExecution({
       toolName: "exec",

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1419,6 +1419,23 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("2 files changed");
   });
 
+  it("matches git diff after guarded terminal setup preludes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "if command -v tt >/dev/null 2>&1; then tt title 'code review'; else tmux select-pane -T 'code review' 2>/dev/null || true; fi; git diff --stat",
+      combinedText: [
+        " src/index.ts | 4 ++--",
+        " test/core/reduce.test.ts | 2 +-",
+        " 2 files changed, 3 insertions(+), 3 deletions(-)",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/diff-stat");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("2 files changed");
+  });
+
   it("summarizes package-lock JSON file inspection instead of replaying the whole lockfile", async () => {
     const result = await reduceExecution({
       toolName: "exec",

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1402,6 +1402,23 @@ describe("reduceExecution", () => {
     expect(result.facts?.["added line"]).toBe(30);
   });
 
+  it("matches git diff after terminal setup preludes", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "command -v tt >/dev/null 2>&1 && tt title 'code review' || tmux select-pane -T 'code review' 2>/dev/null || true; git diff --stat",
+      combinedText: [
+        " src/index.ts | 4 ++--",
+        " test/core/reduce.test.ts | 2 +-",
+        " 2 files changed, 3 insertions(+), 3 deletions(-)",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/diff-stat");
+    expect(result.classification.matchedVia).toBe("effective");
+    expect(result.inlineText).toContain("2 files changed");
+  });
+
   it("summarizes package-lock JSON file inspection instead of replaying the whole lockfile", async () => {
     const result = await reduceExecution({
       toolName: "exec",


### PR DESCRIPTION
Summary
- Treat harmless terminal setup preludes such as `command -v tt`, `tt title`, `tt sync`, and `tmux select-pane -T` as setup-only command segments.
- Preserve reducer matching for the real command after those preludes, including `git diff --stat`.
- Add an unreleased changelog entry for the reducer matching fix.

Verification
- `pnpm exec vitest run test/core/command.test.ts test/core/reduce.test.ts`
- `pnpm verify`
- `codex review --uncommitted` equivalent via the OpenClaw codex-review skill; result: no actionable regressions found.
