### PR TITLE
feat(copilot-agent): add repo hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ beta integrations:
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
 | <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
+| <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot coding agent" /> | [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) | `tokenjuice install copilot-agent` | `.github/hooks/tokenjuice-agent.json` |
 | <img width="48px" src="docs/client-junie.svg" alt="Junie" /> | [Junie](https://junie.jetbrains.com/docs/junie-cli-usage.html) | `tokenjuice install junie` | `.junie/AGENTS.md` |
 | <img width="48px" src="docs/client-kiro.svg" alt="Kiro" /> | [Kiro](https://kiro.dev/) | `tokenjuice install kiro` | `.kiro/steering/tokenjuice.md` |
 | <img width="48px" src="docs/client-kilo.svg" alt="Kilo Code" /> | [Kilo Code](https://kilocode.ai/) | `tokenjuice install kilo` | `kilo.jsonc` or `.kilo/kilo.jsonc` + `.kilo/rules/tokenjuice.md` |
@@ -64,8 +65,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|avante|codex|cline|continue|copilot-agent|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -87,9 +88,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|avante|codex|cline|continue|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|avante|codex|cline|continue|copilot-agent|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -145,6 +146,7 @@ direct payload:
 - [spec](docs/spec.md)
 - [rules](docs/rules.md)
 - [integration playbook](docs/integration-playbook.md)
+- [GitHub Copilot coding agent integration](docs/copilot-agent-integration.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)
 - [Grok CLI integration](docs/grok-cli-integration.md)

--- a/docs/copilot-agent-integration.md
+++ b/docs/copilot-agent-integration.md
@@ -1,0 +1,41 @@
+# GitHub Copilot Coding Agent Integration
+
+`tokenjuice install copilot-agent` writes a repository-level Copilot hook to
+`.github/hooks/tokenjuice-agent.json`.
+
+The hook runs on `postToolUse` events and compacts successful `bash` tool
+results. It runs:
+
+```bash
+tokenjuice copilot-agent-post-tool-use
+```
+
+When Copilot returns noisy successful shell output, tokenjuice replaces the
+tool result with compacted output. Failed, denied, non-bash, malformed, and
+explicit `tokenjuice wrap --raw -- ...` invocations pass through unchanged.
+
+## Cloud Agent Caveat
+
+GitHub Copilot cloud agent loads hook configuration from `.github/hooks/*.json`
+inside the cloned repository. The cloud sandbox is ephemeral and only honors
+`bash` or `command` entries, so this integration writes both fields.
+
+The hook command still needs `tokenjuice` to be available in `PATH` before the
+hook runs. For repositories using Copilot cloud agent, install tokenjuice as
+part of the agent environment setup or use a project-local binary that the
+hook command can resolve.
+
+## Commands
+
+```bash
+tokenjuice install copilot-agent
+tokenjuice doctor copilot-agent
+tokenjuice uninstall copilot-agent
+```
+
+Use `--local` when validating a checkout build:
+
+```bash
+tokenjuice install copilot-agent --local
+tokenjuice doctor copilot-agent --local
+```

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,6 +20,7 @@ import { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallCl
 import { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook } from "../hosts/codebuddy/index.js";
 import { doctorContinueRule, installContinueRule, uninstallContinueRule } from "../hosts/continue/index.js";
 import { doctorCodexHook, installCodexHook, runCodexPostToolUseHook, uninstallCodexHook } from "../hosts/codex/index.js";
+import { doctorCopilotAgentHook, installCopilotAgentHook, runCopilotAgentPostToolUseHook, uninstallCopilotAgentHook } from "../hosts/copilot-agent/index.js";
 import {
   doctorCopilotCliHook,
   getCopilotCliInstructionsSnippet,
@@ -108,6 +109,7 @@ function printUsage(): void {
       "  tokenjuice install cline [--local]",
       "  tokenjuice install codebuddy [--local]",
       "  tokenjuice install continue",
+      "  tokenjuice install copilot-agent [--local]",
       "  tokenjuice install cursor [--local]",
       "  tokenjuice install droid [--local]",
       "  tokenjuice install gemini-cli [--local]",
@@ -129,6 +131,7 @@ function printUsage(): void {
       "  tokenjuice uninstall codex",
       "  tokenjuice uninstall cline",
       "  tokenjuice uninstall continue",
+      "  tokenjuice uninstall copilot-agent",
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall gemini-cli",
       "  tokenjuice uninstall grok-cli",
@@ -147,7 +150,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -614,6 +617,28 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "copilot-agent") {
+    const result = await installCopilotAgentHook(undefined, { local: args.local });
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Hook", value: result.hooksPath },
+      { label: "Command", value: result.command },
+      { label: "Beta", value: "repo-level PostToolUse hook for Copilot coding agent bash output" },
+      { label: "Verify", value: `tokenjuice doctor copilot-agent${args.local ? " --local" : ""}` },
+      { label: "Cloud agent", value: "ensure tokenjuice is available in PATH before Copilot cloud agent hooks run" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("copilot-agent", "hook", details));
+    return 0;
+  }
+
   if (target === "cursor") {
     const result = await installCursorHook(undefined, { local: args.local });
     if (args.format === "json") {
@@ -946,7 +971,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1016,6 +1041,22 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed continue rule: ${result.removed ? "yes" : "no"}\n`);
     process.stdout.write(`rule path: ${result.rulePath}\n`);
     process.stdout.write("enable: tokenjuice install continue\n");
+    return 0;
+  }
+
+  if (target === "copilot-agent") {
+    const result = await uninstallCopilotAgentHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed copilot-agent entries: ${result.removed}\n`);
+    process.stdout.write(`hook path: ${result.hooksPath}\n`);
+    if (result.deletedFile) {
+      process.stdout.write("deleted empty hook file: yes\n");
+    }
+    process.stdout.write("enable: tokenjuice install copilot-agent\n");
     return 0;
   }
 
@@ -1203,7 +1244,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, avante, codex, cline, continue, copilot-agent, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1588,6 +1629,42 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("missing paths:\n");
       for (const path of report.missingPaths) {
         process.stdout.write(`- ${path}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "copilot-agent") {
+    const report = await doctorCopilotAgentHook(undefined, { local: args.local });
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`hooks path: ${report.hooksPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    process.stdout.write(`expected command: ${report.expectedCommand}\n`);
+    if (report.detectedCommand) {
+      process.stdout.write(`configured command: ${report.detectedCommand}\n`);
+    }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
       }
     }
     process.stdout.write(`repair: ${report.fixCommand}\n`);
@@ -2274,6 +2351,8 @@ async function main(): Promise<number> {
       return await runQwenCodePostToolUseHook(await readStdin(args.maxInputBytes));
     case "vscode-copilot-pre-tool-use":
       return await runVscodeCopilotPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
+    case "copilot-agent-post-tool-use":
+      return await runCopilotAgentPostToolUseHook(await readStdin(args.maxInputBytes));
     case "copilot-cli-post-tool-use":
       return await runCopilotCliPostToolUseHook(await readStdin(args.maxInputBytes));
     case "droid-post-tool-use":

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -7,7 +7,7 @@ import type { CompactResult, ReduceOptions, ToolExecutionInput } from "../../typ
 import type { InspectionCommandPolicy, InspectionCommandSkipReason } from "../inventory-safety.js";
 
 export type CompactBashResultInput = {
-  source: "claude-code" | "cline" | "codex" | "copilot-cli" | "droid" | "gemini-cli" | "grok-cli" | "openclaw" | "openhands" | "opencode" | "pi" | "qwen-code";
+  source: "claude-code" | "cline" | "codex" | "copilot-agent" | "copilot-cli" | "droid" | "gemini-cli" | "grok-cli" | "openclaw" | "openhands" | "opencode" | "pi" | "qwen-code";
   command: string;
   cwd?: string;
   visibleText: string;

--- a/src/hosts/copilot-agent/index.ts
+++ b/src/hosts/copilot-agent/index.ts
@@ -1,0 +1,639 @@
+import { readdir, rm, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { stripLeadingCdPrefix, stripLeadingEnvAssignments } from "../../core/command.js";
+import { compactBashResult } from "../../core/integrations/compact-bash-result.js";
+import { extractHookCommandPaths, isNodeExecutablePath, isTokenjuiceExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
+import {
+  buildTokenjuiceHookCommand,
+  isExecutableFile,
+  pathExists,
+  type TokenjuiceHookCommandOptions,
+} from "../shared/host-command.js";
+import {
+  ensureHooksDir,
+  isRecord,
+  loadCopilotHooksConfigWithBackup,
+  readCopilotHooksConfig,
+  writeCopilotHooksConfigAtomic,
+} from "../shared/hooks-json-file.js";
+import type { CopilotHooksConfig } from "../shared/hooks-json-file.js";
+
+export type CopilotAgentHookCommandOptions = TokenjuiceHookCommandOptions & {
+  projectDir?: string;
+};
+
+export type InstallCopilotAgentHookResult = {
+  hooksPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+export type UninstallCopilotAgentHookResult = {
+  hooksPath: string;
+  removed: number;
+  deletedFile: boolean;
+};
+
+export type CopilotAgentDoctorReport = {
+  hooksPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+type CopilotAgentPostToolUsePayload = {
+  hook_event_name?: unknown;
+  hookEventName?: unknown;
+  tool_name?: unknown;
+  toolName?: unknown;
+  tool_input?: unknown;
+  toolInput?: unknown;
+  toolArgs?: unknown;
+  tool_result?: unknown;
+  toolResult?: unknown;
+  cwd?: unknown;
+};
+
+type StrayCopilotAgentHook = {
+  path: string;
+  command: string;
+};
+
+const TOKENJUICE_COPILOT_AGENT_SUBCOMMAND = "copilot-agent-post-tool-use";
+const TOKENJUICE_COPILOT_AGENT_FIX_COMMAND = "tokenjuice install copilot-agent";
+const TOKENJUICE_COPILOT_AGENT_FILENAME = "tokenjuice-agent.json";
+const TOKENJUICE_COPILOT_AGENT_TIMEOUT_SECONDS = 10;
+const TOKENJUICE_COPILOT_AGENT_ADVISORY =
+  "Copilot coding agent support is beta; cloud agent jobs must have tokenjuice available in PATH before the repo hook runs.";
+const TOKENJUICE_COPILOT_AGENT_DISABLED_ADVISORY =
+  "Copilot coding agent support is beta; install writes a repo-level .github/hooks hook for bash PostToolUse events.";
+
+const GENERIC_FALLBACK_MIN_SAVED_CHARS = 120;
+const GENERIC_FALLBACK_MAX_RATIO = 0.75;
+
+async function buildCopilotAgentHookCommand(
+  options: CopilotAgentHookCommandOptions = {},
+): Promise<string> {
+  if (!options.local) {
+    return `${shellQuote("tokenjuice")} ${TOKENJUICE_COPILOT_AGENT_SUBCOMMAND}`;
+  }
+  return buildTokenjuiceHookCommand(TOKENJUICE_COPILOT_AGENT_SUBCOMMAND, "copilot-agent", options);
+}
+
+function getExplicitProjectDir(options: CopilotAgentHookCommandOptions = {}): string | undefined {
+  return options.projectDir || process.env.COPILOT_AGENT_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(
+  options: CopilotAgentHookCommandOptions = {},
+  requireRepositoryRoot = false,
+): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  const gitRoot = await findGitRoot(process.cwd());
+  if (gitRoot) {
+    return gitRoot;
+  }
+  if (requireRepositoryRoot) {
+    throw new Error("copilot-agent install must run inside a git repository or receive an explicit projectDir");
+  }
+  return process.cwd();
+}
+
+async function getDefaultHooksPath(
+  options: CopilotAgentHookCommandOptions = {},
+  requireRepositoryRoot = false,
+): Promise<string> {
+  return join(await resolveProjectDir(options, requireRepositoryRoot), ".github", "hooks", TOKENJUICE_COPILOT_AGENT_FILENAME);
+}
+
+function getCopilotAgentFixCommand(local = false): string {
+  return local
+    ? `${TOKENJUICE_COPILOT_AGENT_FIX_COMMAND} --local`
+    : TOKENJUICE_COPILOT_AGENT_FIX_COMMAND;
+}
+
+function readHookCommand(entry: unknown): string | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  for (const key of ["bash", "command", "powershell"]) {
+    const value = entry[key];
+    if (typeof value === "string" && value.includes(TOKENJUICE_COPILOT_AGENT_SUBCOMMAND)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function isTokenjuiceCopilotAgentHook(entry: unknown): boolean {
+  return readHookCommand(entry) !== undefined;
+}
+
+function getPostToolUseHooks(config: CopilotHooksConfig): unknown[] {
+  const postToolUse = config.hooks.postToolUse;
+  return Array.isArray(postToolUse) ? postToolUse : [];
+}
+
+function removeTokenjuiceCopilotAgentHooks(config: CopilotHooksConfig): number {
+  let removed = 0;
+  for (const [eventName, entries] of Object.entries(config.hooks)) {
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+
+    const retained = entries.filter((entry) => !isTokenjuiceCopilotAgentHook(entry));
+    removed += entries.length - retained.length;
+    if (retained.length === 0) {
+      delete config.hooks[eventName];
+    } else {
+      config.hooks[eventName] = retained;
+    }
+  }
+  return removed;
+}
+
+function isEffectivelyEmptyHooksConfig(config: CopilotHooksConfig): boolean {
+  return Object.keys(config.hooks).length === 0
+    && Object.keys(config).filter((key) => key !== "hooks" && key !== "version").length === 0;
+}
+
+async function writeOrDeleteHooksConfig(hooksPath: string, config: CopilotHooksConfig): Promise<boolean> {
+  if (isEffectivelyEmptyHooksConfig(config)) {
+    await rm(hooksPath, { force: true });
+    return true;
+  }
+
+  await writeCopilotHooksConfigAtomic(hooksPath, config);
+  return false;
+}
+
+function findTokenjuiceCopilotAgentHook(config: CopilotHooksConfig): Record<string, unknown> | undefined {
+  for (const entry of getPostToolUseHooks(config)) {
+    if (isTokenjuiceCopilotAgentHook(entry) && isRecord(entry)) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function findTokenjuiceCopilotAgentHookCommand(config: CopilotHooksConfig): string | undefined {
+  return readHookCommand(findTokenjuiceCopilotAgentHook(config));
+}
+
+function findAnyTokenjuiceCopilotAgentHookCommand(config: CopilotHooksConfig): string | undefined {
+  for (const entries of Object.values(config.hooks)) {
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries) {
+      const command = readHookCommand(entry);
+      if (command) {
+        return command;
+      }
+    }
+  }
+  return undefined;
+}
+
+function findMisplacedTokenjuiceCopilotAgentHookEvents(config: CopilotHooksConfig): string[] {
+  const events: string[] = [];
+  for (const [eventName, entries] of Object.entries(config.hooks)) {
+    if (eventName === "postToolUse" || !Array.isArray(entries)) {
+      continue;
+    }
+    if (entries.some((entry) => isTokenjuiceCopilotAgentHook(entry))) {
+      events.push(eventName);
+    }
+  }
+  return events;
+}
+
+function createTokenjuiceCopilotAgentHook(command: string): Record<string, unknown> {
+  return {
+    type: "command",
+    bash: command,
+    command,
+    timeoutSec: TOKENJUICE_COPILOT_AGENT_TIMEOUT_SECONDS,
+  };
+}
+
+function collectTokenjuiceHookTimeoutWarnings(config: CopilotHooksConfig, fixCommand: string): string[] {
+  const hook = findTokenjuiceCopilotAgentHook(config);
+  if (!hook || hook.timeoutSec === TOKENJUICE_COPILOT_AGENT_TIMEOUT_SECONDS) {
+    return [];
+  }
+  return [
+    `configured copilot-agent tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_COPILOT_AGENT_TIMEOUT_SECONDS}s safety cap`,
+  ];
+}
+
+async function findStrayCopilotAgentHooks(
+  hooksDir: string,
+  canonicalPath: string,
+): Promise<StrayCopilotAgentHook[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(hooksDir);
+  } catch {
+    return [];
+  }
+
+  const hooks: StrayCopilotAgentHook[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) {
+      continue;
+    }
+
+    const candidate = join(hooksDir, entry);
+    if (candidate === canonicalPath) {
+      continue;
+    }
+
+    try {
+      const { config } = await readCopilotHooksConfig(candidate, "copilot-agent");
+      const command = findAnyTokenjuiceCopilotAgentHookCommand(config);
+      if (command) {
+        hooks.push({ path: candidate, command });
+      }
+    } catch {
+      // Ignore unreadable or invalid sibling hook files in doctor output.
+    }
+  }
+  return hooks;
+}
+
+async function uninstallStrayCopilotAgentHookFiles(
+  hooksDir: string,
+  canonicalPath: string,
+): Promise<number> {
+  let entries: string[];
+  try {
+    entries = await readdir(hooksDir);
+  } catch {
+    return 0;
+  }
+
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) {
+      continue;
+    }
+
+    const candidate = join(hooksDir, entry);
+    if (candidate === canonicalPath) {
+      continue;
+    }
+
+    try {
+      const { config } = await readCopilotHooksConfig(candidate, "copilot-agent");
+      const removedFromFile = removeTokenjuiceCopilotAgentHooks(config);
+      if (removedFromFile === 0) {
+        continue;
+      }
+      await writeOrDeleteHooksConfig(candidate, config);
+      removed += removedFromFile;
+    } catch {
+      // Leave unreadable or invalid sibling hook files untouched.
+    }
+  }
+
+  return removed;
+}
+
+export async function installCopilotAgentHook(
+  hooksPath?: string,
+  options: CopilotAgentHookCommandOptions = {},
+): Promise<InstallCopilotAgentHookResult> {
+  const resolvedHooksPath = hooksPath ?? await getDefaultHooksPath(options, true);
+  const { config, backupPath } = await loadCopilotHooksConfigWithBackup(resolvedHooksPath, "copilot-agent");
+  const command = await buildCopilotAgentHookCommand(options);
+  removeTokenjuiceCopilotAgentHooks(config);
+  const retained = getPostToolUseHooks(config);
+  config.hooks.postToolUse = [...retained, createTokenjuiceCopilotAgentHook(command)];
+  if (typeof config.version !== "number") {
+    config.version = 1;
+  }
+
+  await ensureHooksDir(dirname(resolvedHooksPath));
+  await writeCopilotHooksConfigAtomic(resolvedHooksPath, config);
+  await uninstallStrayCopilotAgentHookFiles(dirname(resolvedHooksPath), resolvedHooksPath);
+
+  return {
+    hooksPath: resolvedHooksPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+export async function uninstallCopilotAgentHook(
+  hooksPath?: string,
+  options: CopilotAgentHookCommandOptions = {},
+): Promise<UninstallCopilotAgentHookResult> {
+  const resolvedHooksPath = hooksPath ?? await getDefaultHooksPath(options, true);
+  const hooksDir = dirname(resolvedHooksPath);
+  const { config, exists } = await readCopilotHooksConfig(resolvedHooksPath, "copilot-agent");
+  let removed = 0;
+  let deletedFile = false;
+
+  if (exists) {
+    const removedFromCanonical = removeTokenjuiceCopilotAgentHooks(config);
+    if (removedFromCanonical > 0) {
+      deletedFile = await writeOrDeleteHooksConfig(resolvedHooksPath, config);
+      removed += removedFromCanonical;
+    }
+  }
+
+  removed += await uninstallStrayCopilotAgentHookFiles(hooksDir, resolvedHooksPath);
+
+  return { hooksPath: resolvedHooksPath, removed, deletedFile };
+}
+
+export async function doctorCopilotAgentHook(
+  hooksPath?: string,
+  options: CopilotAgentHookCommandOptions = {},
+): Promise<CopilotAgentDoctorReport> {
+  const resolvedHooksPath = hooksPath ?? await getDefaultHooksPath(options);
+  const expectedCommand = await buildCopilotAgentHookCommand(options);
+  const fixCommand = getCopilotAgentFixCommand(options.local);
+  const { config, exists } = await readCopilotHooksConfig(resolvedHooksPath, "copilot-agent");
+  const strayHooks = await findStrayCopilotAgentHooks(dirname(resolvedHooksPath), resolvedHooksPath);
+  const strayIssues = strayHooks.map((stray) => `stray tokenjuice entry in sibling hook file: ${stray.path}`);
+  const strayDetectedCommand = strayHooks[0]?.command;
+  const advisories = [exists ? TOKENJUICE_COPILOT_AGENT_ADVISORY : TOKENJUICE_COPILOT_AGENT_DISABLED_ADVISORY];
+
+  if (!exists) {
+    return {
+      hooksPath: resolvedHooksPath,
+      status: strayIssues.length > 0 ? "warn" : "disabled",
+      issues: strayIssues,
+      advisories,
+      fixCommand,
+      expectedCommand,
+      ...(strayDetectedCommand ? { detectedCommand: strayDetectedCommand } : {}),
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  const detectedCommand = findTokenjuiceCopilotAgentHookCommand(config);
+  const canonicalDetectedCommand = detectedCommand ?? findAnyTokenjuiceCopilotAgentHookCommand(config);
+  const misplacedEvents = findMisplacedTokenjuiceCopilotAgentHookEvents(config);
+  const misplacedIssues = misplacedEvents.map(
+    (eventName) => `tokenjuice copilot-agent hook is configured outside postToolUse in ${eventName}; run ${fixCommand} to repair`,
+  );
+  if (!detectedCommand) {
+    const detectedInstallCommand = canonicalDetectedCommand ?? strayDetectedCommand;
+    return {
+      hooksPath: resolvedHooksPath,
+      status: canonicalDetectedCommand || strayIssues.length > 0 ? "warn" : "disabled",
+      issues: [...misplacedIssues, ...strayIssues],
+      advisories,
+      fixCommand,
+      expectedCommand,
+      ...(detectedInstallCommand ? { detectedCommand: detectedInstallCommand } : {}),
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  if (config.disableAllHooks === true) {
+    return {
+      hooksPath: resolvedHooksPath,
+      status: "broken",
+      issues: [
+        "copilot-agent hook file sets disableAllHooks: true; configured hooks will not run",
+        ...misplacedIssues,
+        ...strayIssues,
+      ],
+      advisories,
+      fixCommand,
+      expectedCommand,
+      detectedCommand,
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  const checkedPaths = extractHookCommandPaths(detectedCommand);
+  const missingPaths: string[] = [];
+  for (const path of checkedPaths) {
+    if (!(await isExecutableFile(path)) && !(path.endsWith(".js") && await pathExists(path))) {
+      missingPaths.push(path);
+    }
+  }
+
+  const issues: string[] = [];
+  issues.push(...collectTokenjuiceHookTimeoutWarnings(config, fixCommand));
+  issues.push(...misplacedIssues);
+  if (detectedCommand !== expectedCommand) {
+    issues.push("configured copilot-agent hook command does not match the current recommended command");
+  }
+  if (missingPaths.length > 0) {
+    issues.push(`configured copilot-agent hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
+  }
+  issues.push(...strayIssues);
+
+  return {
+    hooksPath: resolvedHooksPath,
+    status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
+    issues,
+    advisories,
+    fixCommand,
+    expectedCommand,
+    detectedCommand,
+    checkedPaths,
+    missingPaths,
+  };
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | undefined {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function commandRequestsTokenjuiceRawBypass(command: string): boolean {
+  let argv: string[];
+  try {
+    argv = stripLeadingEnvAssignments(parseShellWords(stripLeadingCdPrefix(command)));
+  } catch {
+    return false;
+  }
+  if (argv.length < 3) {
+    return false;
+  }
+
+  let wrapIndex = -1;
+  const first = argv[0];
+  const second = argv[1];
+  if (typeof first === "string" && isTokenjuiceExecutablePath(first)) {
+    wrapIndex = 1;
+  } else if (
+    typeof first === "string"
+    && isNodeExecutablePath(first)
+    && typeof second === "string"
+    && second.endsWith(".js")
+  ) {
+    wrapIndex = 2;
+  }
+
+  if (wrapIndex === -1 || argv[wrapIndex] !== "wrap") {
+    return false;
+  }
+
+  const optionEndIndex = argv.indexOf("--", wrapIndex + 1);
+  if (optionEndIndex === -1) {
+    return false;
+  }
+
+  const optionArgs = argv.slice(wrapIndex + 1, optionEndIndex);
+  return optionArgs.includes("--raw") || optionArgs.includes("--full");
+}
+
+function readPositiveIntegerEnv(name: string): number | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function shouldStoreFromEnv(): boolean {
+  const value = process.env.TOKENJUICE_COPILOT_AGENT_STORE;
+  return value === "1" || value === "true" || value === "TRUE" || value === "yes" || value === "YES";
+}
+
+export async function runCopilotAgentPostToolUseHook(rawText: string): Promise<number> {
+  let payload: CopilotAgentPostToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as CopilotAgentPostToolUsePayload;
+  } catch {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const toolName = typeof payload.toolName === "string"
+    ? payload.toolName
+    : typeof payload.tool_name === "string"
+    ? payload.tool_name
+    : undefined;
+  if (toolName !== "bash") {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const toolInput = parseJsonObject(payload.toolArgs)
+    ?? parseJsonObject(payload.toolInput)
+    ?? parseJsonObject(payload.tool_input);
+  const command = typeof toolInput?.command === "string" ? toolInput.command : undefined;
+  if (!command || !command.trim() || commandRequestsTokenjuiceRawBypass(command)) {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const toolResult = parseJsonObject(payload.toolResult) ?? parseJsonObject(payload.tool_result);
+  if (!toolResult) {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const resultType = typeof toolResult.resultType === "string"
+    ? toolResult.resultType
+    : typeof toolResult.result_type === "string"
+    ? toolResult.result_type
+    : undefined;
+  if (resultType && resultType !== "success") {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const visibleText = typeof toolResult.textResultForLlm === "string"
+    ? toolResult.textResultForLlm
+    : typeof toolResult.text_result_for_llm === "string"
+    ? toolResult.text_result_for_llm
+    : "";
+  if (!visibleText.trim()) {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const maxInlineChars = readPositiveIntegerEnv("TOKENJUICE_COPILOT_AGENT_MAX_INLINE_CHARS");
+
+  try {
+    const outcome = await compactBashResult({
+      source: "copilot-agent",
+      command,
+      visibleText,
+      ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
+      ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
+      inspectionPolicy: "allow-safe-inventory",
+      storeRaw: shouldStoreFromEnv(),
+      metadata: { source: "copilot-agent-post-tool-use" },
+      genericFallbackMinSavedChars: GENERIC_FALLBACK_MIN_SAVED_CHARS,
+      genericFallbackMaxRatio: GENERIC_FALLBACK_MAX_RATIO,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    if (outcome.action === "keep") {
+      process.stdout.write("{}\n");
+      return 0;
+    }
+
+    process.stdout.write(`${JSON.stringify({
+      modifiedResult: {
+        ...toolResult,
+        resultType: "success",
+        result_type: "success",
+        textResultForLlm: outcome.result.inlineText,
+        text_result_for_llm: outcome.result.inlineText,
+      },
+    })}\n`);
+    return 0;
+  } catch {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -5,6 +5,7 @@ import { doctorClineHook } from "../cline/index.js";
 import { doctorCodeBuddyHook } from "../codebuddy/index.js";
 import { doctorContinueRule } from "../continue/index.js";
 import { doctorCodexHook } from "../codex/index.js";
+import { doctorCopilotAgentHook } from "../copilot-agent/index.js";
 import { doctorCopilotCliHook } from "../copilot-cli/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
 import { doctorDroidHook } from "../droid/index.js";
@@ -28,6 +29,7 @@ import type { ClineDoctorReport } from "../cline/index.js";
 import type { CodeBuddyDoctorReport, CodeBuddyHookCommandOptions } from "../codebuddy/index.js";
 import type { ContinueDoctorReport } from "../continue/index.js";
 import type { CodexDoctorReport, CodexHookCommandOptions } from "../codex/index.js";
+import type { CopilotAgentDoctorReport, CopilotAgentHookCommandOptions } from "../copilot-agent/index.js";
 import type { CopilotCliDoctorReport } from "../copilot-cli/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
@@ -50,6 +52,7 @@ export type HookIntegrationDoctorReport = {
   aider: AiderDoctorReport;
   avante: AvanteDoctorReport;
   codex: CodexDoctorReport;
+  "copilot-agent": CopilotAgentDoctorReport;
   "claude-code": ClaudeCodeDoctorReport;
   cline: ClineDoctorReport;
   codebuddy: CodeBuddyDoctorReport;
@@ -76,7 +79,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
+export type HookDoctorCommandOptions = CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -95,6 +98,7 @@ const hookDoctorIntegrationDoctors = {
   cline: (options) => doctorClineHook(undefined, getHookCommandOptions(options)),
   codebuddy: (options) => doctorCodeBuddyHook(undefined, getHookCommandOptions(options)),
   continue: () => doctorContinueRule(),
+  "copilot-agent": (options) => doctorCopilotAgentHook(undefined, getHookCommandOptions(options)),
   cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
@@ -141,6 +145,7 @@ function getHookCommandOptions(options: HookDoctorCommandOptions): HookDoctorCom
     ...(typeof options.local === "boolean" ? { local: options.local } : {}),
     ...(typeof options.binaryPath === "string" ? { binaryPath: options.binaryPath } : {}),
     ...(typeof options.nodePath === "string" ? { nodePath: options.nodePath } : {}),
+    ...(typeof options.projectDir === "string" ? { projectDir: options.projectDir } : {}),
   };
 }
 

--- a/src/hosts/shared/hooks-json-file.ts
+++ b/src/hosts/shared/hooks-json-file.ts
@@ -132,17 +132,20 @@ function hasTokenjuiceCommand(
   config: CopilotHooksConfig,
   isTokenjuiceCommand: (command: string) => boolean,
 ): boolean {
+  const commandFields = ["command", "bash", "powershell"] as const;
   for (const bucket of Object.values(config.hooks)) {
     if (!Array.isArray(bucket)) {
       continue;
     }
     for (const entry of bucket) {
-      if (
-        isRecord(entry)
-        && typeof entry.command === "string"
-        && isTokenjuiceCommand(entry.command)
-      ) {
-        return true;
+      if (!isRecord(entry)) {
+        continue;
+      }
+      for (const field of commandFields) {
+        const command = entry[field];
+        if (typeof command === "string" && isTokenjuiceCommand(command)) {
+          return true;
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ export {
 } from "./hosts/codex/index.js";
 export type { CodexFeatureFlagStatus } from "./hosts/codex/index.js";
 export {
+  doctorCopilotAgentHook,
+  installCopilotAgentHook,
+  runCopilotAgentPostToolUseHook,
+  uninstallCopilotAgentHook,
+} from "./hosts/copilot-agent/index.js";
+export {
   doctorCopilotCliHook,
   getCopilotCliInstructionsSnippet,
   installCopilotCliHook,
@@ -181,6 +187,12 @@ export type {
   ZedDoctorReport,
   ZedInstructionsOptions,
 } from "./hosts/zed/index.js";
+export type {
+  CopilotAgentDoctorReport,
+  CopilotAgentHookCommandOptions,
+  InstallCopilotAgentHookResult,
+  UninstallCopilotAgentHookResult,
+} from "./hosts/copilot-agent/index.js";
 export type {
   CopilotCliDoctorReport,
   CopilotCliHookCommandOptions,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/copilot-agent.test.ts
+++ b/test/hosts/copilot-agent.test.ts
@@ -1,0 +1,571 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorCopilotAgentHook,
+  installCopilotAgentHook,
+  runCopilotAgentPostToolUseHook,
+  uninstallCopilotAgentHook,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+const originalHome = process.env.HOME;
+const originalMaxInline = process.env.TOKENJUICE_COPILOT_AGENT_MAX_INLINE_CHARS;
+const originalStore = process.env.TOKENJUICE_COPILOT_AGENT_STORE;
+const originalProjectDir = process.env.COPILOT_AGENT_PROJECT_DIR;
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  process.env.PATH = originalPath;
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  if (originalMaxInline === undefined) {
+    delete process.env.TOKENJUICE_COPILOT_AGENT_MAX_INLINE_CHARS;
+  } else {
+    process.env.TOKENJUICE_COPILOT_AGENT_MAX_INLINE_CHARS = originalMaxInline;
+  }
+  if (originalStore === undefined) {
+    delete process.env.TOKENJUICE_COPILOT_AGENT_STORE;
+  } else {
+    process.env.TOKENJUICE_COPILOT_AGENT_STORE = originalStore;
+  }
+  if (originalProjectDir === undefined) {
+    delete process.env.COPILOT_AGENT_PROJECT_DIR;
+  } else {
+    process.env.COPILOT_AGENT_PROJECT_DIR = originalProjectDir;
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-copilot-agent-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("installCopilotAgentHook", () => {
+  it("writes a repo-level postToolUse bash entry", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+
+    const result = await installCopilotAgentHook(undefined, {
+      projectDir,
+      binaryPath: join(projectDir, "bin", "tokenjuice"),
+    });
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      version?: number;
+      hooks: { postToolUse: Array<{ bash?: string; command?: string; matcher?: string; type?: string; timeoutSec?: number }> };
+    };
+
+    expect(result.hooksPath).toBe(hooksPath);
+    expect(parsed.version).toBe(1);
+    expect(parsed.hooks.postToolUse).toHaveLength(1);
+    expect(parsed.hooks.postToolUse[0]).not.toHaveProperty("matcher");
+    expect(parsed.hooks.postToolUse[0]?.type).toBe("command");
+    expect(parsed.hooks.postToolUse[0]?.bash).toContain("copilot-agent-post-tool-use");
+    expect(parsed.hooks.postToolUse[0]?.command).toBe(parsed.hooks.postToolUse[0]?.bash);
+    expect(parsed.hooks.postToolUse[0]?.timeoutSec).toBe(10);
+  });
+
+  it("is idempotent and preserves unrelated hook entries", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, ".github", "hooks"), { recursive: true });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        customKey: true,
+        hooks: {
+          preToolUse: [{ type: "command", matcher: "bash", bash: "echo pre" }],
+          postToolUse: [{ type: "command", matcher: "bash", bash: "echo post" }],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const options = { projectDir, binaryPath: join(projectDir, "bin", "tokenjuice") };
+    await installCopilotAgentHook(undefined, options);
+    const first = await readFile(hooksPath, "utf8");
+    await installCopilotAgentHook(undefined, options);
+    const second = await readFile(hooksPath, "utf8");
+
+    expect(second).toBe(first);
+    const parsed = JSON.parse(second) as {
+      customKey?: boolean;
+      hooks: {
+        preToolUse: Array<{ bash: string }>;
+        postToolUse: Array<{ bash: string }>;
+      };
+    };
+    expect(parsed.customKey).toBe(true);
+    expect(parsed.hooks.preToolUse[0]?.bash).toBe("echo pre");
+    expect(parsed.hooks.postToolUse).toHaveLength(2);
+    expect(parsed.hooks.postToolUse.find((entry) => entry.bash === "echo post")).toBeTruthy();
+    expect(parsed.hooks.postToolUse.find((entry) => entry.bash.includes("copilot-agent-post-tool-use"))).toBeTruthy();
+  });
+
+  it("removes stale tokenjuice entries from sibling repo hook files", async () => {
+    const projectDir = await createTempDir();
+    const hooksDir = join(projectDir, ".github", "hooks");
+    const strayPath = join(hooksDir, "stray.json");
+    process.env.PATH = "";
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(
+      strayPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+            { type: "command", bash: "echo keep" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installCopilotAgentHook(undefined, {
+      projectDir,
+      binaryPath: join(projectDir, "bin", "tokenjuice"),
+    });
+    const stray = JSON.parse(await readFile(strayPath, "utf8")) as { hooks: { postToolUse: Array<{ bash: string }> } };
+
+    expect(stray.hooks.postToolUse).toEqual([{ type: "command", bash: "echo keep" }]);
+  });
+
+  it("removes stale tokenjuice entries from other canonical hook buckets", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, ".github", "hooks"), { recursive: true });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+            { type: "command", bash: "echo keep" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await installCopilotAgentHook(undefined, {
+      projectDir,
+      binaryPath: join(projectDir, "bin", "tokenjuice"),
+    });
+    const config = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: {
+        preToolUse: Array<{ bash: string }>;
+        postToolUse: Array<{ bash: string }>;
+      };
+    };
+
+    expect(config.hooks.preToolUse).toEqual([{ type: "command", bash: "echo keep" }]);
+    expect(config.hooks.postToolUse).toHaveLength(1);
+    expect(config.hooks.postToolUse[0]?.bash).toContain("copilot-agent-post-tool-use");
+  });
+
+  it("defaults to the repository root when run from a nested directory", async () => {
+    const projectDir = await createTempDir();
+    const nestedDir = join(projectDir, "packages", "cli");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const result = await installCopilotAgentHook(undefined, {
+      binaryPath: join(projectDir, "bin", "tokenjuice"),
+    });
+
+    expect(result.hooksPath).toBe(join(await realpath(projectDir), ".github", "hooks", "tokenjuice-agent.json"));
+  });
+
+  it("fails clearly when default install is run outside a git repository", async () => {
+    const dir = await createTempDir();
+    process.chdir(dir);
+
+    await expect(installCopilotAgentHook()).rejects.toThrow(/inside a git repository/u);
+  });
+});
+
+describe("uninstallCopilotAgentHook", () => {
+  it("removes only the tokenjuice entry and preserves siblings", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+    await installCopilotAgentHook(undefined, { projectDir, binaryPath: join(projectDir, "bin", "tokenjuice") });
+
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as { hooks: { postToolUse: unknown[] } };
+    parsed.hooks.postToolUse.unshift({ type: "command", matcher: "bash", bash: "echo keep" });
+    await writeFile(hooksPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+
+    const result = await uninstallCopilotAgentHook(hooksPath);
+    const after = JSON.parse(await readFile(hooksPath, "utf8")) as { hooks: { postToolUse: Array<{ bash: string }> } };
+
+    expect(result.removed).toBe(1);
+    expect(result.deletedFile).toBe(false);
+    expect(after.hooks.postToolUse).toHaveLength(1);
+    expect(after.hooks.postToolUse[0]?.bash).toBe("echo keep");
+  });
+
+  it("deletes an empty tokenjuice-only file", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+    await installCopilotAgentHook(undefined, { projectDir, binaryPath: join(projectDir, "bin", "tokenjuice") });
+
+    const result = await uninstallCopilotAgentHook(hooksPath);
+
+    expect(result.removed).toBe(1);
+    expect(result.deletedFile).toBe(true);
+    await expect(readFile(hooksPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes tokenjuice entries from sibling repo hook files", async () => {
+    const projectDir = await createTempDir();
+    const hooksDir = join(projectDir, ".github", "hooks");
+    const hooksPath = join(hooksDir, "tokenjuice-agent.json");
+    const strayPath = join(hooksDir, "stray.json");
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(
+      strayPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+            { type: "command", bash: "echo keep" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await uninstallCopilotAgentHook(hooksPath);
+    const after = JSON.parse(await readFile(strayPath, "utf8")) as { hooks: { postToolUse: Array<{ bash: string }> } };
+
+    expect(result.removed).toBe(1);
+    expect(result.deletedFile).toBe(false);
+    expect(after.hooks.postToolUse).toEqual([{ type: "command", bash: "echo keep" }]);
+  });
+});
+
+describe("doctorCopilotAgentHook", () => {
+  it("reports disabled when the repo hook file is absent", async () => {
+    const projectDir = await createTempDir();
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath: join(projectDir, "bin", "tokenjuice") });
+
+    expect(report.status).toBe("disabled");
+    expect(report.hooksPath).toBe(join(projectDir, ".github", "hooks", "tokenjuice-agent.json"));
+  });
+
+  it("reports ok for a matching installed hook", async () => {
+    const projectDir = await createTempDir();
+    const binaryPath = join(projectDir, "bin", "tokenjuice");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, "bin"), { recursive: true });
+    await writeFile(binaryPath, "#!/bin/sh\n", { encoding: "utf8", mode: 0o755 });
+    await installCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    expect(report.status).toBe("ok");
+    expect(report.detectedCommand).toContain("copilot-agent-post-tool-use");
+    expect(report.issues).toEqual([]);
+  });
+
+  it("honors projectDir through aggregate hook doctor", async () => {
+    const projectDir = await createTempDir();
+    const home = await createTempDir();
+    process.env.HOME = home;
+    process.env.PATH = "";
+    await installCopilotAgentHook(undefined, { projectDir });
+
+    const report = await doctorInstalledHooks({ projectDir });
+
+    expect(report.integrations["copilot-agent"].status).toBe("ok");
+    expect(report.integrations["copilot-agent"].hooksPath).toBe(join(projectDir, ".github", "hooks", "tokenjuice-agent.json"));
+  });
+
+  it("reports broken when the configured repo hook file disables all hooks", async () => {
+    const projectDir = await createTempDir();
+    const binaryPath = join(projectDir, "bin", "tokenjuice");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, "bin"), { recursive: true });
+    await writeFile(binaryPath, "#!/bin/sh\n", { encoding: "utf8", mode: 0o755 });
+    await installCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    const config = JSON.parse(await readFile(hooksPath, "utf8")) as Record<string, unknown>;
+    config.disableAllHooks = true;
+    await writeFile(hooksPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    expect(report.status).toBe("broken");
+    expect(report.issues).toContain("copilot-agent hook file sets disableAllHooks: true; configured hooks will not run");
+  });
+
+  it("reports misplaced canonical tokenjuice hooks", async () => {
+    const projectDir = await createTempDir();
+    const binaryPath = join(projectDir, "bin", "tokenjuice");
+    const hooksPath = join(projectDir, ".github", "hooks", "tokenjuice-agent.json");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, ".github", "hooks"), { recursive: true });
+    await mkdir(join(projectDir, "bin"), { recursive: true });
+    await writeFile(binaryPath, "#!/bin/sh\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          preToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.detectedCommand).toContain("copilot-agent-post-tool-use");
+    expect(report.issues.some((issue) => issue.includes("outside postToolUse in preToolUse"))).toBe(true);
+  });
+
+  it("reports stray tokenjuice entries in sibling repo hook files", async () => {
+    const projectDir = await createTempDir();
+    const binaryPath = join(projectDir, "bin", "tokenjuice");
+    const hooksDir = join(projectDir, ".github", "hooks");
+    const strayPath = join(hooksDir, "stray.json");
+    process.env.PATH = "";
+    await mkdir(join(projectDir, "bin"), { recursive: true });
+    await writeFile(binaryPath, "#!/bin/sh\n", { encoding: "utf8", mode: 0o755 });
+    await installCopilotAgentHook(undefined, { projectDir, binaryPath });
+    await writeFile(
+      strayPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.issues.some((issue) => issue.includes(strayPath))).toBe(true);
+  });
+
+  it("reports active sibling hooks when the canonical repo hook file is absent", async () => {
+    const projectDir = await createTempDir();
+    const home = await createTempDir();
+    const binaryPath = join(projectDir, "bin", "tokenjuice");
+    const hooksDir = join(projectDir, ".github", "hooks");
+    const strayPath = join(hooksDir, "stray.json");
+    process.env.HOME = home;
+    process.env.PATH = "";
+    await mkdir(join(projectDir, "bin"), { recursive: true });
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(binaryPath, "#!/bin/sh\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(
+      strayPath,
+      `${JSON.stringify({
+        version: 1,
+        hooks: {
+          postToolUse: [
+            { type: "command", bash: "tokenjuice copilot-agent-post-tool-use" },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCopilotAgentHook(undefined, { projectDir, binaryPath });
+    const aggregateReport = await doctorInstalledHooks({ projectDir, binaryPath });
+
+    expect(report.status).toBe("warn");
+    expect(report.detectedCommand).toContain("copilot-agent-post-tool-use");
+    expect(report.issues.some((issue) => issue.includes(strayPath))).toBe(true);
+    expect(aggregateReport.status).toBe("warn");
+    expect(aggregateReport.integrations["copilot-agent"].status).toBe("warn");
+  });
+});
+
+describe("runCopilotAgentPostToolUseHook", () => {
+  it("rewrites compactable camelCase bash output into modifiedResult", async () => {
+    const longOutput = Array.from({ length: 120 }, (_, i) => `src/file-${i}.ts`).join("\n");
+    const payload = JSON.stringify({
+      sessionId: "abc",
+      timestamp: 1700000000000,
+      cwd: "/tmp/repo",
+      toolName: "bash",
+      toolArgs: { command: "git ls-files" },
+      toolResult: {
+        resultType: "success",
+        textResultForLlm: longOutput,
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    const response = JSON.parse(output) as { modifiedResult?: { resultType?: string; textResultForLlm?: string } };
+    expect(response.modifiedResult?.resultType).toBe("success");
+    const compacted = response.modifiedResult?.textResultForLlm ?? "";
+    expect(compacted.length).toBeGreaterThan(0);
+    expect(compacted.length).toBeLessThan(longOutput.length);
+  });
+
+  it("accepts VS Code-compatible snake_case payloads and JSON-string tool args", async () => {
+    const longOutput = Array.from({ length: 120 }, (_, i) => `src/file-${i}.ts`).join("\n");
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "bash",
+      tool_input: JSON.stringify({ command: "git ls-files" }),
+      tool_result: {
+        result_type: "success",
+        text_result_for_llm: longOutput,
+      },
+    });
+
+    const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    const response = JSON.parse(output) as {
+      modifiedResult?: {
+        textResultForLlm?: string;
+        text_result_for_llm?: string;
+      };
+    };
+    expect(response.modifiedResult?.textResultForLlm).toBeTruthy();
+    expect(response.modifiedResult?.text_result_for_llm).toBe(response.modifiedResult?.textResultForLlm);
+    expect(response.modifiedResult?.text_result_for_llm?.length).toBeLessThan(longOutput.length);
+  });
+
+  it("emits {} for failed, malformed, raw-bypass, and non-bash payloads", async () => {
+    const noisy = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const cases = [
+      "not-json",
+      JSON.stringify({
+        toolName: "view",
+        toolArgs: { command: "git ls-files" },
+        toolResult: { resultType: "success", textResultForLlm: noisy },
+      }),
+      JSON.stringify({
+        toolName: "bash",
+        toolArgs: { command: "exit 1" },
+        toolResult: { resultType: "failure", textResultForLlm: noisy },
+      }),
+      JSON.stringify({
+        toolName: "bash",
+        toolArgs: { command: "tokenjuice wrap --raw -- cat large.log" },
+        toolResult: { resultType: "success", textResultForLlm: noisy },
+      }),
+    ];
+
+    for (const payload of cases) {
+      const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("{}");
+    }
+  });
+
+  it("honors explicit full bypasses after leading cd prefixes", async () => {
+    const noisy = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const payload = JSON.stringify({
+      toolName: "bash",
+      toolArgs: { command: "cd /repo && tokenjuice wrap --full -- cat large.log" },
+      toolResult: { resultType: "success", textResultForLlm: noisy },
+    });
+
+    const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output.trim()).toBe("{}");
+  });
+
+  it("honors absolute tokenjuice raw bypass commands", async () => {
+    const noisy = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const payload = JSON.stringify({
+      toolName: "bash",
+      toolArgs: { command: "/usr/local/bin/tokenjuice wrap --raw -- cat large.log" },
+      toolResult: { resultType: "success", textResultForLlm: noisy },
+    });
+
+    const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(output.trim()).toBe("{}");
+  });
+
+  it("honors env-prefixed tokenjuice raw and full bypass commands", async () => {
+    const noisy = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const cases = [
+      "FOO=1 tokenjuice wrap --raw -- cat large.log",
+      "env FOO=1 tokenjuice wrap --full -- cat large.log",
+    ];
+
+    for (const command of cases) {
+      const payload = JSON.stringify({
+        toolName: "bash",
+        toolArgs: { command },
+        toolResult: { resultType: "success", textResultForLlm: noisy },
+      });
+      const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+
+      expect(code).toBe(0);
+      expect(output.trim()).toBe("{}");
+    }
+  });
+
+  it("does not treat inner command flags as a raw bypass without the wrap separator", async () => {
+    const noisy = Array.from({ length: 200 }, (_, i) => `diff line ${i}`).join("\n");
+    const payload = JSON.stringify({
+      toolName: "bash",
+      toolArgs: { command: "tokenjuice wrap git diff --raw" },
+      toolResult: { resultType: "success", textResultForLlm: noisy },
+    });
+
+    const { code, output } = await captureStdout(() => runCopilotAgentPostToolUseHook(payload));
+    const response = JSON.parse(output) as { modifiedResult?: { textResultForLlm?: string } };
+
+    expect(code).toBe(0);
+    expect(response.modifiedResult?.textResultForLlm).toContain("diff line");
+  });
+});


### PR DESCRIPTION
## Summary
- add `copilot-agent` as a repo-level GitHub Copilot coding agent hook integration
- install `.github/hooks/tokenjuice-agent.json` with a portable `tokenjuice copilot-agent-post-tool-use` command and repo-root resolution
- add doctor/uninstall/aggregate doctor wiring, docs, README entries, and PostToolUse payload handling/tests
- harden repair behavior for Copilot cloud agent loading every `.github/hooks/*.json`: install/uninstall clean stale tokenjuice entries in canonical and sibling hook files while preserving unrelated hooks
- preserve explicit `tokenjuice wrap --raw -- <command>` and `tokenjuice wrap --full -- <command>` bypasses, including leading `cd`, absolute tokenjuice paths, and env-prefixed commands

Rebased onto `main` after #115 merged.

## Validation
- verified against current GitHub Copilot hooks docs: cloud agent loads `.github/hooks/*.json`, command hooks honor `bash`/`command`, `postToolUse` accepts `modifiedResult`, and `matcher` is not used for `postToolUse`
- `pnpm exec vitest run test/hosts/copilot-agent.test.ts test/hosts/copilot-cli.test.ts test/hosts/vscode-copilot.test.ts test/hosts/grok-cli.test.ts test/hosts/qwen-code.test.ts test/cli/doctor-output.test.ts test/core/artifacts.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- privacy scan over changed files for personal paths, private IPs, and smoke temp names
- built CLI smoke from earlier branch validation: nested repo install/doctor, stale canonical bucket cleanup, sibling hook cleanup, snake_case `PostToolUse` compaction, and repaired doctor state
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt <Copilot Agent raw/full bypass parser fix review>`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt <Copilot Agent integration review>`

## Review notes
- accepted earlier autoreview findings and fixed sibling hook detection, uninstall cleanup, install repair cleanup, canonical misplaced hook handling, aggregate doctor visibility, and snake_case raw-output leakage
- accepted and fixed current autoreview finding: env-prefixed `tokenjuice wrap --raw/--full -- ...` bypass commands must not be compacted
- final autoreview clean: no accepted/actionable findings reported