### PR TITLE
feat(grok-cli): add post-tool hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ beta integrations:
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
+| <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
 | <img width="48px" src="docs/client-junie.svg" alt="Junie" /> | [Junie](https://junie.jetbrains.com/docs/junie-cli-usage.html) | `tokenjuice install junie` | `.junie/AGENTS.md` |
 | <img width="48px" src="docs/client-kiro.svg" alt="Kiro" /> | [Kiro](https://kiro.dev/) | `tokenjuice install kiro` | `.kiro/steering/tokenjuice.md` |
 | <img width="48px" src="docs/client-kilo.svg" alt="Kilo Code" /> | [Kilo Code](https://kilocode.ai/) | `tokenjuice install kilo` | `kilo.jsonc` or `.kilo/kilo.jsonc` + `.kilo/rules/tokenjuice.md` |
@@ -63,8 +64,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -86,9 +87,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -146,6 +147,7 @@ direct payload:
 - [integration playbook](docs/integration-playbook.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)
+- [Grok CLI integration](docs/grok-cli-integration.md)
 - [Kiro integration](docs/kiro-integration.md)
 - [Kilo Code integration](docs/kilo-integration.md)
 - [Qwen Code integration](docs/qwen-code-integration.md)

--- a/docs/client-grok-cli.svg
+++ b/docs/client-grok-cli.svg
@@ -1,0 +1,5 @@
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Grok CLI">
+  <rect width="96" height="96" rx="18" fill="#0f172a"/>
+  <path d="M27 49c0-15 11-25 26-25 8 0 15 3 20 8l-7 7c-3-3-8-5-13-5-9 0-16 6-16 15 0 8 6 14 15 14 7 0 12-3 14-9H51v-9h26v5c0 14-10 23-25 23-14 0-25-10-25-24Z" fill="#f8fafc"/>
+  <path d="M20 24h17v8H20v-8Zm0 40h17v8H20v-8Zm46-40h10v48H66V24Z" fill="#22c55e"/>
+</svg>

--- a/docs/grok-cli-integration.md
+++ b/docs/grok-cli-integration.md
@@ -1,0 +1,47 @@
+# Grok CLI integration
+
+Grok CLI support is beta.
+
+`tokenjuice install grok-cli` writes a user-level `PostToolUse` command hook
+into `~/.grok/user-settings.json`. Grok CLI loads hooks only from user settings,
+so tokenjuice does not install hooks into the repo-local `.grok/settings.json`.
+
+The hook matches the `bash` tool and injects compacted context when shell output
+is noisy:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+## Install
+
+```bash
+tokenjuice install grok-cli
+tokenjuice doctor grok-cli
+```
+
+For repo-local verification during development:
+
+```bash
+pnpm build
+HOME=$(mktemp -d)
+HOME=$HOME node dist/cli/main.js install grok-cli --local
+HOME=$HOME node dist/cli/main.js doctor grok-cli --local
+```
+
+## Behavior
+
+- Only successful `PostToolUse` payloads for Grok CLI's `bash` tool are
+  considered.
+- Empty output and low-savings reductions are left untouched.
+- Safe repository inventory commands can still be compacted.
+- Exact file-content inspection commands stay raw unless tokenjuice can build a
+  safe summary.
+- Existing `~/.grok/user-settings.json` keys and unrelated hooks are preserved.
+
+## Current beta caveat
+
+Grok CLI `PostToolUse` hooks expose `additionalContext`. This integration does
+not suppress or replace the original shell result; it adds a compacted context
+block so Grok can prefer the smaller view without losing access to the
+host-owned output path.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -174,17 +174,20 @@ tokenjuice install codex
 tokenjuice install claude-code
 tokenjuice install codebuddy
 tokenjuice install cursor
+tokenjuice install grok-cli
 tokenjuice install pi
 tokenjuice install opencode
 tokenjuice install qwen-code
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice doctor opencode
+tokenjuice doctor grok-cli
 tokenjuice doctor qwen-code
 tokenjuice install codex --local
 tokenjuice install claude-code --local
 tokenjuice install codebuddy --local
 tokenjuice install cursor --local
+tokenjuice install grok-cli --local
 tokenjuice install pi --local
 tokenjuice install opencode --local
 tokenjuice install qwen-code --local
@@ -205,6 +208,7 @@ supported host hooks:
 | Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; `tokenjuice install cursor --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
 | Droid (Factory CLI) | `tokenjuice install droid` | `~/.factory/settings.json` | Uses a `PostToolUse` hook for the `Execute` tool to compact shell output before Droid sees it; preserves unrelated settings keys; `tokenjuice install droid --local` is available for repo-local verification |
 | Gemini CLI | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` | ✴️ Beta. Uses an `AfterTool` hook for `run_shell_command` to compact shell output before Gemini CLI sees it; `tokenjuice install gemini-cli --local` is available for repo-local verification; see `docs/gemini-cli-integration.md` |
+| Grok CLI | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` | ✴️ Beta. Uses a user-level `PostToolUse` hook for the `bash` tool; compacted context is injected alongside the original output; `tokenjuice install grok-cli --local` is available for repo-local verification; see `docs/grok-cli-integration.md` |
 | GitHub Copilot CLI | `tokenjuice install copilot-cli` | `~/.copilot/hooks/tokenjuice-cli.json` | Uses `postToolUse` shell output rewriting on the `bash` tool (matcher `"shell"`) to compact command output before it returns to the agent. Honors `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the VS Code Copilot Chat install. After install, run `tokenjuice doctor copilot-cli --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |
 | Junie | `tokenjuice install junie` | `.junie/AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block that tells Junie to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Junie instructions do not intercept tool output; see `docs/junie-integration.md` |
 | Kiro | `tokenjuice install kiro` | `.kiro/steering/tokenjuice.md` | ✴️ Beta. Installs an always-included steering file that tells Kiro to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Kiro hooks do not replace terminal command output; see `docs/kiro-integration.md` |
@@ -218,7 +222,7 @@ supported host hooks:
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -30,6 +30,7 @@ import {
 import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../hosts/cursor/index.js";
 import { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "../hosts/droid/index.js";
 import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "../hosts/gemini-cli/index.js";
+import { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "../hosts/grok-cli/index.js";
 import { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "../hosts/junie/index.js";
 import { doctorKiroSteering, installKiroSteering, uninstallKiroSteering } from "../hosts/kiro/index.js";
 import { doctorKiloRule, installKiloRule, uninstallKiloRule } from "../hosts/kilo/index.js";
@@ -110,6 +111,7 @@ function printUsage(): void {
       "  tokenjuice install cursor [--local]",
       "  tokenjuice install droid [--local]",
       "  tokenjuice install gemini-cli [--local]",
+      "  tokenjuice install grok-cli [--local]",
       "  tokenjuice install junie",
       "  tokenjuice install kiro",
       "  tokenjuice install kilo",
@@ -129,6 +131,7 @@ function printUsage(): void {
       "  tokenjuice uninstall continue",
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall gemini-cli",
+      "  tokenjuice uninstall grok-cli",
       "  tokenjuice uninstall junie",
       "  tokenjuice uninstall kiro",
       "  tokenjuice uninstall kilo",
@@ -144,7 +147,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -652,6 +655,27 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "grok-cli") {
+    const result = await installGrokCliHook(undefined, { local: args.local });
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Hook", value: result.settingsPath },
+      { label: "Command", value: result.command },
+      { label: "Beta", value: "user-level PostToolUse hook; compacted context is injected alongside original output" },
+      { label: "Verify", value: `tokenjuice doctor grok-cli${args.local ? " --local" : ""}` },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("grok-cli", "hook", details));
+    return 0;
+  }
+
   if (target === "junie") {
     const result = await installJunieInstructions();
     if (args.format === "json") {
@@ -922,7 +946,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1005,6 +1029,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed gemini-cli entries: ${result.removed}\n`);
     process.stdout.write(`settings path: ${result.settingsPath}\n`);
     process.stdout.write("enable: tokenjuice install gemini-cli\n");
+    return 0;
+  }
+
+  if (target === "grok-cli") {
+    const result = await uninstallGrokCliHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed grok-cli entries: ${result.removed}\n`);
+    process.stdout.write(`settings path: ${result.settingsPath}\n`);
+    process.stdout.write("enable: tokenjuice install grok-cli\n");
     return 0;
   }
 
@@ -1166,7 +1203,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, droid, gemini-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1559,6 +1596,42 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
 
   if (args.positionals[0] === "gemini-cli") {
     const report = await doctorGeminiCliHook(undefined, { local: args.local });
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`settings path: ${report.settingsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    process.stdout.write(`expected command: ${report.expectedCommand}\n`);
+    if (report.detectedCommand) {
+      process.stdout.write(`configured command: ${report.detectedCommand}\n`);
+    }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "grok-cli") {
+    const report = await doctorGrokCliHook(undefined, { local: args.local });
 
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -2193,6 +2266,8 @@ async function main(): Promise<number> {
       return await runCursorPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "gemini-cli-after-tool":
       return await runGeminiCliAfterToolHook(await readStdin(args.maxInputBytes));
+    case "grok-cli-post-tool-use":
+      return await runGrokCliPostToolUseHook(await readStdin(args.maxInputBytes));
     case "openhands-post-tool-use":
       return await runOpenHandsPostToolUseHook(await readStdin(args.maxInputBytes));
     case "qwen-code-post-tool-use":

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -7,7 +7,7 @@ import type { CompactResult, ReduceOptions, ToolExecutionInput } from "../../typ
 import type { InspectionCommandPolicy, InspectionCommandSkipReason } from "../inventory-safety.js";
 
 export type CompactBashResultInput = {
-  source: "claude-code" | "cline" | "codex" | "copilot-cli" | "droid" | "gemini-cli" | "openclaw" | "openhands" | "opencode" | "pi" | "qwen-code";
+  source: "claude-code" | "cline" | "codex" | "copilot-cli" | "droid" | "gemini-cli" | "grok-cli" | "openclaw" | "openhands" | "opencode" | "pi" | "qwen-code";
   command: string;
   cwd?: string;
   visibleText: string;

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -34,6 +34,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("gemini")) {
     return "gemini-cli";
   }
+  if (source.startsWith("grok")) {
+    return "grok-cli";
+  }
   if (source.startsWith("openclaw")) {
     return "openclaw";
   }

--- a/src/hosts/grok-cli/index.ts
+++ b/src/hosts/grok-cli/index.ts
@@ -1,0 +1,336 @@
+import { constants as fsConstants } from "node:fs";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { stripLeadingCdPrefix } from "../../core/command.js";
+import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
+import {
+  buildTokenjuiceHookCommand,
+  type TokenjuiceHookCommandOptions,
+} from "../shared/host-command.js";
+import { isTokenjuiceExecutablePath, parseShellWords } from "../shared/hook-command.js";
+import { buildHookCommandDoctorFields } from "../shared/hook-command-doctor.js";
+import { buildCompactedOutputContext, writeEmptyHookJsonLine, writeHookJsonLine } from "../shared/hook-output.js";
+import { isRecord } from "../shared/hooks-json-file.js";
+
+export type GrokCliHookCommandOptions = TokenjuiceHookCommandOptions;
+
+export type InstallGrokCliHookResult = {
+  settingsPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+export type UninstallGrokCliHookResult = {
+  settingsPath: string;
+  removed: number;
+};
+
+export type GrokCliDoctorReport = {
+  settingsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+type GrokCliUserSettings = Record<string, unknown> & {
+  hooks: Record<string, unknown>;
+};
+
+type GrokCliPostToolUsePayload = {
+  hook_event_name?: unknown;
+  tool_name?: unknown;
+  tool_input?: unknown;
+  tool_output?: unknown;
+  cwd?: unknown;
+};
+
+const TOKENJUICE_GROK_CLI_SUBCOMMAND = "grok-cli-post-tool-use";
+const TOKENJUICE_GROK_CLI_FIX_COMMAND = "tokenjuice install grok-cli";
+const TOKENJUICE_GROK_CLI_ADVISORY = "Grok CLI support is beta and injects compacted context without suppressing the original tool result.";
+const TOKENJUICE_GROK_CLI_DISABLED_ADVISORY = "Grok CLI support is beta; verify live PostToolUse behavior after install.";
+
+function getDefaultSettingsPath(): string {
+  return join(homedir(), ".grok", "user-settings.json");
+}
+
+function sanitizeGrokCliSettings(raw: unknown): GrokCliUserSettings {
+  if (!isRecord(raw)) {
+    return { hooks: {} };
+  }
+  return {
+    ...raw,
+    hooks: isRecord(raw.hooks) ? { ...raw.hooks } : {},
+  };
+}
+
+async function readGrokCliSettings(settingsPath: string): Promise<{ config: GrokCliUserSettings; exists: boolean }> {
+  try {
+    const rawText = await readFile(settingsPath, "utf8");
+    return { config: sanitizeGrokCliSettings(JSON.parse(rawText) as unknown), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { hooks: {} }, exists: false };
+    }
+    throw error;
+  }
+}
+
+async function loadGrokCliSettingsWithBackup(settingsPath: string): Promise<{ config: GrokCliUserSettings; backupPath?: string }> {
+  try {
+    const rawText = await readFile(settingsPath, "utf8");
+    const backupPath = `${settingsPath}.bak`;
+    await writeFile(backupPath, rawText, { encoding: "utf8", mode: fsConstants.S_IRUSR | fsConstants.S_IWUSR });
+    return { config: sanitizeGrokCliSettings(JSON.parse(rawText) as unknown), backupPath };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: { hooks: {} } };
+    }
+    throw error;
+  }
+}
+
+async function writeGrokCliSettings(settingsPath: string, config: GrokCliUserSettings): Promise<void> {
+  await mkdir(dirname(settingsPath), { recursive: true, mode: fsConstants.S_IRWXU });
+  const tempPath = `${settingsPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: fsConstants.S_IRUSR | fsConstants.S_IWUSR,
+  });
+  await rename(tempPath, settingsPath);
+  await chmod(settingsPath, fsConstants.S_IRUSR | fsConstants.S_IWUSR);
+}
+
+function isTokenjuiceGrokCliHook(entry: unknown): boolean {
+  return isRecord(entry)
+    && typeof entry.command === "string"
+    && entry.command.includes(TOKENJUICE_GROK_CLI_SUBCOMMAND);
+}
+
+function getPostToolUseHooks(config: GrokCliUserSettings): unknown[] {
+  const postToolUse = config.hooks.PostToolUse;
+  return Array.isArray(postToolUse) ? postToolUse : [];
+}
+
+function findTokenjuiceGrokCliHookCommand(config: GrokCliUserSettings): string | undefined {
+  for (const group of getPostToolUseHooks(config)) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      continue;
+    }
+    for (const hook of group.hooks) {
+      if (isTokenjuiceGrokCliHook(hook)) {
+        return (hook as { command: string }).command;
+      }
+    }
+  }
+  return undefined;
+}
+
+function removeTokenjuiceGrokCliHooks(config: GrokCliUserSettings): number {
+  let removed = 0;
+  const retainedGroups: unknown[] = [];
+  for (const group of getPostToolUseHooks(config)) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      retainedGroups.push(group);
+      continue;
+    }
+    const retainedHooks = group.hooks.filter((hook) => {
+      const remove = isTokenjuiceGrokCliHook(hook);
+      if (remove) {
+        removed += 1;
+      }
+      return !remove;
+    });
+    if (retainedHooks.length > 0) {
+      retainedGroups.push({ ...group, hooks: retainedHooks });
+    }
+  }
+  config.hooks.PostToolUse = retainedGroups;
+  return removed;
+}
+
+function createGrokCliHook(command: string): Record<string, unknown> {
+  return {
+    matcher: "bash",
+    hooks: [
+      {
+        type: "command",
+        command,
+        timeout: 30,
+      },
+    ],
+  };
+}
+
+export async function installGrokCliHook(
+  settingsPath = getDefaultSettingsPath(),
+  options: GrokCliHookCommandOptions = {},
+): Promise<InstallGrokCliHookResult> {
+  const { config, backupPath } = await loadGrokCliSettingsWithBackup(settingsPath);
+  const command = await buildTokenjuiceHookCommand(TOKENJUICE_GROK_CLI_SUBCOMMAND, "grok-cli", options);
+  removeTokenjuiceGrokCliHooks(config);
+  config.hooks.PostToolUse = [...getPostToolUseHooks(config), createGrokCliHook(command)];
+  await writeGrokCliSettings(settingsPath, config);
+  return {
+    settingsPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+export async function uninstallGrokCliHook(settingsPath = getDefaultSettingsPath()): Promise<UninstallGrokCliHookResult> {
+  const { config } = await readGrokCliSettings(settingsPath);
+  const removed = removeTokenjuiceGrokCliHooks(config);
+  if (removed > 0) {
+    await writeGrokCliSettings(settingsPath, config);
+  }
+  return { settingsPath, removed };
+}
+
+export async function doctorGrokCliHook(
+  settingsPath = getDefaultSettingsPath(),
+  options: GrokCliHookCommandOptions = {},
+): Promise<GrokCliDoctorReport> {
+  const expectedCommand = await buildTokenjuiceHookCommand(TOKENJUICE_GROK_CLI_SUBCOMMAND, "grok-cli", options);
+  const { config, exists } = await readGrokCliSettings(settingsPath);
+  const detectedCommand = findTokenjuiceGrokCliHookCommand(config);
+
+  return {
+    settingsPath,
+    ...(await buildHookCommandDoctorFields({
+      expectedCommand,
+      detectedCommand: exists ? detectedCommand : undefined,
+      disabledIssue: "tokenjuice PostToolUse hook is not installed for Grok CLI",
+      hostLabel: "Grok CLI",
+      advisory: detectedCommand ? TOKENJUICE_GROK_CLI_ADVISORY : TOKENJUICE_GROK_CLI_DISABLED_ADVISORY,
+      fixCommand: TOKENJUICE_GROK_CLI_FIX_COMMAND,
+    })),
+  };
+}
+
+function readStringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readGrokCliOutputText(output: unknown): string {
+  if (typeof output === "string") {
+    return output;
+  }
+  if (!isRecord(output)) {
+    return "";
+  }
+  return readStringField(output, ["output", "error", "text", "content", "result", "stdout"]) ?? "";
+}
+
+function readPositiveIntegerEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function commandRequestsTokenjuiceRawBypass(command: string): boolean {
+  let argv: string[];
+  try {
+    argv = parseShellWords(stripLeadingCdPrefix(command));
+  } catch {
+    return false;
+  }
+  if (argv.length < 3) {
+    return false;
+  }
+
+  const first = argv[0];
+  const wrapIndex = typeof first === "string" && isTokenjuiceExecutablePath(first) ? 1 : -1;
+
+  if (wrapIndex === -1 || argv[wrapIndex] !== "wrap") {
+    return false;
+  }
+
+  const optionEndIndex = argv.indexOf("--", wrapIndex + 1);
+  if (optionEndIndex === -1) {
+    return false;
+  }
+
+  const optionArgs = argv.slice(wrapIndex + 1, optionEndIndex);
+  return optionArgs.includes("--raw") || optionArgs.includes("--full");
+}
+
+export async function runGrokCliPostToolUseHook(rawText: string): Promise<number> {
+  let payload: GrokCliPostToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as GrokCliPostToolUsePayload;
+  } catch {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  if (
+    (payload.hook_event_name !== undefined && payload.hook_event_name !== "PostToolUse")
+    || payload.tool_name !== "bash"
+  ) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  const toolInput = isRecord(payload.tool_input) ? payload.tool_input : undefined;
+  const command = toolInput ? readStringField(toolInput, ["command", "cmd"]) : undefined;
+  const toolOutput = isRecord(payload.tool_output) ? payload.tool_output : undefined;
+  if (toolOutput?.success !== true) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+  const visibleText = readGrokCliOutputText(payload.tool_output);
+  if (!command || !visibleText.trim()) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  if (commandRequestsTokenjuiceRawBypass(command)) {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+
+  try {
+    const maxInlineChars = readPositiveIntegerEnv("TOKENJUICE_GROK_CLI_MAX_INLINE_CHARS");
+    const outcome = await compactBashResult({
+      source: "grok-cli",
+      command,
+      visibleText,
+      ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
+      ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
+      inspectionPolicy: "allow-safe-inventory",
+      metadata: { source: "grok-cli-post-tool-use" },
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    if (outcome.action === "keep") {
+      writeEmptyHookJsonLine();
+      return 0;
+    }
+
+    writeHookJsonLine({
+      additionalContext: buildCompactedOutputContext(outcome.result.inlineText),
+    });
+    return 0;
+  } catch {
+    writeEmptyHookJsonLine();
+    return 0;
+  }
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -9,6 +9,7 @@ import { doctorCopilotCliHook } from "../copilot-cli/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
 import { doctorDroidHook } from "../droid/index.js";
 import { doctorGeminiCliHook } from "../gemini-cli/index.js";
+import { doctorGrokCliHook } from "../grok-cli/index.js";
 import { doctorJunieInstructions } from "../junie/index.js";
 import { doctorKiroSteering } from "../kiro/index.js";
 import { doctorKiloRule } from "../kilo/index.js";
@@ -31,6 +32,7 @@ import type { CopilotCliDoctorReport } from "../copilot-cli/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
 import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
+import type { GrokCliDoctorReport, GrokCliHookCommandOptions } from "../grok-cli/index.js";
 import type { JunieDoctorReport } from "../junie/index.js";
 import type { KiroDoctorReport } from "../kiro/index.js";
 import type { KiloDoctorReport } from "../kilo/index.js";
@@ -55,6 +57,7 @@ export type HookIntegrationDoctorReport = {
   cursor: CursorDoctorReport;
   droid: DroidDoctorReport;
   "gemini-cli": GeminiCliDoctorReport;
+  "grok-cli": GrokCliDoctorReport;
   junie: JunieDoctorReport;
   kiro: KiroDoctorReport;
   kilo: KiloDoctorReport;
@@ -73,7 +76,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions & QwenCodeHookCommandOptions;
+export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -95,6 +98,7 @@ const hookDoctorIntegrationDoctors = {
   cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
+  "grok-cli": (options) => doctorGrokCliHook(undefined, getHookCommandOptions(options)),
   junie: () => doctorJunieInstructions(),
   kiro: () => doctorKiroSteering(),
   kilo: () => doctorKiloRule(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
 export { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "./hosts/cursor/index.js";
 export { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "./hosts/droid/index.js";
 export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "./hosts/gemini-cli/index.js";
+export { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "./hosts/grok-cli/index.js";
 export { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "./hosts/junie/index.js";
 export { doctorKiroSteering, installKiroSteering, uninstallKiroSteering } from "./hosts/kiro/index.js";
 export { doctorKiloRule, installKiloRule, uninstallKiloRule } from "./hosts/kilo/index.js";
@@ -120,6 +121,12 @@ export type {
   InstallGeminiCliHookResult,
   UninstallGeminiCliHookResult,
 } from "./hosts/gemini-cli/index.js";
+export type {
+  GrokCliDoctorReport,
+  GrokCliHookCommandOptions,
+  InstallGrokCliHookResult,
+  UninstallGrokCliHookResult,
+} from "./hosts/grok-cli/index.js";
 export type {
   InstallJunieInstructionsResult,
   JunieDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -11,6 +11,7 @@ import {
   installCodeBuddyHook,
   installCodexHook,
   installCursorHook,
+  installGrokCliHook,
   installPiExtension,
   installQwenCodeHook,
   runClaudeCodePostToolUseHook,
@@ -659,6 +660,7 @@ describe("doctorInstalledHooks", () => {
     process.env.CURSOR_HOME = cursorHome;
     process.env.FACTORY_HOME = join(home, "factory");
     process.env.COPILOT_HOME = home;
+    process.env.HOME = home;
     process.env.PI_CODING_AGENT_DIR = piAgentDir;
     await mkdir(binDir, { recursive: true });
     await mkdir(join(home, "dist", "cli"), { recursive: true });
@@ -689,6 +691,11 @@ describe("doctorInstalledHooks", () => {
       binaryPath: localBinaryPath,
       nodePath: localNodePath,
     });
+    await installGrokCliHook(undefined, {
+      local: true,
+      binaryPath: localBinaryPath,
+      nodePath: localNodePath,
+    });
     await installQwenCodeHook(undefined, {
       projectDir: home,
       local: true,
@@ -710,12 +717,14 @@ describe("doctorInstalledHooks", () => {
     expect(report.integrations["claude-code"].status).toBe("ok");
     expect(report.integrations.codebuddy.status).toBe("ok");
     expect(report.integrations.cursor.status).toBe("ok");
+    expect(report.integrations["grok-cli"].status).toBe("ok");
     expect(report.integrations["qwen-code"].status).toBe("ok");
     expect(report.integrations.pi.status).toBe("ok");
     expect(report.integrations.codex.expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations["claude-code"].expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations.codebuddy.expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations.cursor.expectedCommand).toContain(expectedHookPrefix);
+    expect(report.integrations["grok-cli"].expectedCommand).toContain(expectedHookPrefix);
     expect(report.integrations["qwen-code"].expectedCommand).toContain(expectedHookPrefix);
   });
 });

--- a/test/hosts/grok-cli.test.ts
+++ b/test/hosts/grok-cli.test.ts
@@ -1,0 +1,277 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorGrokCliHook,
+  installGrokCliHook,
+  runGrokCliPostToolUseHook,
+  uninstallGrokCliHook,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-grok-cli-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("grok-cli hooks", () => {
+  it("installs a PostToolUse hook into Grok CLI user settings", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, ".grok", "user-settings.json");
+    const launcherPath = join(home, "bin", "tokenjuice");
+    await mkdir(join(home, ".grok"), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      defaultModel: "grok-code-fast-1",
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "read_file",
+            hooks: [{ type: "command", command: "other-hook" }],
+          },
+        ],
+      },
+    }));
+
+    const result = await installGrokCliHook(settingsPath, { binaryPath: launcherPath, local: true });
+    const parsed = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      defaultModel: string;
+      hooks: { PostToolUse: Array<{ matcher: string; hooks: Array<{ command: string; type?: string; timeout?: number }> }> };
+    };
+
+    await expect(access(`${settingsPath}.bak`)).resolves.toBeUndefined();
+    expect(result.settingsPath).toBe(settingsPath);
+    expect(result.command).toBe(`${launcherPath} grok-cli-post-tool-use`);
+    expect(result.backupPath).toBe(`${settingsPath}.bak`);
+    expect(parsed.defaultModel).toBe("grok-code-fast-1");
+    expect(parsed.hooks.PostToolUse).toHaveLength(2);
+    expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("bash");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.type).toBe("command");
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.timeout).toBe(30);
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toBe(`${launcherPath} grok-cli-post-tool-use`);
+  });
+
+  it("reports installed and uninstalled hook health", async () => {
+    const home = await createTempDir();
+    const settingsPath = join(home, ".grok", "user-settings.json");
+    const launcherPath = join(home, "tokenjuice");
+    await mkdir(join(home, ".grok"), { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    await installGrokCliHook(settingsPath, { binaryPath: launcherPath, local: true });
+    const installed = await doctorGrokCliHook(settingsPath, { binaryPath: launcherPath, local: true });
+
+    expect(installed.status).toBe("ok");
+    expect(installed.detectedCommand).toBe(`${launcherPath} grok-cli-post-tool-use`);
+    expect(installed.advisories[0]).toContain("beta");
+
+    const removed = await uninstallGrokCliHook(settingsPath);
+    const disabled = await doctorGrokCliHook(settingsPath, { binaryPath: launcherPath, local: true });
+
+    expect(removed.removed).toBe(1);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("injects compacted context for noisy bash output", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "git status",
+      },
+      tool_output: {
+        success: true,
+        output: [
+          "On branch pr-65478-security-fix",
+          "Your branch and 'origin/pr-65478-security-fix' have diverged,",
+          "and have 8 and 642 different commits each, respectively.",
+          "",
+          "Changes not staged for commit:",
+          "\tmodified:   src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts",
+          "\tmodified:   src/agents/pi-embedded-runner/run/attempt.test.ts",
+          "",
+          "no changes added to commit",
+        ].join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+    const response = JSON.parse(output) as {
+      additionalContext?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(response.additionalContext).toContain("Changes not staged:");
+    expect(response.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
+    expect(response.additionalContext).not.toContain("and have 8 and 642");
+    expect(response.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
+  });
+
+  it("accepts PostToolUse payloads without an event name", async () => {
+    const payload = JSON.stringify({
+      tool_name: "bash",
+      tool_input: {
+        command: "git status",
+      },
+      tool_output: {
+        success: true,
+        output: [
+          "Changes not staged for commit:",
+          "\tmodified:   README.md",
+          "\tmodified:   docs/spec.md",
+          "no changes added to commit",
+        ].join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+    const response = JSON.parse(output) as {
+      additionalContext?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(response.additionalContext).toContain("M: README.md");
+    expect(response.additionalContext).toContain("M: docs/spec.md");
+  });
+
+  it("honors tokenjuice raw bypass commands without re-compacting them", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "tokenjuice wrap --raw -- git log --oneline -50",
+      },
+      tool_output: {
+        success: true,
+        output: Array.from({ length: 50 }, (_, i) => `${String(i).padStart(7, "0")} commit message ${i}`).join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+
+  it("honors tokenjuice full bypass commands with leading cd prefixes", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "cd /data/code/project && tokenjuice wrap --full -- python scripts/dump.py --limit 500",
+      },
+      tool_output: {
+        success: true,
+        output: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+
+  it("does not treat inner command flags as a raw bypass without the wrap separator", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "tokenjuice wrap git diff --raw",
+      },
+      tool_output: {
+        success: true,
+        output: Array.from({ length: 80 }, (_, i) => `diff line ${i + 1}`).join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+    const response = JSON.parse(output) as {
+      additionalContext?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(response.additionalContext).toContain("diff line");
+  });
+
+  it("honors absolute tokenjuice raw bypass commands", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      cwd: "/repo",
+      tool_input: {
+        command: "/usr/local/bin/tokenjuice wrap --raw -- git status",
+      },
+      tool_output: {
+        success: true,
+        output: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n"),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+
+  it("keeps unrelated hook payloads silent", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "read_file",
+      tool_input: { path: "README.md" },
+      tool_output: { output: "hello" },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+
+  it("keeps failed bash payloads silent", async () => {
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      tool_input: {
+        command: "pnpm test",
+      },
+      tool_output: {
+        success: false,
+        output: "FAIL test/example.test.ts\nexpected true to be false\n".repeat(20),
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runGrokCliPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output).toBe("{}\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add beta Grok CLI integration that writes a user-level `PostToolUse` hook into `~/.grok/user-settings.json`
- inject compacted shell-output context for Grok CLI `bash` tool results without suppressing the original result
- preserve explicit `tokenjuice wrap --raw -- <command>` and `tokenjuice wrap --full -- <command>` escape hatches so user-requested full output is not re-compacted
- wire install/uninstall/doctor, aggregate hook doctor, source normalization, public exports, docs, and tests
- accept Grok hook payloads with or without `hook_event_name` on the dedicated `grok-cli-post-tool-use` subcommand

Rebased onto `main` after #114 merged.

## Validation
- `pnpm exec vitest run test/hosts/grok-cli.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `git diff --check`
- privacy scan over changed files for local paths, private IPs, and smoke temp names
- built CLI smoke from earlier branch validation: `install grok-cli --local`, settings file check, `doctor grok-cli --local`, `uninstall grok-cli`, disabled doctor
- built CLI hook smoke from earlier branch validation: `grok-cli-post-tool-use` with a successful `bash` payload emits compacted top-level `additionalContext`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt <Grok CLI raw/full bypass fix review>`

## Review Notes
- accepted and fixed autoreview finding: tolerate missing `hook_event_name` for the dedicated PostToolUse hook command
- accepted and fixed autoreview finding: preserve explicit `--raw` / `--full` tokenjuice wrap bypasses before post-tool compaction
- final autoreview result: clean, no accepted/actionable findings