### PR TITLE
feat(qwen-code): add post-tool hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ beta integrations:
 | <img width="48px" src="docs/client-kiro.svg" alt="Kiro" /> | [Kiro](https://kiro.dev/) | `tokenjuice install kiro` | `.kiro/steering/tokenjuice.md` |
 | <img width="48px" src="docs/client-kilo.svg" alt="Kilo Code" /> | [Kilo Code](https://kilocode.ai/) | `tokenjuice install kilo` | `kilo.jsonc` or `.kilo/kilo.jsonc` + `.kilo/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-openhands.svg" alt="OpenHands" /> | [OpenHands](https://docs.openhands.dev/) | `tokenjuice install openhands` | `.openhands/hooks.json` |
+| <img width="48px" src="docs/client-qwen-code.svg" alt="Qwen Code" /> | [Qwen Code](https://qwenlm.github.io/qwen-code-docs/) | `tokenjuice install qwen-code` | `.qwen/settings.json` |
 | <img width="48px" src="docs/client-roo.svg" alt="Roo Code" /> | [Roo Code](https://roocode.com/) | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-windsurf.svg" alt="Windsurf" /> | [Windsurf](https://windsurf.com/) | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" /> | [Zed](https://zed.dev/docs/ai/rules.html) | `tokenjuice install zed` | `.rules` |
@@ -62,8 +63,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -85,9 +86,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -147,6 +148,7 @@ direct payload:
 - [CodeBuddy integration](docs/codebuddy-integration.md)
 - [Kiro integration](docs/kiro-integration.md)
 - [Kilo Code integration](docs/kilo-integration.md)
+- [Qwen Code integration](docs/qwen-code-integration.md)
 - [Roo Code integration](docs/roo-integration.md)
 - [Windsurf integration](docs/windsurf-integration.md)
 - [security](SECURITY.md)

--- a/docs/client-qwen-code.svg
+++ b/docs/client-qwen-code.svg
@@ -1,0 +1,6 @@
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Qwen Code">
+  <rect width="96" height="96" rx="18" fill="#111827"/>
+  <path d="M26 49c0-14 10-24 23-24 14 0 24 10 24 24 0 7-3 14-8 18l8 8h-12l-4-4c-3 1-5 2-8 2-13 0-23-10-23-24Z" fill="#38bdf8"/>
+  <path d="M37 49c0 8 5 14 12 14 2 0 4 0 5-1l-7-7h12l2 2c1-2 2-5 2-8 0-8-6-14-14-14-7 0-12 6-12 14Z" fill="#f8fafc"/>
+  <path d="M22 24h15v7H22v-7Zm37 0h15v7H59v-7ZM22 65h15v7H22v-7Z" fill="#a78bfa"/>
+</svg>

--- a/docs/qwen-code-integration.md
+++ b/docs/qwen-code-integration.md
@@ -1,0 +1,46 @@
+# Qwen Code integration
+
+Qwen Code support is beta.
+
+`tokenjuice install qwen-code` writes a project-local `PostToolUse` command hook
+into `.qwen/settings.json`. The hook matches Qwen Code shell tools
+(`Bash`, `Shell`, and `run_shell_command`) and injects compacted context when
+shell output is noisy.
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+## Install
+
+```bash
+tokenjuice install qwen-code
+tokenjuice doctor qwen-code
+```
+
+For repo-local verification during development:
+
+```bash
+pnpm build
+QWEN_PROJECT_DIR=$(mktemp -d)
+QWEN_PROJECT_DIR=$QWEN_PROJECT_DIR node dist/cli/main.js install qwen-code --local
+QWEN_PROJECT_DIR=$QWEN_PROJECT_DIR node dist/cli/main.js doctor qwen-code --local
+```
+
+## Behavior
+
+- Only `PostToolUse` payloads for shell tool names are considered.
+- Empty output and low-savings reductions are left untouched.
+- Safe repository inventory commands can still be compacted.
+- Exact file-content inspection commands stay raw unless tokenjuice can build a
+  safe summary.
+- Existing `.qwen/settings.json` keys and unrelated hooks are preserved.
+- `QWEN_PROJECT_DIR` can override the workspace root for tests and scripted
+  installs.
+
+## Current beta caveat
+
+Qwen Code `PostToolUse` hooks support adding context after tool execution. This
+integration does not suppress or replace the original shell result; it adds a
+compacted context block so Qwen can prefer the smaller view without losing access
+to the host-owned output path.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -176,15 +176,18 @@ tokenjuice install codebuddy
 tokenjuice install cursor
 tokenjuice install pi
 tokenjuice install opencode
+tokenjuice install qwen-code
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice doctor opencode
+tokenjuice doctor qwen-code
 tokenjuice install codex --local
 tokenjuice install claude-code --local
 tokenjuice install codebuddy --local
 tokenjuice install cursor --local
 tokenjuice install pi --local
 tokenjuice install opencode --local
+tokenjuice install qwen-code --local
 tokenjuice doctor hooks --local
 ```
 
@@ -209,12 +212,13 @@ supported host hooks:
 | OpenCode | `tokenjuice install opencode` | `~/.config/opencode/plugins/tokenjuice.js` | Installs a project-agnostic plugin that is auto-loaded on OpenCode session start; `tokenjuice install opencode --local` bundles the plugin from the current repo source |
 | OpenHands | `tokenjuice install openhands` | `.openhands/hooks.json` | ✴️ Beta. Uses a project-local `PostToolUse` hook for `terminal` output; compacted context is injected alongside the original output; `tokenjuice install openhands --local` is available for repo-local verification; see `docs/openhands-integration.md` |
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
+| Qwen Code | `tokenjuice install qwen-code` | `.qwen/settings.json` | ✴️ Beta. Uses a project-local `PostToolUse` hook for shell tools; compacted context is injected alongside the original output; `tokenjuice install qwen-code --local` is available for repo-local verification; see `docs/qwen-code-integration.md` |
 | Roo Code | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` | ✴️ Beta. Inserts a marker-delimited workspace rule that tells Roo to use `tokenjuice wrap` for noisy `execute_command` terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Roo workspace rules do not intercept tool output; see `docs/roo-integration.md` |
 | VS Code Copilot Chat | `tokenjuice install vscode-copilot` | `~/.copilot/hooks/tokenjuice-vscode.json` | Uses `preToolUse` shell input rewriting on the `run_in_terminal` tool to route commands through `tokenjuice wrap`. Requires `chat.useHooks` enabled and a trusted workspace. Ignores `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the Copilot CLI install. After install, run `tokenjuice doctor vscode-copilot --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, OpenHands, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -40,6 +40,7 @@ import {
 } from "../hosts/opencode/index.js";
 import { doctorOpenHandsHook, installOpenHandsHook, runOpenHandsPostToolUseHook, uninstallOpenHandsHook } from "../hosts/openhands/index.js";
 import { doctorPiExtension, installPiExtension } from "../hosts/pi/index.js";
+import { doctorQwenCodeHook, installQwenCodeHook, runQwenCodePostToolUseHook, uninstallQwenCodeHook } from "../hosts/qwen-code/index.js";
 import { doctorRooInstructions, installRooInstructions, uninstallRooInstructions } from "../hosts/roo/index.js";
 import {
   doctorVscodeCopilotHook,
@@ -115,6 +116,7 @@ function printUsage(): void {
       "  tokenjuice install openhands [--local]",
       "  tokenjuice install pi [--local]",
       "  tokenjuice install opencode [--local]",
+      "  tokenjuice install qwen-code [--local]",
       "  tokenjuice install roo",
       "  tokenjuice install vscode-copilot [--local]",
       "  tokenjuice install copilot-cli [--local]",
@@ -132,6 +134,7 @@ function printUsage(): void {
       "  tokenjuice uninstall kilo",
       "  tokenjuice uninstall openhands",
       "  tokenjuice uninstall opencode",
+      "  tokenjuice uninstall qwen-code",
       "  tokenjuice uninstall roo",
       "  tokenjuice uninstall vscode-copilot",
       "  tokenjuice uninstall copilot-cli",
@@ -141,7 +144,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -734,6 +737,27 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "qwen-code") {
+    const result = await installQwenCodeHook(undefined, { local: args.local });
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Hook", value: result.settingsPath },
+      { label: "Command", value: result.command },
+      { label: "Beta", value: "project-local PostToolUse hook; compacted context is injected alongside original output" },
+      { label: "Verify", value: `tokenjuice doctor qwen-code${args.local ? " --local" : ""}` },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("qwen-code", "hook", details));
+    return 0;
+  }
+
   if (target === "pi") {
     const result = await installPiExtension(undefined, { local: args.local });
     if (args.format === "json") {
@@ -898,7 +922,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, opencode, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1051,6 +1075,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "qwen-code") {
+    const result = await uninstallQwenCodeHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed qwen-code entries: ${result.removed}\n`);
+    process.stdout.write(`settings path: ${result.settingsPath}\n`);
+    process.stdout.write("enable: tokenjuice install qwen-code\n");
+    return 0;
+  }
+
   if (target === "roo") {
     const result = await uninstallRooInstructions();
     if (args.format === "json") {
@@ -1129,7 +1166,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, droid, gemini-cli, junie, kiro, kilo, openhands, opencode, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, droid, gemini-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1448,6 +1485,42 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("issues:\n");
       for (const issue of report.issues) {
         process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "qwen-code") {
+    const report = await doctorQwenCodeHook(undefined, { local: args.local });
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`settings path: ${report.settingsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    process.stdout.write(`expected command: ${report.expectedCommand}\n`);
+    if (report.detectedCommand) {
+      process.stdout.write(`configured command: ${report.detectedCommand}\n`);
+    }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
       }
     }
     process.stdout.write(`repair: ${report.fixCommand}\n`);
@@ -2122,6 +2195,8 @@ async function main(): Promise<number> {
       return await runGeminiCliAfterToolHook(await readStdin(args.maxInputBytes));
     case "openhands-post-tool-use":
       return await runOpenHandsPostToolUseHook(await readStdin(args.maxInputBytes));
+    case "qwen-code-post-tool-use":
+      return await runQwenCodePostToolUseHook(await readStdin(args.maxInputBytes));
     case "vscode-copilot-pre-tool-use":
       return await runVscodeCopilotPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "copilot-cli-post-tool-use":

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -7,7 +7,7 @@ import type { CompactResult, ReduceOptions, ToolExecutionInput } from "../../typ
 import type { InspectionCommandPolicy, InspectionCommandSkipReason } from "../inventory-safety.js";
 
 export type CompactBashResultInput = {
-  source: "claude-code" | "cline" | "codex" | "copilot-cli" | "droid" | "gemini-cli" | "openclaw" | "openhands" | "opencode" | "pi";
+  source: "claude-code" | "cline" | "codex" | "copilot-cli" | "droid" | "gemini-cli" | "openclaw" | "openhands" | "opencode" | "pi" | "qwen-code";
   command: string;
   cwd?: string;
   visibleText: string;

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -46,6 +46,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("pi")) {
     return "pi";
   }
+  if (source.startsWith("qwen")) {
+    return "qwen-code";
+  }
   if (source === "direct" || source === "tokenjuice" || source === "wrap") {
     return DEFAULT_CLI_ARTIFACT_SOURCE;
   }

--- a/src/hosts/qwen-code/index.ts
+++ b/src/hosts/qwen-code/index.ts
@@ -1,0 +1,358 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
+import {
+  buildTokenjuiceHookCommand,
+  type TokenjuiceHookCommandOptions,
+} from "../shared/host-command.js";
+import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
+import { buildCompactedOutputContext, writeEmptyHookJsonLine, writeHookJsonLine } from "../shared/hook-output.js";
+import { isRecord } from "../shared/hooks-json-file.js";
+
+export type QwenCodeHookCommandOptions = TokenjuiceHookCommandOptions & {
+  projectDir?: string;
+};
+
+export type InstallQwenCodeHookResult = {
+  settingsPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+export type UninstallQwenCodeHookResult = {
+  settingsPath: string;
+  removed: number;
+};
+
+export type QwenCodeDoctorReport = {
+  settingsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+type QwenCodeSettings = Record<string, unknown> & {
+  hooks: Record<string, unknown>;
+};
+
+type QwenCodePostToolUsePayload = {
+  hook_event_name?: unknown;
+  hookEventName?: unknown;
+  tool_name?: unknown;
+  toolName?: unknown;
+  tool_input?: unknown;
+  toolInput?: unknown;
+  tool_response?: unknown;
+  toolResponse?: unknown;
+  cwd?: unknown;
+};
+
+const TOKENJUICE_QWEN_CODE_SUBCOMMAND = "qwen-code-post-tool-use";
+const TOKENJUICE_QWEN_CODE_FIX_COMMAND = "tokenjuice install qwen-code";
+const TOKENJUICE_QWEN_CODE_ADVISORY = "Qwen Code support is beta and injects compacted context without suppressing the original tool result.";
+const TOKENJUICE_QWEN_CODE_DISABLED_ADVISORY = "Qwen Code support is beta; verify live PostToolUse behavior after install.";
+
+function getProjectDir(options: QwenCodeHookCommandOptions = {}): string {
+  return options.projectDir || process.env.QWEN_PROJECT_DIR || process.cwd();
+}
+
+function getDefaultSettingsPath(options: QwenCodeHookCommandOptions = {}): string {
+  return join(getProjectDir(options), ".qwen", "settings.json");
+}
+
+function sanitizeQwenCodeSettings(raw: unknown): QwenCodeSettings {
+  if (!isRecord(raw)) {
+    return { hooks: {} };
+  }
+  return {
+    ...raw,
+    hooks: isRecord(raw.hooks) ? { ...raw.hooks } : {},
+  };
+}
+
+async function readQwenCodeSettings(settingsPath: string): Promise<{ config: QwenCodeSettings; exists: boolean }> {
+  try {
+    const rawText = await readFile(settingsPath, "utf8");
+    return { config: sanitizeQwenCodeSettings(JSON.parse(rawText) as unknown), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { hooks: {} }, exists: false };
+    }
+    throw error;
+  }
+}
+
+async function loadQwenCodeSettingsWithBackup(settingsPath: string): Promise<{ config: QwenCodeSettings; backupPath?: string }> {
+  try {
+    const rawText = await readFile(settingsPath, "utf8");
+    const backupPath = `${settingsPath}.bak`;
+    await writeFile(backupPath, rawText, "utf8");
+    return { config: sanitizeQwenCodeSettings(JSON.parse(rawText) as unknown), backupPath };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { hooks: {} } };
+    }
+    throw error;
+  }
+}
+
+async function writeQwenCodeSettings(settingsPath: string, config: QwenCodeSettings): Promise<void> {
+  await mkdir(dirname(settingsPath), { recursive: true });
+  const tempPath = `${settingsPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await rename(tempPath, settingsPath);
+}
+
+function isTokenjuiceQwenCodeHook(entry: unknown): boolean {
+  return isRecord(entry)
+    && typeof entry.command === "string"
+    && entry.command.includes(TOKENJUICE_QWEN_CODE_SUBCOMMAND);
+}
+
+function getPostToolUseHooks(config: QwenCodeSettings): unknown[] {
+  const postToolUse = config.hooks.PostToolUse;
+  return Array.isArray(postToolUse) ? postToolUse : [];
+}
+
+function findTokenjuiceQwenCodeHookCommand(config: QwenCodeSettings): string | undefined {
+  for (const group of getPostToolUseHooks(config)) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      continue;
+    }
+    for (const hook of group.hooks) {
+      if (isTokenjuiceQwenCodeHook(hook)) {
+        return (hook as { command: string }).command;
+      }
+    }
+  }
+  return undefined;
+}
+
+function removeTokenjuiceQwenCodeHooks(config: QwenCodeSettings): number {
+  let removed = 0;
+  const retainedGroups: unknown[] = [];
+  for (const group of getPostToolUseHooks(config)) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      retainedGroups.push(group);
+      continue;
+    }
+    const retainedHooks = group.hooks.filter((hook) => {
+      const remove = isTokenjuiceQwenCodeHook(hook);
+      if (remove) {
+        removed += 1;
+      }
+      return !remove;
+    });
+    if (retainedHooks.length > 0) {
+      retainedGroups.push({ ...group, hooks: retainedHooks });
+    }
+  }
+  config.hooks.PostToolUse = retainedGroups;
+  return removed;
+}
+
+function createQwenCodeHook(command: string): Record<string, unknown> {
+  return {
+    matcher: "^(Bash|Shell|run_shell_command)$",
+    sequential: true,
+    hooks: [
+      {
+        type: "command",
+        name: "tokenjuice",
+        command,
+        timeout: 60000,
+        description: "Inject compacted context for noisy shell output after Qwen Code runs a command.",
+      },
+    ],
+  };
+}
+
+export async function installQwenCodeHook(
+  settingsPath?: string,
+  options: QwenCodeHookCommandOptions = {},
+): Promise<InstallQwenCodeHookResult> {
+  const resolvedSettingsPath = settingsPath ?? getDefaultSettingsPath(options);
+  const { config, backupPath } = await loadQwenCodeSettingsWithBackup(resolvedSettingsPath);
+  const command = await buildTokenjuiceHookCommand(TOKENJUICE_QWEN_CODE_SUBCOMMAND, "qwen-code", options);
+  removeTokenjuiceQwenCodeHooks(config);
+  config.hooks.PostToolUse = [...getPostToolUseHooks(config), createQwenCodeHook(command)];
+  await writeQwenCodeSettings(resolvedSettingsPath, config);
+  return {
+    settingsPath: resolvedSettingsPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+export async function uninstallQwenCodeHook(
+  settingsPath?: string,
+  options: QwenCodeHookCommandOptions = {},
+): Promise<UninstallQwenCodeHookResult> {
+  const resolvedSettingsPath = settingsPath ?? getDefaultSettingsPath(options);
+  const { config } = await readQwenCodeSettings(resolvedSettingsPath);
+  const removed = removeTokenjuiceQwenCodeHooks(config);
+  if (removed > 0) {
+    await writeQwenCodeSettings(resolvedSettingsPath, config);
+  }
+  return { settingsPath: resolvedSettingsPath, removed };
+}
+
+export async function doctorQwenCodeHook(
+  settingsPath?: string,
+  options: QwenCodeHookCommandOptions = {},
+): Promise<QwenCodeDoctorReport> {
+  const resolvedSettingsPath = settingsPath ?? getDefaultSettingsPath(options);
+  const expectedCommand = await buildTokenjuiceHookCommand(TOKENJUICE_QWEN_CODE_SUBCOMMAND, "qwen-code", options);
+  const { config, exists } = await readQwenCodeSettings(resolvedSettingsPath);
+  const detectedCommand = findTokenjuiceQwenCodeHookCommand(config);
+  const fields = await buildHookCommandDoctorFields({
+    expectedCommand,
+    detectedCommand: exists ? detectedCommand : undefined,
+    disabledIssue: "tokenjuice PostToolUse hook is not installed for Qwen Code",
+    hostLabel: "Qwen Code",
+    advisory: detectedCommand ? TOKENJUICE_QWEN_CODE_ADVISORY : TOKENJUICE_QWEN_CODE_DISABLED_ADVISORY,
+    fixCommand: TOKENJUICE_QWEN_CODE_FIX_COMMAND,
+  });
+
+  if (detectedCommand && config.disableAllHooks === true) {
+    return {
+      settingsPath: resolvedSettingsPath,
+      ...fields,
+      status: "broken",
+      issues: [...fields.issues, "Qwen Code has disableAllHooks enabled; configured hooks will not run"],
+    };
+  }
+
+  return {
+    settingsPath: resolvedSettingsPath,
+    ...fields,
+  };
+}
+
+function readStringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readNestedStringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      const text = value.map(readQwenCodeOutputText).filter(Boolean).join("\n");
+      if (text.trim()) {
+        return text;
+      }
+    }
+  }
+  return undefined;
+}
+
+function readQwenCodeOutputText(response: unknown): string {
+  if (typeof response === "string") {
+    return response;
+  }
+  if (Array.isArray(response)) {
+    return response.map(readQwenCodeOutputText).filter(Boolean).join("\n");
+  }
+  if (!isRecord(response)) {
+    return "";
+  }
+  const direct = readNestedStringField(response, ["llmContent", "returnDisplay", "text", "content", "output", "result", "stdout"]);
+  if (direct) {
+    return direct;
+  }
+  if (isRecord(response.result)) {
+    return readQwenCodeOutputText(response.result);
+  }
+  return "";
+}
+
+function readPositiveIntegerEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readPayloadField(payload: QwenCodePostToolUsePayload, snakeKey: keyof QwenCodePostToolUsePayload, camelKey: keyof QwenCodePostToolUsePayload): unknown {
+  return payload[snakeKey] ?? payload[camelKey];
+}
+
+export async function runQwenCodePostToolUseHook(rawText: string): Promise<number> {
+  let payload: QwenCodePostToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as QwenCodePostToolUsePayload;
+  } catch {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  const hookEventName = readPayloadField(payload, "hook_event_name", "hookEventName");
+  const toolName = readPayloadField(payload, "tool_name", "toolName");
+  if (
+    (typeof hookEventName === "string" && hookEventName !== "PostToolUse")
+    || (toolName !== "Bash" && toolName !== "Shell" && toolName !== "run_shell_command")
+  ) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  const toolInputValue = readPayloadField(payload, "tool_input", "toolInput");
+  const toolInput = isRecord(toolInputValue) ? toolInputValue : undefined;
+  const command = toolInput ? readStringField(toolInput, ["command", "cmd"]) : undefined;
+  const visibleText = readQwenCodeOutputText(readPayloadField(payload, "tool_response", "toolResponse"));
+  if (!command || !visibleText.trim()) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  try {
+    const maxInlineChars = readPositiveIntegerEnv("TOKENJUICE_QWEN_CODE_MAX_INLINE_CHARS");
+    const outcome = await compactBashResult({
+      source: "qwen-code",
+      command,
+      visibleText,
+      ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
+      ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
+      inspectionPolicy: "allow-safe-inventory",
+      metadata: { source: "qwen-code-post-tool-use" },
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    if (outcome.action === "keep") {
+      writeEmptyHookJsonLine();
+      return 0;
+    }
+
+    writeHookJsonLine({
+      decision: "allow",
+      reason: "tokenjuice compacted noisy shell output",
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: buildCompactedOutputContext(outcome.result.inlineText),
+      },
+    });
+    return 0;
+  } catch {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -14,6 +14,7 @@ import { doctorKiroSteering } from "../kiro/index.js";
 import { doctorKiloRule } from "../kilo/index.js";
 import { doctorOpenHandsHook } from "../openhands/index.js";
 import { doctorPiExtension } from "../pi/index.js";
+import { doctorQwenCodeHook } from "../qwen-code/index.js";
 import { doctorRooInstructions } from "../roo/index.js";
 import { doctorVscodeCopilotHook } from "../vscode-copilot/index.js";
 import { doctorWindsurfRule } from "../windsurf/index.js";
@@ -35,6 +36,7 @@ import type { KiroDoctorReport } from "../kiro/index.js";
 import type { KiloDoctorReport } from "../kilo/index.js";
 import type { OpenHandsDoctorReport } from "../openhands/index.js";
 import type { PiDoctorReport } from "../pi/index.js";
+import type { QwenCodeDoctorReport, QwenCodeHookCommandOptions } from "../qwen-code/index.js";
 import type { RooDoctorReport } from "../roo/index.js";
 import type { VscodeCopilotDoctorReport } from "../vscode-copilot/index.js";
 import type { WindsurfDoctorReport } from "../windsurf/index.js";
@@ -58,6 +60,7 @@ export type HookIntegrationDoctorReport = {
   kilo: KiloDoctorReport;
   openhands: OpenHandsDoctorReport;
   pi: PiDoctorReport;
+  "qwen-code": QwenCodeDoctorReport;
   roo: RooDoctorReport;
   "vscode-copilot": VscodeCopilotDoctorReport;
   windsurf: WindsurfDoctorReport;
@@ -70,7 +73,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions;
+export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions & QwenCodeHookCommandOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -97,6 +100,7 @@ const hookDoctorIntegrationDoctors = {
   kilo: () => doctorKiloRule(),
   openhands: (options) => doctorOpenHandsHook(undefined, getHookCommandOptions(options)),
   pi: () => doctorPiExtension(),
+  "qwen-code": (options) => doctorQwenCodeHook(undefined, options),
   roo: () => doctorRooInstructions(),
   "vscode-copilot": (options) => doctorVscodeCopilotHook(undefined, getHookCommandOptions(options)),
   windsurf: () => doctorWindsurfRule(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export {
   installOpenCodeExtension,
   uninstallOpenCodeExtension,
 } from "./hosts/opencode/index.js";
+export { doctorQwenCodeHook, installQwenCodeHook, runQwenCodePostToolUseHook, uninstallQwenCodeHook } from "./hosts/qwen-code/index.js";
 export { runReduceJsonCli } from "./core/cli-client.js";
 export { clearFixtureCache, loadBuiltinFixtures, verifyBuiltinFixtures } from "./core/fixtures.js";
 export { parseReduceJsonRequest } from "./core/json-protocol.js";
@@ -143,6 +144,12 @@ export type {
   OpenHandsHookCommandOptions,
   UninstallOpenHandsHookResult,
 } from "./hosts/openhands/index.js";
+export type {
+  InstallQwenCodeHookResult,
+  QwenCodeDoctorReport,
+  QwenCodeHookCommandOptions,
+  UninstallQwenCodeHookResult,
+} from "./hosts/qwen-code/index.js";
 export type {
   InstallRooInstructionsResult,
   RooDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -12,6 +12,7 @@ import {
   installCodexHook,
   installCursorHook,
   installPiExtension,
+  installQwenCodeHook,
   runClaudeCodePostToolUseHook,
   runClaudeCodePreToolUseHook,
 } from "../../src/index.js";
@@ -688,12 +689,19 @@ describe("doctorInstalledHooks", () => {
       binaryPath: localBinaryPath,
       nodePath: localNodePath,
     });
+    await installQwenCodeHook(undefined, {
+      projectDir: home,
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+    });
     await installPiExtension(undefined, { local: true });
 
     const report = await doctorInstalledHooks({
       local: true,
       binaryPath: localBinaryPath,
       nodePath: localNodePath,
+      projectDir: home,
       featureFlagConfigPath: join(codexHome, "config.toml"),
     });
 
@@ -702,11 +710,13 @@ describe("doctorInstalledHooks", () => {
     expect(report.integrations["claude-code"].status).toBe("ok");
     expect(report.integrations.codebuddy.status).toBe("ok");
     expect(report.integrations.cursor.status).toBe("ok");
+    expect(report.integrations["qwen-code"].status).toBe("ok");
     expect(report.integrations.pi.status).toBe("ok");
     expect(report.integrations.codex.expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations["claude-code"].expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations.codebuddy.expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations.cursor.expectedCommand).toContain(expectedHookPrefix);
+    expect(report.integrations["qwen-code"].expectedCommand).toContain(expectedHookPrefix);
   });
 });
 

--- a/test/hosts/qwen-code.test.ts
+++ b/test/hosts/qwen-code.test.ts
@@ -1,0 +1,225 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorQwenCodeHook,
+  installQwenCodeHook,
+  runQwenCodePostToolUseHook,
+  uninstallQwenCodeHook,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalProjectDir = process.env.QWEN_PROJECT_DIR;
+
+afterEach(async () => {
+  if (originalProjectDir === undefined) {
+    delete process.env.QWEN_PROJECT_DIR;
+  } else {
+    process.env.QWEN_PROJECT_DIR = originalProjectDir;
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-qwen-code-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("qwen-code hooks", () => {
+  it("installs a PostToolUse hook into project Qwen Code settings", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, ".qwen", "settings.json");
+    const launcherPath = join(home, "bin", "tokenjuice");
+    await mkdir(join(home, ".qwen"), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      selectedAuthType: "openai",
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "ReadFile",
+            hooks: [{ type: "command", command: "other-hook" }],
+          },
+        ],
+      },
+    }));
+
+    const result = await installQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      selectedAuthType: string;
+      hooks: { PostToolUse: Array<{ matcher: string; hooks: Array<{ command: string; name?: string }> }> };
+    };
+
+    await expect(access(`${settingsPath}.bak`)).resolves.toBeUndefined();
+    expect(result.settingsPath).toBe(settingsPath);
+    expect(result.command).toBe(`${launcherPath} qwen-code-post-tool-use`);
+    expect(result.backupPath).toBe(`${settingsPath}.bak`);
+    expect(parsed.selectedAuthType).toBe("openai");
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("^(Bash|Shell|run_shell_command)$");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.name).toBe("tokenjuice");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toBe(`${launcherPath} qwen-code-post-tool-use`);
+  });
+
+  it("reports installed and uninstalled hook health", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, ".qwen", "settings.json");
+    const launcherPath = join(home, "tokenjuice");
+    await mkdir(join(home, ".qwen"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    await installQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+    const installed = await doctorQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+
+    expect(installed.status).toBe("ok");
+    expect(installed.detectedCommand).toBe(`${launcherPath} qwen-code-post-tool-use`);
+    expect(installed.advisories[0]).toContain("beta");
+
+    const removed = await uninstallQwenCodeHook(settingsPath);
+    const disabled = await doctorQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+
+    expect(removed.removed).toBe(1);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken health when Qwen Code hooks are globally disabled", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, ".qwen", "settings.json");
+    const launcherPath = join(home, "tokenjuice");
+    await mkdir(join(home, ".qwen"), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({ disableAllHooks: true, hooks: {} }), "utf8");
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    await installQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+    const doctor = await doctorQwenCodeHook(settingsPath, { binaryPath: launcherPath, local: true });
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("Qwen Code has disableAllHooks enabled; configured hooks will not run");
+  });
+
+  it("uses QWEN_PROJECT_DIR for the default project-local settings file", async () => {
+    const home = await createTempDir();
+    process.env.QWEN_PROJECT_DIR = home;
+
+    const installed = await installQwenCodeHook(undefined, { local: true });
+    const expectedSettingsPath = join(home, ".qwen", "settings.json");
+    const doctor = await doctorQwenCodeHook(undefined, { local: true });
+
+    expect(installed.settingsPath).toBe(expectedSettingsPath);
+    expect(doctor.settingsPath).toBe(expectedSettingsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("uses projectDir when uninstalling the default project-local settings file", async () => {
+    const home = await createTempDir();
+    const expectedSettingsPath = join(home, ".qwen", "settings.json");
+
+    await installQwenCodeHook(undefined, { projectDir: home, local: true });
+    const removed = await uninstallQwenCodeHook(undefined, { projectDir: home, local: true });
+    const parsed = JSON.parse(await readFile(expectedSettingsPath, "utf8")) as { hooks: { PostToolUse: unknown[] } };
+
+    expect(removed.settingsPath).toBe(expectedSettingsPath);
+    expect(removed.removed).toBe(1);
+    expect(parsed.hooks.PostToolUse).toEqual([]);
+  });
+
+  it("injects compacted context for noisy Bash output", async () => {
+    const payload = JSON.stringify({
+      tool_name: "Bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "git status",
+      },
+      tool_response: {
+        llmContent: [
+          "On branch pr-65478-security-fix",
+          "Your branch and 'origin/pr-65478-security-fix' have diverged,",
+          "and have 8 and 642 different commits each, respectively.",
+          "",
+          "Changes not staged for commit:",
+          "\tmodified:   src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts",
+          "\tmodified:   src/agents/pi-embedded-runner/run/attempt.test.ts",
+          "",
+          "no changes added to commit",
+        ].join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runQwenCodePostToolUseHook(payload));
+    const response = JSON.parse(output) as {
+      decision?: string;
+      reason?: string;
+      hookSpecificOutput?: {
+        hookEventName?: string;
+        additionalContext?: string;
+      };
+    };
+
+    expect(code).toBe(0);
+    expect(response.decision).toBe("allow");
+    expect(response.reason).toContain("tokenjuice compacted");
+    expect(response.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("Changes not staged:");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
+    expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
+  });
+
+  it("accepts camelCase payload fields and run_shell_command aliases", async () => {
+    const payload = JSON.stringify({
+      hookEventName: "PostToolUse",
+      toolName: "run_shell_command",
+      toolInput: {
+        cmd: "git status",
+      },
+      toolResponse: {
+        output: [
+          "Changes not staged for commit:",
+          "\tmodified:   README.md",
+          "\tmodified:   docs/spec.md",
+          "no changes added to commit",
+        ].join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runQwenCodePostToolUseHook(payload));
+    const response = JSON.parse(output) as { hookSpecificOutput?: { additionalContext?: string } };
+
+    expect(code).toBe(0);
+    expect(response.hookSpecificOutput?.additionalContext).toContain("M: README.md");
+    expect(response.hookSpecificOutput?.additionalContext).toContain("M: docs/spec.md");
+  });
+
+  it("keeps unrelated hook payloads silent", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "ReadFile",
+      tool_input: { path: "README.md" },
+      tool_response: { llmContent: "hello" },
+    });
+
+    const { code, output } = await captureStdout(() => runQwenCodePostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add beta Qwen Code integration that writes a project-local `PostToolUse` hook into `.qwen/settings.json`
- inject compacted shell-output context for Bash/Shell/run_shell_command without suppressing the original tool result
- wire install/uninstall/doctor, aggregate hook doctor, source normalization, public exports, docs, and tests
- handle projectDir-aware doctor/uninstall and flag `disableAllHooks: true` as broken because configured hooks will not run

Stacked on https://github.com/vincentkoc/tokenjuice/pull/113.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run test/hosts/qwen-code.test.ts test/hosts/kiro.test.ts test/hosts/claude-code.test.ts test/cli/doctor-output.test.ts test/core/artifacts.test.ts`
- `pnpm build`
- built CLI smoke: `install qwen-code --local`, settings file check, `doctor qwen-code --local`, `uninstall qwen-code`, disabled doctor
- built CLI hook smoke: `qwen-code-post-tool-use` with a `PostToolUse` Bash payload emits compacted `additionalContext`
- `git diff --check origin/feat/kiro-integration...HEAD`
- privacy scan over changed files for local paths, private IPs, and emails
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/feat/kiro-integration --prompt <Qwen Code hook docs context> --parallel-tests "pnpm lint && pnpm exec vitest run test/hosts/qwen-code.test.ts test/hosts/kiro.test.ts test/hosts/claude-code.test.ts test/cli/doctor-output.test.ts test/core/artifacts.test.ts"`

## Review Notes
- accepted and fixed autoreview finding: aggregate hook doctor now preserves Qwen `projectDir`
- accepted and fixed autoreview finding: Qwen doctor reports `disableAllHooks: true` as broken when the tokenjuice hook is configured
- final autoreview result: clean, no accepted/actionable findings

## Qwen rebase proof
- Rebased onto main after #113 merged and retargeted this PR to main.
- Refreshed proof: pnpm exec vitest run test/hosts/qwen-code.test.ts test/cli/doctor-output.test.ts && pnpm typecheck.
- Autoreview clean: .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main.