### PR TITLE
fix(scripts): add codex log analyzer help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Route `node scripts/run-vitest.mjs` output through the Vitest reducer so Rolldown plugin-timing warnings do not drown out passing test summaries.
+- Add `--help`/`-h` output to the Codex log analysis script.
 - Route Claude Code through a `PreToolUse` Bash wrapper so Tokenjuice compacts the actual command result without appending duplicate `PostToolUse` context or bypassing Claude Code approvals.
 - Keep Tokenjuice's Codex hook compatible with current Codex hook and approval surfaces, including `hooks`, `PermissionRequest`, Windows commands, async hooks, and approval/sandbox doctor reporting.
 - Compact whole JSON fallback output without dropping non-zero exit status.

--- a/scripts/analyze-codex-logs.mjs
+++ b/scripts/analyze-codex-logs.mjs
@@ -14,10 +14,24 @@ const SECRET_ASSIGNMENT_PATTERN = /\b([A-Z][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWOR
 const SECRET_VALUE_PATTERN = /\bsk-[A-Za-z0-9._-]+\b/g;
 const TOOL_FAILURE_PATTERN = /^(?:[a-z_]+) failed:/u;
 
+function usage() {
+  return [
+    "Usage: node scripts/analyze-codex-logs.mjs [options]",
+    "",
+    "Options:",
+    "  --codex-home <path>  Codex home directory to inspect (default: ~/.codex)",
+    "  --format <text|json> Output format (default: text)",
+    "  --sessions <count>   Number of recent session files to analyze (default: 20)",
+    "  --top <count>        Number of rows per section (default: 15)",
+    "  -h, --help           Show this help",
+  ].join("\n");
+}
+
 function parseArgs(argv) {
   const options = {
     codexHome: join(homedir(), ".codex"),
     format: "text",
+    help: false,
     sessionLimit: DEFAULT_SESSION_LIMIT,
     top: DEFAULT_TOP,
   };
@@ -27,6 +41,10 @@ function parseArgs(argv) {
     const next = argv[index + 1];
 
     switch (current) {
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
       case "--codex-home":
         if (!next) {
           throw new Error("--codex-home requires a value");
@@ -524,6 +542,11 @@ function emitText(report) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
   const report = {
     generatedAt: new Date().toISOString(),
     codexHome: options.codexHome,

--- a/test/scripts/analyze-codex-logs.test.ts
+++ b/test/scripts/analyze-codex-logs.test.ts
@@ -1,0 +1,19 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(new URL("../../scripts/analyze-codex-logs.mjs", import.meta.url));
+
+describe("analyze-codex-logs", () => {
+  it("prints help without reading Codex logs", async () => {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [scriptPath, "--help"]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage: node scripts/analyze-codex-logs.mjs [options]");
+    expect(stdout).toContain("--codex-home <path>");
+    expect(stdout).toContain("--format <text|json>");
+  });
+});


### PR DESCRIPTION
Summary
- Add `--help` and `-h` output to `scripts/analyze-codex-logs.mjs`.
- Ensure help exits before reading Codex session or hook-history files.
- Add a focused script test for the help path and an unreleased changelog entry.

Verification
- `node scripts/analyze-codex-logs.mjs --help`
- `pnpm exec vitest run test/scripts/analyze-codex-logs.test.ts`
- `pnpm verify`
- `codex review --uncommitted` equivalent via the OpenClaw codex-review skill; result: no actionable regressions found.
