### PR TITLE
feat(core): add TOKENJUICE_NO_OMISSION env var and --no-omit CLI flag

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
 import { stdin as inputStdin } from "node:process";
+import { fileURLToPath } from "node:url";
 import packageJson from "../../package.json" with { type: "json" };
 
 import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifacts.js";
@@ -64,6 +66,7 @@ type ParsedArgs = {
   store: boolean;
   tee: boolean;
   raw: boolean;
+  noOmit: boolean;
   storeDir: string | undefined;
   maxInlineChars: number | undefined;
   maxCaptureBytes: number | undefined;
@@ -91,9 +94,9 @@ function printUsage(): void {
       "usage:",
       "  tokenjuice --help",
       "  tokenjuice --version",
-      "  tokenjuice reduce [file] [--format text|json] [--classifier <id>] [--store] [--raw|--full]",
+      "  tokenjuice reduce [file] [--format text|json] [--classifier <id>] [--store] [--raw|--full] [--no-omit]",
       "  tokenjuice reduce-json [file]",
-      "  tokenjuice wrap [--raw|--full] [--source <name>] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
+      "  tokenjuice wrap [--raw|--full] [--no-omit] [--source <name>] -- <command> [args...] [--tee] [--store] [--max-capture-bytes <n>]",
       "  tokenjuice <command> ... [--trace]",
       "  tokenjuice install aider",
       "  tokenjuice install avante",
@@ -136,7 +139,7 @@ function printUsage(): void {
   process.stderr.write("\n");
 }
 
-function parseArgs(argv: string[]): ParsedArgs {
+export function parseArgs(argv: string[]): ParsedArgs {
   const command = argv[0];
   const positionals: string[] = [];
   const passthrough: string[] = [];
@@ -150,6 +153,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   let store = false;
   let tee = false;
   let raw = false;
+  let noOmit = false;
   let storeDir: string | undefined;
   let maxInlineChars: number | undefined;
   let maxCaptureBytes: number | undefined;
@@ -227,6 +231,10 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--raw":
       case "--full":
         raw = true;
+        index += 1;
+        break;
+      case "--no-omit":
+        noOmit = true;
         index += 1;
         break;
       case "--tee":
@@ -311,6 +319,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     store,
     tee,
     raw,
+    noOmit,
     storeDir,
     maxInlineChars,
     maxCaptureBytes,
@@ -379,6 +388,7 @@ async function runReduce(args: ParsedArgs): Promise<number> {
     {
       ...(args.classifier ? { classifier: args.classifier } : {}),
       ...(args.raw ? { raw: true } : {}),
+      ...(args.noOmit ? { noOmit: true } : {}),
       ...(args.trace ? { trace: true } : {}),
       recordStats: true,
       ...(args.store ? { store: true } : {}),
@@ -411,6 +421,7 @@ async function runReduceJson(args: ParsedArgs): Promise<number> {
     ...request.options,
     ...(args.classifier ? { classifier: args.classifier } : {}),
     ...(args.raw ? { raw: true } : {}),
+    ...(args.noOmit ? { noOmit: true } : {}),
     ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
@@ -425,6 +436,7 @@ async function runWrap(args: ParsedArgs): Promise<number> {
   const wrapped = await runWrappedCommand(args.passthrough, {
     tee: args.tee,
     ...(args.raw ? { raw: true } : {}),
+    ...(args.noOmit ? { noOmit: true } : {}),
     ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
@@ -433,14 +445,14 @@ async function runWrap(args: ParsedArgs): Promise<number> {
     ...(typeof args.maxCaptureBytes === "number" ? { maxCaptureBytes: args.maxCaptureBytes } : {}),
     ...(args.source ? { source: args.source } : {}),
   });
-  const inlineText = decorateWrapInlineText(wrapped.result, args.raw);
+  const inlineText = decorateWrapInlineText(wrapped.result, args.raw, args.noOmit);
   emit(args.format, wrapped, inlineText, args.raw);
   return wrapped.exitCode;
 }
 
-function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): string {
+export function decorateWrapInlineText(result: WrapResult["result"], raw: boolean, noOmit = false): string {
   const { rawChars, reducedChars } = result.stats;
-  if (raw || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
+  if (raw || noOmit || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
     return result.inlineText;
   }
   const footer = [
@@ -1815,8 +1827,8 @@ async function runStats(args: ParsedArgs): Promise<number> {
   return 0;
 }
 
-async function main(): Promise<number> {
-  const args = parseArgs(process.argv.slice(2));
+async function main(argv = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv);
   switch (args.command) {
     case undefined:
     case "help":
@@ -1879,11 +1891,34 @@ async function main(): Promise<number> {
   }
 }
 
-main()
-  .then((code) => {
-    process.exitCode = code;
-  })
-  .catch((error: unknown) => {
+export async function isDirectModuleEntrypoint(moduleUrl: string | URL, argv = process.argv): Promise<boolean> {
+  const entrypoint = argv[1];
+  if (!entrypoint) {
+    return false;
+  }
+
+  const [moduleStat, entrypointStat] = await Promise.allSettled([
+    stat(fileURLToPath(moduleUrl)),
+    stat(resolve(entrypoint)),
+  ]);
+  if (moduleStat.status !== "fulfilled" || entrypointStat.status !== "fulfilled") {
+    return false;
+  }
+
+  return moduleStat.value.dev === entrypointStat.value.dev && moduleStat.value.ino === entrypointStat.value.ino;
+}
+
+async function runCliIfEntrypoint(): Promise<void> {
+  if (!(await isDirectModuleEntrypoint(import.meta.url))) {
+    return;
+  }
+
+  try {
+    process.exitCode = await main();
+  } catch (error: unknown) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
-  });
+  }
+}
+
+void runCliIfEntrypoint();

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,6 +9,7 @@ import packageJson from "../../package.json" with { type: "json" };
 import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifacts.js";
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
+import { readNoOmissionFromEnv } from "../core/env.js";
 import { parseReduceJsonRequest } from "../core/json-protocol.js";
 import { WRAP_AUTHORITATIVE_FOOTER } from "../core/compaction-metadata.js";
 import { reduceExecution } from "../core/reduce.js";
@@ -377,6 +378,7 @@ function emit(format: Format, value: unknown, text: string, exactText = false): 
 async function runReduce(args: ParsedArgs): Promise<number> {
   const file = args.positionals[0];
   const rawText = await readTextInput(file, args.maxInputBytes);
+  const noOmit = resolveNoOmit(args.noOmit);
   const result = await reduceExecution(
     {
       toolName: "exec",
@@ -388,7 +390,7 @@ async function runReduce(args: ParsedArgs): Promise<number> {
     {
       ...(args.classifier ? { classifier: args.classifier } : {}),
       ...(args.raw ? { raw: true } : {}),
-      ...(args.noOmit ? { noOmit: true } : {}),
+      ...(noOmit ? { noOmit: true } : {}),
       ...(args.trace ? { trace: true } : {}),
       recordStats: true,
       ...(args.store ? { store: true } : {}),
@@ -403,6 +405,7 @@ async function runReduce(args: ParsedArgs): Promise<number> {
 async function runReduceJson(args: ParsedArgs): Promise<number> {
   const file = args.positionals[0];
   const rawText = await readTextInput(file, args.maxInputBytes);
+  const noOmit = resolveNoOmit(args.noOmit);
   if (!rawText.trim()) {
     throw new Error("reduce-json requires JSON input from stdin or a file");
   }
@@ -421,7 +424,7 @@ async function runReduceJson(args: ParsedArgs): Promise<number> {
     ...request.options,
     ...(args.classifier ? { classifier: args.classifier } : {}),
     ...(args.raw ? { raw: true } : {}),
-    ...(args.noOmit ? { noOmit: true } : {}),
+    ...(noOmit ? { noOmit: true } : {}),
     ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
@@ -433,10 +436,11 @@ async function runReduceJson(args: ParsedArgs): Promise<number> {
 }
 
 async function runWrap(args: ParsedArgs): Promise<number> {
+  const noOmit = resolveNoOmit(args.noOmit);
   const wrapped = await runWrappedCommand(args.passthrough, {
     tee: args.tee,
     ...(args.raw ? { raw: true } : {}),
-    ...(args.noOmit ? { noOmit: true } : {}),
+    ...(noOmit ? { noOmit: true } : {}),
     ...(args.trace ? { trace: true } : {}),
     recordStats: true,
     ...(args.store ? { store: true } : {}),
@@ -445,14 +449,18 @@ async function runWrap(args: ParsedArgs): Promise<number> {
     ...(typeof args.maxCaptureBytes === "number" ? { maxCaptureBytes: args.maxCaptureBytes } : {}),
     ...(args.source ? { source: args.source } : {}),
   });
-  const inlineText = decorateWrapInlineText(wrapped.result, args.raw, args.noOmit);
+  const inlineText = decorateWrapInlineText(wrapped.result, args.raw);
   emit(args.format, wrapped, inlineText, args.raw);
   return wrapped.exitCode;
 }
 
-export function decorateWrapInlineText(result: WrapResult["result"], raw: boolean, noOmit = false): string {
+export function resolveNoOmit(noOmitFlag: boolean, env: NodeJS.ProcessEnv = process.env): boolean {
+  return noOmitFlag || readNoOmissionFromEnv(env);
+}
+
+export function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): string {
   const { rawChars, reducedChars } = result.stats;
-  if (raw || noOmit || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
+  if (raw || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
     return result.inlineText;
   }
   const footer = [

--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -8,7 +8,10 @@ export type CompactionKind =
   | "inspection-large-document-summary"
   | "github-actions-command-list-omission"
   | "github-actions-log-signal-filter"
-  | "github-status-check-rollup-omission";
+  | "github-status-check-rollup-omission"
+  | "no-omit-head-tail-passthrough"
+  | "no-omit-char-clip-passthrough"
+  | "no-omit-domain-passthrough";
 
 export type CompactionMetadata = {
   authoritative: boolean;
@@ -22,18 +25,31 @@ export const NO_COMPACTION_METADATA: CompactionMetadata = {
 
 export const WRAP_AUTHORITATIVE_FOOTER = "[tokenjuice] This is the complete, authoritative output for this command. It was deterministically compacted to remove low-signal noise; the omitted content is not retrievable. Do not re-run the command, vary flags, or switch tools to try to recover it. Proceed with the task using this output.";
 
-export function createCompactionMetadata(...kinds: CompactionKind[]): CompactionMetadata {
+function buildCompactionMetadata(authoritative: boolean, ...kinds: CompactionKind[]): CompactionMetadata {
   if (kinds.length === 0) {
     return NO_COMPACTION_METADATA;
   }
 
   return {
-    authoritative: true,
+    authoritative,
     kinds: Array.from(new Set(kinds)),
   };
 }
 
+export function createCompactionMetadata(...kinds: CompactionKind[]): CompactionMetadata {
+  return buildCompactionMetadata(true, ...kinds);
+}
+
+export function createPassthroughCompactionMetadata(...kinds: CompactionKind[]): CompactionMetadata {
+  return buildCompactionMetadata(false, ...kinds);
+}
+
 export function mergeCompactionMetadata(...values: Array<CompactionMetadata | undefined>): CompactionMetadata {
-  const kinds = values.flatMap((value) => value?.kinds ?? []);
-  return createCompactionMetadata(...kinds);
+  const presentValues = values.filter((value): value is CompactionMetadata => Boolean(value) && (value?.kinds.length ?? 0) > 0);
+  if (presentValues.length === 0) {
+    return NO_COMPACTION_METADATA;
+  }
+
+  const kinds = presentValues.flatMap((value) => value.kinds);
+  return buildCompactionMetadata(presentValues.every((value) => value.authoritative), ...kinds);
 }

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,0 +1,6 @@
+const NO_OMISSION_ENV = "TOKENJUICE_NO_OMISSION";
+const NO_OMISSION_TRUTHY_VALUES = new Set(["1", "true", "TRUE", "yes", "YES"]);
+
+export function readNoOmissionFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return NO_OMISSION_TRUTHY_VALUES.has(env[NO_OMISSION_ENV] ?? "");
+}

--- a/src/core/github-actions-summary.ts
+++ b/src/core/github-actions-summary.ts
@@ -1,6 +1,6 @@
 import type { ToolExecutionInput } from "../types.js";
 
-import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+import { createCompactionMetadata, createPassthroughCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { normalizeLines, stripAnsi, trimEmptyEdges } from "./text.js";
 
 const GITHUB_ACTIONS_EXIT_PATTERN = /^Error: Process completed with exit code (\d+)\.?$/u;
@@ -71,9 +71,16 @@ function extractRunCommands(lines: string[]): string[] {
   return dedupeAdjacent(commands).filter((line) => !isShellSetupLine(line));
 }
 
-function formatCommandList(commands: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+function formatCommandList(commands: string[], noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   if (commands.length <= MAX_LISTED_COMMANDS) {
     return { lines: commands.map((command) => `- ${command}`) };
+  }
+
+  if (noOmit) {
+    return {
+      lines: commands.map((command) => `- ${command}`),
+      compaction: createPassthroughCompactionMetadata("no-omit-head-tail-passthrough"),
+    };
   }
 
   const headCount = Math.floor(MAX_LISTED_COMMANDS * 0.65);
@@ -89,7 +96,11 @@ function formatCommandList(commands: string[]): { lines: string[]; compaction?: 
   };
 }
 
-export function buildGithubActionsFailureSummary(input: ToolExecutionInput, rawText: string): { text: string; compaction?: CompactionMetadata } | null {
+export function buildGithubActionsFailureSummary(
+  input: ToolExecutionInput,
+  rawText: string,
+  noOmit = false,
+): { text: string; compaction?: CompactionMetadata } | null {
   const lines = trimEmptyEdges(normalizeLines(stripAnsi(rawText))).map((line) => line.trimEnd());
   const exitLine = [...lines].reverse().find((line) => GITHUB_ACTIONS_EXIT_PATTERN.test(stripGithubActionsScriptPrefix(line)));
   const exitCode = exitLine?.match(GITHUB_ACTIONS_EXIT_PATTERN)?.[1] ?? (input.exitCode && input.exitCode !== 0 ? String(input.exitCode) : null);
@@ -102,7 +113,7 @@ export function buildGithubActionsFailureSummary(input: ToolExecutionInput, rawT
     return null;
   }
 
-  const commandList = formatCommandList(commands);
+  const commandList = formatCommandList(commands, noOmit);
   const summary = [`GitHub Actions shell step failed (exit ${exitCode}).`];
   if (commands.length === 1) {
     summary.push(`Failing command: ${commands[0]}`);

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -1,4 +1,5 @@
 import { getInspectionCommandSkipReason, getSafeRepositoryInventorySourceArgv } from "../inventory-safety.js";
+import { readNoOmissionFromEnv } from "../env.js";
 import { buildInspectionSummary } from "../reduce-inspection-summary.js";
 import { reduceExecution } from "../reduce.js";
 import { getCompactionSkipReason, type RewritePolicyOptions } from "./rewrite-policy.js";
@@ -14,6 +15,7 @@ export type CompactBashResultInput = {
   trustedFullText?: string;
   exitCode?: number;
   maxInlineChars?: number;
+  noOmit?: boolean;
   storeRaw?: boolean;
   metadata?: Record<string, unknown>;
   inspectionPolicy?: InspectionCommandPolicy;
@@ -114,6 +116,7 @@ export async function compactBashResult(input: CompactBashResultInput): Promise<
   const options: ReduceOptions = {
     ...(typeof input.cwd === "string" && input.cwd.trim() ? { cwd: input.cwd } : {}),
     ...(typeof input.maxInlineChars === "number" ? { maxInlineChars: input.maxInlineChars } : {}),
+    ...(readNoOmissionFromEnv() || input.noOmit ? { noOmit: true } : {}),
     recordStats: true,
     ...(input.storeRaw ? { store: true } : {}),
   };

--- a/src/core/reduce-formatters.ts
+++ b/src/core/reduce-formatters.ts
@@ -1,4 +1,4 @@
-import { createCompactionMetadata, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+import { createCompactionMetadata, createPassthroughCompactionMetadata, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { compactWhitespace, clipMiddleWithHash, parseJsonObjectLine, parseJsonValue } from "./reduce-utils.js";
 
 import type { ToolExecutionInput } from "../types.js";
@@ -174,8 +174,8 @@ function extractGhDuration(record: Record<string, unknown>): string | null {
   return null;
 }
 
-function formatGhJsonRecord(record: Record<string, unknown>): { line: string; compaction?: CompactionMetadata } | null {
-  const comment = formatGhCommentJsonRecord(record);
+function formatGhJsonRecord(record: Record<string, unknown>, noOmit = false): { line: string; compaction?: CompactionMetadata } | null {
+  const comment = formatGhCommentJsonRecord(record, noOmit);
   if (comment) {
     return comment;
   }
@@ -239,7 +239,7 @@ function getNestedLogin(value: unknown): string | null {
   return null;
 }
 
-function formatGhCommentJsonRecord(record: Record<string, unknown>): { line: string; compaction?: CompactionMetadata } | null {
+function formatGhCommentJsonRecord(record: Record<string, unknown>, noOmit = false): { line: string; compaction?: CompactionMetadata } | null {
   const body = typeof record.body === "string" ? record.body
     : typeof record.bodyText === "string" ? record.bodyText
       : null;
@@ -264,7 +264,7 @@ function formatGhCommentJsonRecord(record: Record<string, unknown>): { line: str
   const createdAt = typeof record.createdAt === "string" ? record.createdAt.slice(0, 10)
     : typeof record.created_at === "string" ? record.created_at.slice(0, 10)
       : null;
-  const clippedBody = clipMiddleWithHash(compactWhitespace(body), 180);
+  const clippedBody = clipMiddleWithHash(compactWhitespace(body), 180, noOmit);
 
   const location = path ? `${path}${line !== null ? `:${line}` : ""}` : null;
   const parts = [
@@ -342,7 +342,7 @@ function formatGhStatusCheckLine(record: Record<string, unknown>): string | null
   return parts.join(" ");
 }
 
-function formatGhStatusCheckRollup(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
+function formatGhStatusCheckRollup(value: unknown, noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const records = getGhCollection(value)
     .filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry));
   if (records.length === 0) {
@@ -352,7 +352,8 @@ function formatGhStatusCheckRollup(value: unknown): { lines: string[]; compactio
   const attention = records.filter((record) => !isGhStatusCheckOk(record));
   const okCount = records.length - attention.length;
   const lines = [`status checks: ${okCount} ok, ${attention.length} attention`];
-  const listed = attention.slice(0, MAX_GH_STATUS_CHECK_ATTENTION_LINES);
+  const listed = noOmit ? records : attention.slice(0, MAX_GH_STATUS_CHECK_ATTENTION_LINES);
+  const omittedAttention = Math.max(0, attention.length - MAX_GH_STATUS_CHECK_ATTENTION_LINES);
   for (const record of listed) {
     const line = formatGhStatusCheckLine(record);
     if (line) {
@@ -360,27 +361,28 @@ function formatGhStatusCheckRollup(value: unknown): { lines: string[]; compactio
     }
   }
 
-  const omittedAttention = attention.length - listed.length;
-  if (omittedAttention > 0) {
+  if (!noOmit && omittedAttention > 0) {
     lines.push(`... ${omittedAttention} attention checks omitted ...`);
   }
 
+  const compaction = noOmit
+    ? (okCount > 0 || omittedAttention > 0 ? createPassthroughCompactionMetadata("no-omit-domain-passthrough") : undefined)
+    : (okCount > 0 || omittedAttention > 0 ? createCompactionMetadata("github-status-check-rollup-omission") : undefined);
+
   return {
     lines,
-    ...(okCount > 0 || omittedAttention > 0
-      ? { compaction: createCompactionMetadata("github-status-check-rollup-omission") }
-      : {}),
+    ...(compaction && compaction.kinds.length > 0 ? { compaction } : {}),
   };
 }
 
-function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: CompactionMetadata } {
+function formatGhJsonValue(value: unknown, noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const compactions: CompactionMetadata[] = [];
   if (Array.isArray(value)) {
     const lines = value.flatMap((entry) => {
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         return [];
       }
-      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
+      const formatted = formatGhJsonRecord(entry as Record<string, unknown>, noOmit);
       if (!formatted) {
         return [];
       }
@@ -402,7 +404,7 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
 
   const record = value as Record<string, unknown>;
   const lines: string[] = [];
-  const header = formatGhJsonRecord(record);
+  const header = formatGhJsonRecord(record, noOmit);
   if (header) {
     lines.push(header.line);
     if (header.compaction) {
@@ -410,7 +412,7 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
     }
   }
 
-  const statusCheckRollup = formatGhStatusCheckRollup(record.statusCheckRollup);
+  const statusCheckRollup = formatGhStatusCheckRollup(record.statusCheckRollup, noOmit);
   if (statusCheckRollup.lines.length > 0) {
     lines.push(...statusCheckRollup.lines);
     if (statusCheckRollup.compaction) {
@@ -428,7 +430,7 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         continue;
       }
-      const formatted = formatGhJsonRecord(entry as Record<string, unknown>);
+      const formatted = formatGhJsonRecord(entry as Record<string, unknown>, noOmit);
       if (formatted) {
         lines.push(formatted.line);
         if (formatted.compaction) {
@@ -444,19 +446,19 @@ function formatGhJsonValue(value: unknown): { lines: string[]; compaction?: Comp
   };
 }
 
-export function rewriteSearchLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+export function rewriteSearchLines(lines: string[], noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const compactions: CompactionMetadata[] = [];
   const rewritten = lines.map((line) => {
     const match = /^(.+?:\d+(?::|-))(.*)$/u.exec(line);
     if (!match) {
-      const clipped = clipMiddleWithHash(line, LONG_SEARCH_LINE_MAX_CHARS);
+      const clipped = clipMiddleWithHash(line, LONG_SEARCH_LINE_MAX_CHARS, noOmit);
       if (clipped.compaction) {
         compactions.push(clipped.compaction);
       }
       return clipped.text;
     }
     const [, prefix, rest] = match;
-    const clipped = clipMiddleWithHash(rest ?? "", LONG_SEARCH_LINE_MAX_CHARS);
+    const clipped = clipMiddleWithHash(rest ?? "", LONG_SEARCH_LINE_MAX_CHARS, noOmit);
     if (clipped.compaction) {
       compactions.push(clipped.compaction);
     }
@@ -469,12 +471,13 @@ export function rewriteSearchLines(lines: string[]): { lines: string[]; compacti
   };
 }
 
-export function rewriteGitDiffLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+export function rewriteGitDiffLines(lines: string[], noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const rewritten: string[] = [];
   const compactions: CompactionMetadata[] = [];
   let emittedChangedLinesInHunk = 0;
   let omittedAdded = 0;
   let omittedRemoved = 0;
+  let bypassedHunkClip = false;
 
   const flushOmitted = () => {
     if (omittedAdded > 0 || omittedRemoved > 0) {
@@ -505,9 +508,12 @@ export function rewriteGitDiffLines(lines: string[]): { lines: string[]; compact
       continue;
     }
 
-    if (emittedChangedLinesInHunk < GIT_DIFF_CHANGED_LINES_PER_HUNK) {
+    if (noOmit || emittedChangedLinesInHunk < GIT_DIFF_CHANGED_LINES_PER_HUNK) {
+      if (noOmit && emittedChangedLinesInHunk >= GIT_DIFF_CHANGED_LINES_PER_HUNK) {
+        bypassedHunkClip = true;
+      }
       emittedChangedLinesInHunk += 1;
-      const clipped = clipMiddleWithHash(line, LONG_CHANGED_LINE_MAX_CHARS);
+      const clipped = clipMiddleWithHash(line, LONG_CHANGED_LINE_MAX_CHARS, noOmit);
       if (clipped.compaction) {
         compactions.push(clipped.compaction);
       }
@@ -523,6 +529,9 @@ export function rewriteGitDiffLines(lines: string[]): { lines: string[]; compact
   }
 
   flushOmitted();
+  if (bypassedHunkClip) {
+    compactions.push(createPassthroughCompactionMetadata("no-omit-domain-passthrough"));
+  }
   return {
     lines: rewritten,
     ...(compactions.length > 0 ? { compaction: mergeCompactionMetadata(...compactions) } : {}),
@@ -573,7 +582,7 @@ function formatOmittedGhLogLines(count: number): string {
   return `... ${count} non-signal log lines omitted ...`;
 }
 
-function filterGhRunLogSignalLines(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+function filterGhRunLogSignalLines(lines: string[], noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const signalIndexes = lines
     .map((line, index) => GH_RUN_LOG_SIGNAL_PATTERN.test(line) ? index : -1)
     .filter((index) => index >= 0);
@@ -614,13 +623,20 @@ function filterGhRunLogSignalLines(lines: string[]): { lines: string[]; compacti
     return { lines };
   }
 
+  if (noOmit) {
+    return {
+      lines,
+      compaction: createPassthroughCompactionMetadata("no-omit-domain-passthrough"),
+    };
+  }
+
   return {
     lines: rewritten,
     compaction: createCompactionMetadata("github-actions-log-signal-filter"),
   };
 }
 
-export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { lines: string[]; compaction?: CompactionMetadata } {
+export function rewriteGhLines(lines: string[], input: ToolExecutionInput, noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const nonEmpty = lines.filter((line) => line.trim() !== "");
   if (nonEmpty.length === 0) {
     return { lines: [] };
@@ -628,7 +644,7 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
 
   const parsedWholeJson = parseJsonValue(nonEmpty.join("\n"));
   if (parsedWholeJson !== null) {
-    const rewrittenWholeJson = formatGhJsonValue(parsedWholeJson);
+    const rewrittenWholeJson = formatGhJsonValue(parsedWholeJson, noOmit);
     if (rewrittenWholeJson.lines.length > 0) {
       return rewrittenWholeJson;
     }
@@ -638,7 +654,7 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
   if (parsedJsonLines.every((entry) => entry !== null)) {
     const compactions: CompactionMetadata[] = [];
     const rewritten = parsedJsonLines
-      .map((entry) => formatGhJsonRecord(entry!))
+      .map((entry) => formatGhJsonRecord(entry!, noOmit))
       .flatMap((line) => {
         if (!line || line.line.length === 0) {
           return [];
@@ -659,7 +675,7 @@ export function rewriteGhLines(lines: string[], input: ToolExecutionInput): { li
   if (isGithubCliCommand((input.argv ?? [])[0])) {
     const formattedLines = lines.map(formatGhTableLine);
     if (isGhRunLogCommand(input)) {
-      return filterGhRunLogSignalLines(formattedLines);
+      return filterGhRunLogSignalLines(formattedLines, noOmit);
     }
     return { lines: formattedLines };
   }

--- a/src/core/reduce-inspection-summary.ts
+++ b/src/core/reduce-inspection-summary.ts
@@ -17,7 +17,7 @@ export type InspectionSummary = {
   compaction: CompactionMetadata;
 };
 
-function buildPackageLockSummary(value: unknown): string[] {
+function buildPackageLockSummary(value: unknown, noOmit = false): string[] {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return [];
   }
@@ -38,22 +38,22 @@ function buildPackageLockSummary(value: unknown): string[] {
     `dependencies: ${dependencies.length}`,
   ].filter((line): line is string => line !== null);
 
-  const packageSamples = packages.filter(Boolean).slice(0, 12);
+  const packageSamples = noOmit ? packages.filter(Boolean) : packages.filter(Boolean).slice(0, 12);
   if (packageSamples.length > 0) {
     lines.push(`sample packages: ${packageSamples.join(", ")}`);
   }
   return lines;
 }
 
-function buildLargeDocumentSummary(lines: string[], rawText: string): { lines: string[]; compaction: CompactionMetadata } {
+function buildLargeDocumentSummary(lines: string[], rawText: string, noOmit = false): { lines: string[]; compaction: CompactionMetadata } {
   const headings = lines
     .map((line) => line.trim())
     .filter((line) => /^#{1,6}\s+\S/u.test(line))
     .slice(0, 24);
-  const excerpt = headTail(lines, 6, 6);
+  const excerpt = headTail(lines, 6, 6, noOmit);
   const clippedHeadingCompactions: CompactionMetadata[] = [];
   const clippedHeadings = headings.map((line) => {
-    const clipped = clipMiddleWithHash(line, 180);
+    const clipped = clipMiddleWithHash(line, 180, noOmit);
     if (clipped.compaction) {
       clippedHeadingCompactions.push(clipped.compaction);
     }
@@ -61,7 +61,7 @@ function buildLargeDocumentSummary(lines: string[], rawText: string): { lines: s
   });
   const clippedExcerptCompactions: CompactionMetadata[] = [];
   const excerptLines = excerpt.lines.map((line) => {
-    const clipped = clipMiddleWithHash(line, 180);
+    const clipped = clipMiddleWithHash(line, 180, noOmit);
     if (clipped.compaction) {
       clippedExcerptCompactions.push(clipped.compaction);
     }
@@ -131,10 +131,10 @@ function isLargeDocumentOutput(lines: string[], rawChars: number): boolean {
     && codeLines / nonEmptyLines.length < 0.25;
 }
 
-export function buildInspectionSummary(input: ToolExecutionInput, rawText: string): InspectionSummary | null {
+export function buildInspectionSummary(input: ToolExecutionInput, rawText: string, noOmit = false): InspectionSummary | null {
   const command = input.command ?? "";
   if (PACKAGE_LOCK_RE.test(command)) {
-    const lines = buildPackageLockSummary(parseJsonValue(rawText));
+    const lines = buildPackageLockSummary(parseJsonValue(rawText), noOmit);
     return lines.length > 0
       ? { lines, matchedReducer: "generic/package-lock-summary", compaction: createCompactionMetadata("inspection-package-lock-summary") }
       : null;
@@ -146,7 +146,7 @@ export function buildInspectionSummary(input: ToolExecutionInput, rawText: strin
     return null;
   }
 
-  const summary = buildLargeDocumentSummary(lines, rawText);
+  const summary = buildLargeDocumentSummary(lines, rawText, noOmit);
   return {
     lines: summary.lines,
     matchedReducer: "generic/large-document-summary",

--- a/src/core/reduce-utils.ts
+++ b/src/core/reduce-utils.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+import { createCompactionMetadata, createPassthroughCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { countTextChars, sliceTextChars } from "./text.js";
 
 export function compactWhitespace(text: string): string {
@@ -11,9 +11,16 @@ function shortHash(text: string): string {
   return createHash("sha256").update(text).digest("hex").slice(0, 12);
 }
 
-function clipMiddleWithHashStrict(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+function clipMiddleWithHashStrict(text: string, maxChars: number, noOmit = false): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
     return { text };
+  }
+
+  if (noOmit) {
+    return {
+      text,
+      compaction: createPassthroughCompactionMetadata("no-omit-char-clip-passthrough"),
+    };
   }
 
   const omitted = countTextChars(text) - maxChars;
@@ -70,9 +77,15 @@ function minifyJsonLexically(rawText: string): string {
   return output;
 }
 
-export function clipMiddleWithHash(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+export function clipMiddleWithHash(text: string, maxChars: number, noOmit = false): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
     return { text };
+  }
+  if (noOmit) {
+    return {
+      text,
+      compaction: createPassthroughCompactionMetadata("no-omit-char-clip-passthrough"),
+    };
   }
   const omitted = countTextChars(text) - maxChars;
   const headChars = Math.max(20, Math.floor(maxChars * 0.55));
@@ -83,10 +96,10 @@ export function clipMiddleWithHash(text: string, maxChars: number): { text: stri
   };
 }
 
-export function compactWholeJsonText(rawText: string, maxChars: number): { text: string; compaction?: CompactionMetadata } | null {
+export function compactWholeJsonText(rawText: string, maxChars: number, noOmit = false): { text: string; compaction?: CompactionMetadata } | null {
   return parseJsonValue(rawText) === null
     ? null
-    : clipMiddleWithHashStrict(minifyJsonLexically(rawText), maxChars);
+    : clipMiddleWithHashStrict(minifyJsonLexically(rawText), maxChars, noOmit);
 }
 
 export function parseJsonObjectLine(line: string): Record<string, unknown> | null {

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -50,7 +50,12 @@ function prettyPrintJsonIfPossible(text: string): string {
   return text;
 }
 
-function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawText: string): { summary: string; facts: Record<string, number>; compaction: CompactionMetadata } {
+function applyRule(
+  compiledRule: CompiledRule,
+  input: ToolExecutionInput,
+  rawText: string,
+  noOmit = false,
+): { summary: string; facts: Record<string, number>; compaction: CompactionMetadata } {
   const rule = compiledRule.rule;
   if (rule.transforms?.prettyPrintJson) {
     rawText = prettyPrintJsonIfPossible(rawText);
@@ -102,18 +107,18 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
   const preRewriteLines = [...lines];
   let rewriteCompaction: CompactionMetadata | undefined;
   if (rule.id === "cloud/gh") {
-    counterLines = rewriteGhLines(counterLines, input).lines;
-    const rewritten = rewriteGhLines(lines, input);
+    counterLines = rewriteGhLines(counterLines, input, noOmit).lines;
+    const rewritten = rewriteGhLines(lines, input, noOmit);
     lines = rewritten.lines;
     rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
   if (rule.id === "search/rg") {
-    const rewritten = rewriteSearchLines(lines);
+    const rewritten = rewriteSearchLines(lines, noOmit);
     lines = rewritten.lines;
     rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
   if (rule.id === "git/diff") {
-    const rewritten = rewriteGitDiffLines(lines);
+    const rewritten = rewriteGitDiffLines(lines, noOmit);
     lines = rewritten.lines;
     rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, rewritten.compaction);
   }
@@ -145,7 +150,7 @@ function applyRule(compiledRule: CompiledRule, input: ToolExecutionInput, rawTex
         tail: rule.summarize?.tail ?? 6,
       };
 
-  const compacted = headTail(lines, summarize.head, summarize.tail);
+  const compacted = headTail(lines, summarize.head, summarize.tail, noOmit);
   return {
     summary: compacted.lines.join("\n").trim(),
     facts,
@@ -218,6 +223,7 @@ function formatInline(
   input: ToolExecutionInput,
   summary: string,
   facts: Record<string, number>,
+  noOmit = false,
 ): string {
   const factParts = Object.entries(facts)
     .filter(([, count]) => count > 0)
@@ -232,7 +238,7 @@ function formatInline(
     || (
       classification.family !== "git-status"
       && classification.family !== "help"
-      && summary.includes("omitted")
+      && (noOmit || summary.includes("omitted"))
     )
     || (classification.family === "test-results" && (input.exitCode ?? 0) !== 0);
 
@@ -250,10 +256,17 @@ function selectInlineText(
   compactText: string,
   maxInlineChars: number,
   compactCompaction: CompactionMetadata,
+  noOmit = false,
 ): { text: string; compaction: CompactionMetadata } {
   const passthroughText = buildPassthroughText(input, rawText);
   const rawChars = countTextChars(stripAnsi(rawText));
   const compactChars = countTextChars(compactText);
+  if (noOmit) {
+    return {
+      text: compactText,
+      compaction: compactCompaction,
+    };
+  }
   if (shouldKeepSmallOutput(classification, input, rawChars, compactChars, maxInlineChars)) {
     return {
       text: buildLiteralPassthroughText(input, rawText),
@@ -377,10 +390,10 @@ export async function reduceExecutionWithRules(
     };
   }
 
-  const inspectionSummary = buildInspectionSummary(normalizedInput, rawText);
+  const inspectionSummary = buildInspectionSummary(normalizedInput, rawText, opts.noOmit);
   if (inspectionSummary) {
     const summaryText = inspectionSummary.lines.join("\n").trim();
-    const selectedText = clampTextMiddleWithMetadata(summaryText, maxInlineChars);
+    const selectedText = clampTextMiddleWithMetadata(summaryText, maxInlineChars, opts.noOmit);
     const reducedChars = countTextChars(selectedText.text);
     const summaryClassification = {
       family: "structured-summary",
@@ -465,10 +478,10 @@ export async function reduceExecutionWithRules(
   }
 
   const githubActionsFailureSummary = classification.matchedReducer === "generic/fallback"
-    ? buildGithubActionsFailureSummary(reducerInput, rawText)
+    ? buildGithubActionsFailureSummary(reducerInput, rawText, opts.noOmit)
     : null;
   if (githubActionsFailureSummary) {
-    const inlineText = clampTextMiddleWithMetadata(githubActionsFailureSummary.text, maxInlineChars);
+    const inlineText = clampTextMiddleWithMetadata(githubActionsFailureSummary.text, maxInlineChars, opts.noOmit);
     const reducedChars = countTextChars(inlineText.text);
     const stats = {
       rawChars: measuredRawChars,
@@ -513,7 +526,7 @@ export async function reduceExecutionWithRules(
   if (classification.matchedReducer === "generic/fallback") {
     const exitPrefix = reducerInput.exitCode && reducerInput.exitCode !== 0 ? `exit ${reducerInput.exitCode}\n` : "";
     const jsonBudget = Math.max(0, maxInlineChars - countTextChars(exitPrefix));
-    const jsonOutput = compactWholeJsonText(rawText, jsonBudget);
+    const jsonOutput = compactWholeJsonText(rawText, jsonBudget, opts.noOmit);
     if (jsonOutput) {
       const inlineText = `${exitPrefix}${jsonOutput.text}`;
       const reducedChars = countTextChars(inlineText);
@@ -560,16 +573,16 @@ export async function reduceExecutionWithRules(
     }
   }
 
-  const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText);
-  const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts);
-  const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars, compaction);
+  const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText, opts.noOmit);
+  const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts, opts.noOmit);
+  const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars, compaction, opts.noOmit);
   const clamp = classification.family === "help" || selectedText.text.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
-  const provisionalInlineText = clamp(selectedText.text, maxInlineChars);
-  const provisionalReducedChars = countTextChars(provisionalInlineText.text);
-  const provisionalStats = {
+  const inlineText = clamp(selectedText.text, maxInlineChars, opts.noOmit);
+  const reducedChars = countTextChars(inlineText.text);
+  const stats = {
     rawChars: measuredRawChars,
-    reducedChars: provisionalReducedChars,
-    ratio: measuredRawChars === 0 ? 1 : provisionalReducedChars / measuredRawChars,
+    reducedChars,
+    ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
   };
   const rawRef = opts.store
     ? await storeArtifact(
@@ -577,22 +590,11 @@ export async function reduceExecutionWithRules(
           input: normalizedInput,
           rawText,
           classification,
-          stats: {
-            rawChars: provisionalStats.rawChars,
-            reducedChars: provisionalStats.reducedChars,
-            ratio: provisionalStats.ratio,
-          },
+          stats,
         },
         opts.storeDir,
       )
     : undefined;
-  const inlineText = clamp(selectedText.text, maxInlineChars);
-  const reducedChars = countTextChars(inlineText.text);
-  const stats = {
-    rawChars: measuredRawChars,
-    reducedChars,
-    ratio: measuredRawChars === 0 ? 1 : reducedChars / measuredRawChars,
-  };
 
   if (!opts.store && opts.recordStats) {
     await storeArtifactMetadata(

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -1,4 +1,4 @@
-import { createCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
+import { createCompactionMetadata, createPassthroughCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 
 const ANSI_CSI_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
 const ANSI_OSC_PATTERN = new RegExp(String.raw`\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)`, "g");
@@ -139,7 +139,7 @@ export function dedupeAdjacent(lines: string[]): string[] {
   return next;
 }
 
-export function headTail(lines: string[], head: number, tail: number): { lines: string[]; compaction?: CompactionMetadata } {
+export function headTail(lines: string[], head: number, tail: number, noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {
   const safeHead = Math.max(0, head);
   const safeTail = Math.max(0, tail);
   if (safeHead === 0 && safeTail === 0) {
@@ -148,6 +148,13 @@ export function headTail(lines: string[], head: number, tail: number): { lines: 
 
   if (lines.length <= safeHead + safeTail) {
     return { lines };
+  }
+
+  if (noOmit) {
+    return {
+      lines,
+      compaction: createPassthroughCompactionMetadata("no-omit-head-tail-passthrough"),
+    };
   }
 
   return {
@@ -169,9 +176,16 @@ export function clampText(text: string, maxChars: number): string {
   return `${head}${TRUNCATION_SUFFIX}`;
 }
 
-export function clampTextWithMetadata(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+export function clampTextWithMetadata(text: string, maxChars: number, noOmit = false): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
     return { text };
+  }
+
+  if (noOmit) {
+    return {
+      text,
+      compaction: createPassthroughCompactionMetadata("no-omit-char-clip-passthrough"),
+    };
   }
 
   return {
@@ -184,9 +198,16 @@ export function clampTextMiddle(text: string, maxChars: number): string {
   return clampTextMiddleWithMetadata(text, maxChars).text;
 }
 
-export function clampTextMiddleWithMetadata(text: string, maxChars: number): { text: string; compaction?: CompactionMetadata } {
+export function clampTextMiddleWithMetadata(text: string, maxChars: number, noOmit = false): { text: string; compaction?: CompactionMetadata } {
   if (countTextChars(text) <= maxChars) {
     return { text };
+  }
+
+  if (noOmit) {
+    return {
+      text,
+      compaction: createPassthroughCompactionMetadata("no-omit-char-clip-passthrough"),
+    };
   }
 
   const markerChars = countTextChars(MIDDLE_TRUNCATION_MARKER);

--- a/src/core/wrap.ts
+++ b/src/core/wrap.ts
@@ -108,6 +108,7 @@ export async function runWrappedCommand(argv: string[], opts: WrapOptions = {}):
           },
           {
             raw: opts.raw ?? false,
+            noOmit: opts.noOmit ?? false,
             trace: opts.trace ?? false,
             recordStats: opts.recordStats ?? false,
             store: opts.store ?? false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,7 @@ export type StoredArtifact = {
 export type ReduceOptions = {
   classifier?: string;
   maxInlineChars?: number;
+  noOmit?: boolean;
   trace?: boolean;
   raw?: boolean;
   recordStats?: boolean;
@@ -217,6 +218,7 @@ export type RuleFixture = {
 export type WrapOptions = {
   cwd?: string;
   source?: string;
+  noOmit?: boolean;
   recordStats?: boolean;
   store?: boolean;
   storeDir?: string;

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { WRAP_AUTHORITATIVE_FOOTER } from "../../src/core/compaction-metadata.js";
-import { decorateWrapInlineText, isDirectModuleEntrypoint, parseArgs } from "../../src/cli/main.js";
+import { decorateWrapInlineText, isDirectModuleEntrypoint, parseArgs, resolveNoOmit } from "../../src/cli/main.js";
 import type { CompactResult } from "../../src/types.js";
 
 const tempDirs: string[] = [];
@@ -29,7 +29,7 @@ describe("parseArgs", () => {
 });
 
 describe("decorateWrapInlineText", () => {
-  it("suppresses the authoritative footer when noOmit is enabled", () => {
+  it("keeps the authoritative footer for lossy summaries", () => {
     const result: CompactResult = {
       inlineText: "summary",
       compaction: {
@@ -48,8 +48,39 @@ describe("decorateWrapInlineText", () => {
       },
     };
 
-    expect(decorateWrapInlineText(result, false, false)).toContain(WRAP_AUTHORITATIVE_FOOTER);
-    expect(decorateWrapInlineText(result, false, true)).toBe("summary");
+    expect(decorateWrapInlineText(result, false)).toContain(WRAP_AUTHORITATIVE_FOOTER);
+  });
+
+  it("suppresses the authoritative footer for lossless rewrites", () => {
+    const result: CompactResult = {
+      inlineText: "summary",
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-domain-passthrough"],
+      },
+      stats: {
+        rawChars: 4_000,
+        reducedChars: 40,
+        ratio: 0.01,
+      },
+      classification: {
+        family: "generic",
+        confidence: 0.9,
+        matchedReducer: "generic/fallback",
+      },
+    };
+
+    expect(decorateWrapInlineText(result, false)).toBe("summary");
+  });
+});
+
+describe("resolveNoOmit", () => {
+  it("enables noOmit from TOKENJUICE_NO_OMISSION", () => {
+    expect(resolveNoOmit(false, { TOKENJUICE_NO_OMISSION: "1" })).toBe(true);
+  });
+
+  it("keeps noOmit enabled when the CLI flag is set", () => {
+    expect(resolveNoOmit(true, {})).toBe(true);
   });
 });
 

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WRAP_AUTHORITATIVE_FOOTER } from "../../src/core/compaction-metadata.js";
+import { decorateWrapInlineText, isDirectModuleEntrypoint, parseArgs } from "../../src/cli/main.js";
+import type { CompactResult } from "../../src/types.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-cli-main-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("parseArgs", () => {
+  it("parses --no-omit for reduce and wrap", () => {
+    expect(parseArgs(["reduce", "--no-omit"]).noOmit).toBe(true);
+    expect(parseArgs(["wrap", "--no-omit", "--", "echo", "hi"]).noOmit).toBe(true);
+  });
+});
+
+describe("decorateWrapInlineText", () => {
+  it("suppresses the authoritative footer when noOmit is enabled", () => {
+    const result: CompactResult = {
+      inlineText: "summary",
+      compaction: {
+        authoritative: true,
+        kinds: ["head-tail-omission"],
+      },
+      stats: {
+        rawChars: 4_000,
+        reducedChars: 40,
+        ratio: 0.01,
+      },
+      classification: {
+        family: "generic",
+        confidence: 0.9,
+        matchedReducer: "generic/fallback",
+      },
+    };
+
+    expect(decorateWrapInlineText(result, false, false)).toContain(WRAP_AUTHORITATIVE_FOOTER);
+    expect(decorateWrapInlineText(result, false, true)).toBe("summary");
+  });
+});
+
+describe("isDirectModuleEntrypoint", () => {
+  it("matches a relative argv[1] path", async () => {
+    const dir = await createTempDir();
+    const modulePath = join(dir, "main.js");
+    const cwd = join(dir, "cwd");
+    const originalCwd = process.cwd();
+    await writeFile(modulePath, "");
+    await mkdir(cwd);
+    process.chdir(cwd);
+
+    try {
+      await expect(isDirectModuleEntrypoint(pathToFileURL(modulePath), ["node", "../main.js"])).resolves.toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it("matches a symlinked argv[1] path", async () => {
+    const dir = await createTempDir();
+    const modulePath = join(dir, "main.js");
+    const symlinkPath = join(dir, "tokenjuice");
+    await writeFile(modulePath, "");
+    await symlink(modulePath, symlinkPath);
+
+    await expect(isDirectModuleEntrypoint(pathToFileURL(modulePath), ["node", symlinkPath])).resolves.toBe(true);
+  });
+});

--- a/test/core/env.test.ts
+++ b/test/core/env.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readNoOmissionFromEnv } from "../../src/core/env.js";
+
+const NO_OMISSION_ENV = "TOKENJUICE_NO_OMISSION";
+const originalNoOmissionEnv = process.env[NO_OMISSION_ENV];
+
+afterEach(() => {
+  if (originalNoOmissionEnv === undefined) {
+    delete process.env[NO_OMISSION_ENV];
+    return;
+  }
+  process.env[NO_OMISSION_ENV] = originalNoOmissionEnv;
+});
+
+describe("readNoOmissionFromEnv", () => {
+  it.each(["1", "true", "TRUE", "yes", "YES"])("returns true for %s", (value) => {
+    process.env[NO_OMISSION_ENV] = value;
+
+    expect(readNoOmissionFromEnv()).toBe(true);
+  });
+
+  it.each(["", "0", "false", "True", "on"])("returns false for %s", (value) => {
+    process.env[NO_OMISSION_ENV] = value;
+
+    expect(readNoOmissionFromEnv()).toBe(false);
+  });
+
+  it("returns false when the environment variable is unset", () => {
+    delete process.env[NO_OMISSION_ENV];
+
+    expect(readNoOmissionFromEnv()).toBe(false);
+  });
+});

--- a/test/core/github-actions-summary.test.ts
+++ b/test/core/github-actions-summary.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGithubActionsFailureSummary } from "../../src/core/github-actions-summary.js";
+
+describe("buildGithubActionsFailureSummary", () => {
+  it("lists every command when noOmit is enabled", () => {
+    const commands = Array.from({ length: 30 }, (_, index) => `echo step-${index}`);
+    const rawText = [
+      "Run bash ./ci.sh",
+      ...commands.map((command) => `  ${command}`),
+      "Error: Process completed with exit code 1.",
+    ].join("\n");
+
+    const summary = buildGithubActionsFailureSummary(
+      {
+        toolName: "exec",
+        command: "custom-tool --emit-gh-log",
+        exitCode: 1,
+      },
+      rawText,
+      true,
+    );
+
+    expect(summary?.text).toContain("- echo step-0");
+    expect(summary?.text).toContain("- echo step-29");
+    expect(summary?.text).not.toContain("commands omitted");
+    expect(summary?.compaction).toEqual({
+      authoritative: false,
+      kinds: ["no-omit-head-tail-passthrough"],
+    });
+  });
+});

--- a/test/core/integrations/compact-bash-result.test.ts
+++ b/test/core/integrations/compact-bash-result.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { compactBashResult } from "../../../src/core/integrations/compact-bash-result.js";
 
 type CompactBashResultOutcome = Awaited<ReturnType<typeof compactBashResult>>;
+const originalNoOmissionEnv = process.env.TOKENJUICE_NO_OMISSION;
 
 function expectRewrite(outcome: CompactBashResultOutcome): Extract<CompactBashResultOutcome, { action: "rewrite" }> {
   expect(outcome.action).toBe("rewrite");
@@ -21,6 +22,14 @@ function expectKeep(outcome: CompactBashResultOutcome): Extract<CompactBashResul
 }
 
 describe("compactBashResult", () => {
+  afterEach(() => {
+    if (originalNoOmissionEnv === undefined) {
+      delete process.env.TOKENJUICE_NO_OMISSION;
+      return;
+    }
+    process.env.TOKENJUICE_NO_OMISSION = originalNoOmissionEnv;
+  });
+
   it("uses trusted full text when provided", async () => {
     const outcome = await compactBashResult({
       source: "pi",
@@ -295,6 +304,60 @@ describe("compactBashResult", () => {
 
     const kept = expectKeep(outcome);
     expect(kept.reason).toBe("generic-compound-command");
+  });
+
+  it("enables noOmit from the environment even when input.noOmit is false", async () => {
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+
+    const outcome = await compactBashResult({
+      source: "codex",
+      command: "git status",
+      visibleText: [
+        "On branch main",
+        "Changes not staged for commit:",
+        ...Array.from({ length: 30 }, (_, index) => `  modified:   src/file-${index}.ts`),
+        "",
+        "no changes added to commit",
+      ].join("\n"),
+      maxInlineChars: 20_000,
+      noOmit: false,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    const rewritten = expectRewrite(outcome);
+    expect(rewritten.result.inlineText).toContain("M: src/file-29.ts");
+    expect(rewritten.result.inlineText).not.toContain("omitted");
+    expect(rewritten.result.compaction?.authoritative).toBe(false);
+  });
+
+  it("enables noOmit from the input flag when the environment is unset", async () => {
+    delete process.env.TOKENJUICE_NO_OMISSION;
+
+    const outcome = await compactBashResult({
+      source: "codex",
+      command: "git status",
+      visibleText: [
+        "On branch main",
+        "Changes not staged for commit:",
+        ...Array.from({ length: 30 }, (_, index) => `  modified:   src/file-${index}.ts`),
+        "",
+        "no changes added to commit",
+      ].join("\n"),
+      maxInlineChars: 20_000,
+      noOmit: true,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    const rewritten = expectRewrite(outcome);
+    expect(rewritten.result.inlineText).toContain("M: src/file-29.ts");
+    expect(rewritten.result.inlineText).not.toContain("omitted");
+    expect(rewritten.result.compaction?.authoritative).toBe(false);
   });
 
 });

--- a/test/core/reduce-inspection-summary.test.ts
+++ b/test/core/reduce-inspection-summary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildInspectionSummary } from "../../src/core/reduce-inspection-summary.js";
+
+describe("buildInspectionSummary", () => {
+  it("keeps the full large document summary content when noOmit is enabled", () => {
+    const longHeading = `## ${"Detailed heading ".repeat(16).trim()}`;
+    const rawText = [
+      "# Review",
+      longHeading,
+      ...Array.from({ length: 60 }, (_, index) => `paragraph ${index} ${"x".repeat(120)}`),
+    ].join("\n");
+
+    const summary = buildInspectionSummary(
+      {
+        toolName: "exec",
+        command: "sed -n '1,260p' notes.txt",
+        argv: ["sed", "-n", "1,260p", "notes.txt"],
+        exitCode: 0,
+      },
+      rawText,
+      true,
+    );
+
+    expect(summary?.matchedReducer).toBe("generic/large-document-summary");
+    expect(summary?.lines.join("\n")).toContain(longHeading);
+    expect(summary?.lines.join("\n")).toContain("paragraph 59");
+    expect(summary?.lines.join("\n")).not.toContain("omitted");
+    expect(summary?.lines.join("\n")).not.toContain("sha256:");
+    expect(summary?.compaction.authoritative).toBe(false);
+    expect(summary?.compaction.kinds).toEqual(expect.arrayContaining([
+      "inspection-large-document-summary",
+      "no-omit-head-tail-passthrough",
+      "no-omit-char-clip-passthrough",
+    ]));
+  });
+});

--- a/test/core/reduce-utils.test.ts
+++ b/test/core/reduce-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { clipMiddleWithHash, compactWholeJsonText } from "../../src/core/reduce-utils.js";
+
+describe("reduce-utils no-omit support", () => {
+  it("returns the full text for clipMiddleWithHash when noOmit is enabled", () => {
+    const text = "x".repeat(300);
+
+    expect(clipMiddleWithHash(text, 60, true)).toEqual({
+      text,
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-char-clip-passthrough"],
+      },
+    });
+  });
+
+  it("returns the full minified JSON when noOmit is enabled", () => {
+    const value = {
+      alpha: "x".repeat(120),
+      nested: {
+        beta: "y".repeat(120),
+      },
+    };
+
+    expect(compactWholeJsonText(JSON.stringify(value, null, 2), 80, true)).toEqual({
+      text: JSON.stringify(value),
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-char-clip-passthrough"],
+      },
+    });
+  });
+});

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -1227,6 +1227,41 @@ describe("reduceExecution", () => {
     });
   });
 
+  it("keeps full git diff content and facts when noOmit is enabled", async () => {
+    const changedLines = Array.from({ length: 30 }, (_, index) => `+const value${index} = "${"x".repeat(300)}";`);
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "git diff -- src/index.ts",
+      argv: ["git", "diff", "--", "src/index.ts"],
+      combinedText: [
+        "diff --git a/src/index.ts b/src/index.ts",
+        "index 1111111..2222222 100644",
+        "--- a/src/index.ts",
+        "+++ b/src/index.ts",
+        "@@ -1,3 +1,33 @@",
+        "-const old = true;",
+        ...changedLines,
+      ].join("\n"),
+      exitCode: 0,
+    }, {
+      noOmit: true,
+      maxInlineChars: 30_000,
+    });
+
+    expect(result.classification.matchedReducer).toBe("git/diff");
+    expect(result.inlineText).toContain("30 added lines");
+    expect(result.inlineText).toContain("1 removed line");
+    expect(result.inlineText).toContain("value29");
+    expect(result.inlineText).not.toContain("hunk clipped");
+    expect(result.inlineText).not.toContain("sha256:");
+    expect(result.inlineText).not.toContain("omitted");
+    expect(result.compaction?.authoritative).toBe(false);
+    expect(result.compaction?.kinds).toEqual(expect.arrayContaining([
+      "no-omit-domain-passthrough",
+      "no-omit-char-clip-passthrough",
+    ]));
+  });
+
   it("clears lossy compaction metadata when passthrough text wins", async () => {
     const rawText = `${Array.from({ length: 13 }, (_, index) => `v${index}`).join("\n")}\n`;
     const result = await reduceExecution({
@@ -1299,6 +1334,71 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("{bug, bug:behavior}");
     expect(result.inlineText).toContain("2026-04-16");
     expect(result.inlineText).not.toContain("\"number\":67473");
+  });
+
+  it("keeps all gh status check attention lines when noOmit is enabled", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh pr view 42 --json statusCheckRollup",
+      argv: ["gh", "pr", "view", "42", "--json", "statusCheckRollup"],
+      combinedText: JSON.stringify({
+        statusCheckRollup: Array.from({ length: 15 }, (_, index) => ({
+          name: `check-${index}`,
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+          workflowName: "ci",
+          detailsUrl: `https://example.com/check-${index}`,
+        })),
+      }),
+      exitCode: 0,
+    }, {
+      noOmit: true,
+      maxInlineChars: 20_000,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("status checks: 0 ok, 15 attention");
+    expect(result.inlineText).toContain("check check-14 [FAILURE]");
+    expect(result.inlineText).not.toContain("attention checks omitted");
+    expect(result.compaction?.authoritative).toBe(false);
+    expect(result.compaction?.kinds).toEqual(expect.arrayContaining(["no-omit-domain-passthrough"]));
+  });
+
+  it("keeps successful gh status checks when noOmit is enabled", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh pr view 42 --json statusCheckRollup",
+      argv: ["gh", "pr", "view", "42", "--json", "statusCheckRollup"],
+      combinedText: JSON.stringify({
+        statusCheckRollup: [
+          {
+            name: "build",
+            status: "COMPLETED",
+            conclusion: "SUCCESS",
+            workflowName: "ci",
+            detailsUrl: "https://example.com/build",
+          },
+          {
+            name: "lint",
+            status: "COMPLETED",
+            conclusion: "FAILURE",
+            workflowName: "ci",
+            detailsUrl: "https://example.com/lint",
+          },
+        ],
+      }),
+      exitCode: 0,
+    }, {
+      noOmit: true,
+      maxInlineChars: 20_000,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("status checks: 1 ok, 1 attention");
+    expect(result.inlineText).toContain("check build [SUCCESS]");
+    expect(result.inlineText).toContain("check lint [FAILURE]");
+    expect(result.compaction?.authoritative).toBe(false);
+    expect(result.compaction?.kinds).toEqual(expect.arrayContaining(["no-omit-domain-passthrough"]));
   });
 
   it("treats ghx as a GitHub CLI drop-in replacement", async () => {
@@ -1942,6 +2042,37 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("non-signal log lines omitted");
     expect(result.inlineText).not.toContain("progress line 0");
     expect(result.compaction).toEqual({ authoritative: true, kinds: ["github-actions-log-signal-filter"] });
+  });
+
+  it("keeps full gh run logs when noOmit is enabled", async () => {
+    const filler = Array.from(
+      { length: 80 },
+      (_, index) =>
+        `checks-node-core\tRun test shard\t2026-04-28T06:34:${String(index % 60).padStart(2, "0")}.000Z\tprogress line ${index}`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "gh run view 25037757449 --repo openclaw/openclaw --log",
+      argv: ["gh", "run", "view", "25037757449", "--log"],
+      combinedText: [
+        ...filler.slice(0, 40),
+        "checks-node-core\tRun test shard\t2026-04-28T06:35:06.000Z\t##[error]test/core/reduce.test.ts(41,7): expected gh log passthrough",
+        "checks-node-core\tRun test shard\t2026-04-28T06:35:07.000Z\tELIFECYCLE Command failed with exit code 2",
+        ...filler.slice(40),
+      ].join("\n"),
+      exitCode: 0,
+    }, {
+      noOmit: true,
+      maxInlineChars: 20_000,
+    });
+
+    expect(result.classification.matchedReducer).toBe("cloud/gh");
+    expect(result.inlineText).toContain("progress line 0");
+    expect(result.inlineText).toContain("progress line 79");
+    expect(result.inlineText).toContain("expected gh log passthrough");
+    expect(result.inlineText).not.toContain("non-signal log lines omitted");
+    expect(result.compaction?.authoritative).toBe(false);
+    expect(result.compaction?.kinds).toEqual(expect.arrayContaining(["no-omit-domain-passthrough"]));
   });
 
   it("filters gh run --log-failed output around explicit error annotations", async () => {

--- a/test/core/text.test.ts
+++ b/test/core/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { clampText, clampTextWithMetadata, countTerminalCells, countTextChars, headTail, stripAnsi } from "../../src/core/text.js";
+import { clampText, clampTextMiddleWithMetadata, clampTextWithMetadata, countTerminalCells, countTextChars, headTail, stripAnsi } from "../../src/core/text.js";
 
 describe("text helpers", () => {
   it("strips xterm colors and OSC hyperlinks while preserving emoji and CJK", () => {
@@ -78,5 +78,41 @@ describe("text helpers", () => {
 
     expect(clamped).toContain("\n... truncated ...");
     expect(clamped).not.toContain("li\n... truncated ...");
+  });
+
+  it("returns all lines when headTail receives noOmit", () => {
+    const lines = Array.from({ length: 12 }, (_, index) => `line ${index}`);
+
+    expect(headTail(lines, 3, 3, true)).toEqual({
+      lines,
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-head-tail-passthrough"],
+      },
+    });
+  });
+
+  it("returns the full text from clampTextWithMetadata when noOmit is enabled", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+
+    expect(clampTextWithMetadata(text, 10, true)).toEqual({
+      text,
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-char-clip-passthrough"],
+      },
+    });
+  });
+
+  it("returns the full text from clampTextMiddleWithMetadata when noOmit is enabled", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+
+    expect(clampTextMiddleWithMetadata(text, 10, true)).toEqual({
+      text,
+      compaction: {
+        authoritative: false,
+        kinds: ["no-omit-char-clip-passthrough"],
+      },
+    });
   });
 });

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -145,4 +145,28 @@ describe("runWrappedCommand", () => {
     expect(wrapped.result.inlineText).toContain("omitted");
     expect(wrapped.result.compaction?.authoritative).toBe(true);
   });
+
+  it("propagates noOmit through wrap without adding lossy omission markers", async () => {
+    const commandLines = Array.from({ length: 30 }, (_, index) => `echo step-${index}`);
+    const outputLines = [
+      "Run bash ./ci.sh",
+      ...commandLines.map((command) => `  ${command}`),
+      "Error: Process completed with exit code 1.",
+    ];
+    const wrapped = await runWrappedCommand([
+      "bash",
+      "-lc",
+      `printf '%s\\n' ${outputLines.map((line) => JSON.stringify(line)).join(" ")}; exit 1`,
+    ], {
+      noOmit: true,
+      maxInlineChars: 20_000,
+    });
+
+    expect(wrapped.exitCode).toBe(1);
+    expect(wrapped.result.inlineText).toContain("- echo step-0");
+    expect(wrapped.result.inlineText).toContain("- echo step-29");
+    expect(wrapped.result.inlineText).not.toContain("commands omitted");
+    expect(wrapped.result.compaction?.authoritative).toBe(false);
+    expect(wrapped.result.inlineText).not.toContain(WRAP_AUTHORITATIVE_FOOTER);
+  });
 });

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -1034,19 +1034,21 @@ describe("runCodexPostToolUseHook", () => {
       skipped?: string;
     };
     const metadata = await listArtifactMetadata();
-    const newMetadata = metadata.find((entry) => !metadataBefore.some((before) => before.id === entry.id));
+    const newMetadata = metadata.filter(
+      (entry) => !metadataBefore.some((before) => before.id === entry.id)
+        && entry.metadata.command === "tokenjuice wrap --raw -- printf 'ok\\n'",
+    );
 
     expect(code).toBe(0);
     expect(output).toBe("");
     expect(debug.rewrote).toBe(false);
     expect(debug.skipped).toBe("explicit-raw-bypass");
-    expect(metadata).toHaveLength(metadataBefore.length + 1);
-    expect(newMetadata?.metadata.command).toBe("tokenjuice wrap --raw -- printf 'ok\\n'");
-    expect(newMetadata?.metadata.rawChars).toBeGreaterThan(0);
-    expect(newMetadata?.metadata.reducedChars).toBe(newMetadata?.metadata.rawChars);
-    expect(newMetadata?.metadata.ratio).toBe(1);
-    expect(newMetadata?.path).toBeUndefined();
-    expect(resolve(dirname(newMetadata!.metadataPath))).toBe(resolve(artifactDir!));
+    expect(newMetadata).toHaveLength(1);
+    expect(newMetadata[0]?.metadata.rawChars).toBeGreaterThan(0);
+    expect(newMetadata[0]?.metadata.reducedChars).toBe(newMetadata[0]?.metadata.rawChars);
+    expect(newMetadata[0]?.metadata.ratio).toBe(1);
+    expect(newMetadata[0]?.path).toBeUndefined();
+    expect(resolve(dirname(newMetadata[0]!.metadataPath))).toBe(resolve(artifactDir!));
     expect(existsSync(join(home, ".tokenjuice", "artifacts"))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Adds a mechanism to suppress all omission/truncation behavior while preserving formatting transformations (stripAnsi, dedupe, filter, rewrite, fact-counting). This gives agent workflows a middle ground between full compaction (default) and `--raw` (which skips everything).

### Motivation

In high-cost agent workflows like OpenClaw auto-review, tokenjuice's omission markers (`... N lines omitted ...`, `... chars omitted ...`) can cause agents to lose critical information that is expensive or impossible to re-acquire. Re-running a full auto-review costs significant time, API calls, and tokens. The existing `--raw` escape hatch is too coarse — it also skips useful formatting like ANSI stripping, deduplication, and structured rewrites. This PR introduces a focused middle ground.

### What this does

- **`TOKENJUICE_NO_OMISSION` env var** — Set to `1`, `true`, `TRUE`, `yes`, or `YES` to enable no-omit mode. Read by the shared helper `readNoOmissionFromEnv()` in `src/core/env.ts`. Host adapters (codex, pi, opencode, openclaw) automatically inherit this via `compactBashResult`.
- **`--no-omit` CLI flag** — For `tokenjuice wrap` and `tokenjuice reduce`. OR-semantics with the env var: either one enables the mode.
- **Pipeline threading** — `noOmit` is threaded through every function that produces omission markers: `headTail`, all clamp/clip functions, domain-level formatters (git diff hunks, GitHub status checks, run logs, command lists), and the inspection summary path.
- **Passthrough compaction metadata** — New `CompactionKind` values (`no-omit-head-tail-passthrough`, `no-omit-char-clip-passthrough`, `no-omit-domain-passthrough`) with `authoritative: false`, so consumers can distinguish "content was preserved" from "content was lost".
- **Authoritative footer suppression** — `WRAP_AUTHORITATIVE_FOOTER` is not appended when `noOmit` is active, since nothing was omitted.
- **Facts always included** — `formatInline` previously gated fact inclusion on `summary.includes("omitted")`. With noOmit active, facts are always included since the omission marker is suppressed.

### Bug fixes included

- **`runWrap` missing noOmit propagation** — `tokenjuice wrap --no-omit` was not passing `noOmit` to `runWrappedCommand`, so the reduce pipeline still applied omissions. Only the footer was suppressed. Now fixed.
- **`buildPackageLockSummary` truncation** — Package sample list was hard-capped at 12 entries regardless of `noOmit`. Now passes `noOmit` through to remove truncation.
- **Redundant clamp removed** — `reduceExecutionWithRules` computed the same clamp twice with identical inputs. Removed the provisional computation.

### Behavior summary

| Mode | Transform | Omit | Footer |
|------|----------|------|--------|
| default | yes | yes | yes (if content lost) |
| `--no-omit` / `TOKENJUICE_NO_OMISSION=1` | yes | **no** | **no** |
| `--raw` | **no** | **no** | **no** |

### Test plan

```bash
pnpm verify  # lint + circular-dep check + typecheck + full vitest suite
```

All 785 tests pass including new coverage for:
- `readNoOmissionFromEnv` (truthy/falsy/unset)
- `headTail`, `clampText*`, `clipMiddleWithHash*` with `noOmit`
- Domain-level suppression (git diff, gh status, gh run log, GitHub Actions)
- `compactBashResult` env var + `input.noOmit`
- `tokenjuice wrap --no-omit` and `tokenjuice reduce --no-omit`
- Inspection summary passthrough