### PR TITLE
feat(crush): add skill integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ beta integrations:
 | <img width="48px" src="docs/client-avante.png" alt="Avante" /> | [Avante.nvim](https://github.com/yetone/avante.nvim) | `tokenjuice install avante` | `avante.md` |
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
+| <img width="48px" src="docs/client-crush.svg" alt="Crush" /> | [Crush](https://github.com/charmbracelet/crush) | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
 | <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot coding agent" /> | [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) | `tokenjuice install copilot-agent` | `.github/hooks/tokenjuice-agent.json` |
@@ -66,8 +67,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -89,9 +90,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -149,6 +150,7 @@ direct payload:
 - [integration playbook](docs/integration-playbook.md)
 - [Amp integration](docs/amp-integration.md)
 - [GitHub Copilot coding agent integration](docs/copilot-agent-integration.md)
+- [Crush integration](docs/crush-integration.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)
 - [Grok CLI integration](docs/grok-cli-integration.md)

--- a/docs/client-crush.svg
+++ b/docs/client-crush.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Crush">
+  <rect width="64" height="64" rx="12" fill="#ff5c8a"/>
+  <path d="M32 50s-2.7-2.2-5.9-5.1C15.6 35.5 10 30.3 10 22.6 10 16.4 14.9 12 20.8 12c3.4 0 6.7 1.6 8.8 4.1L32 19l2.4-2.9c2.1-2.5 5.4-4.1 8.8-4.1C49.1 12 54 16.4 54 22.6c0 7.7-5.6 12.9-16.1 22.3C34.7 47.8 32 50 32 50z" fill="#fff4f7"/>
+  <path d="M22 25h20M22 32h20M22 39h13" stroke="#3b1230" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/docs/crush-integration.md
+++ b/docs/crush-integration.md
@@ -1,0 +1,47 @@
+# Crush integration
+
+Crush support is beta.
+
+`tokenjuice install crush` writes a project-local Agent Skill:
+
+```text
+.crush/skills/tokenjuice/SKILL.md
+```
+
+The skill tells Crush how to use `tokenjuice wrap -- <command>` for noisy
+terminal commands and `tokenjuice wrap --raw -- <command>` as the raw-output
+escape hatch.
+
+## Install
+
+```bash
+tokenjuice install crush
+tokenjuice doctor crush
+```
+
+## Behavior
+
+- This is guidance-only. It does not install Crush hooks and does not rewrite
+  shell commands before execution.
+- Crush remains responsible for command approval, shell state, and any existing
+  project or global hook policy.
+- The skill explicitly tells Crush not to wrap commands that intentionally
+  change shell state, such as `cd`, `export`, `source`, shell option changes,
+  or activation scripts.
+- Existing `SKILL.md` content at the tokenjuice skill path is backed up before
+  replacement.
+
+## Why this is not a hook
+
+Crush `PreToolUse` hooks can return `updated_input`, but hook composition and
+config merge behavior make a project-local command-rewrite hook risky: it can
+compete with other input rewriters, mask parent or global hook arrays, and break
+stateful shell commands by moving side effects into a child shell. The
+tokenjuice integration therefore uses an Agent Skill instead of intercepting
+command execution.
+
+## Uninstall
+
+```bash
+tokenjuice uninstall crush
+```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,6 +173,7 @@ install host wiring when tokenjuice can own it directly:
 tokenjuice install codex
 tokenjuice install claude-code
 tokenjuice install codebuddy
+tokenjuice install crush
 tokenjuice install cursor
 tokenjuice install grok-cli
 tokenjuice install pi
@@ -181,6 +182,7 @@ tokenjuice install qwen-code
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice doctor opencode
+tokenjuice doctor crush
 tokenjuice doctor grok-cli
 tokenjuice doctor qwen-code
 tokenjuice install codex --local
@@ -206,6 +208,7 @@ supported host hooks:
 | CodeBuddy (Linux/macOS/WSL) | `tokenjuice install codebuddy` | `~/.codebuddy/settings.json` | Uses `PreToolUse` shell input rewriting (same pattern as Cursor) to route Bash commands through `tokenjuice wrap`; preserves unrelated hooks that share a matcher group with the tokenjuice entry; `tokenjuice install codebuddy --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/codebuddy-integration.md` |
 | Codex CLI | `tokenjuice install codex` | `~/.codex/hooks.json` | `tokenjuice install codex --local` is available for repo-local verification |
 | Continue | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` | ✴️ Beta. Installs a workspace rule that tells Continue agents to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Continue rules do not intercept tool output; see `docs/continue-integration.md` |
+| Crush | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` | ✴️ Beta. Installs a project Agent Skill that tells Crush to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Crush hook composition and stateful shell behavior make command rewriting unsafe; see `docs/crush-integration.md` |
 | Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; `tokenjuice install cursor --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
 | Droid (Factory CLI) | `tokenjuice install droid` | `~/.factory/settings.json` | Uses a `PostToolUse` hook for the `Execute` tool to compact shell output before Droid sees it; preserves unrelated settings keys; `tokenjuice install droid --local` is available for repo-local verification |
 | Gemini CLI | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` | ✴️ Beta. Uses an `AfterTool` hook for `run_shell_command` to compact shell output before Gemini CLI sees it; `tokenjuice install gemini-cli --local` is available for repo-local verification; see `docs/gemini-cli-integration.md` |
@@ -223,7 +226,7 @@ supported host hooks:
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/doctor-output.ts
+++ b/src/cli/doctor-output.ts
@@ -3,29 +3,30 @@ import type { HookDoctorReport } from "../hosts/shared/hook-doctor.js";
 
 type IntegrationDoctorReport = HookDoctorReport["integrations"][keyof HookDoctorReport["integrations"]];
 
+function getStringField(report: IntegrationDoctorReport, key: string): string | undefined {
+  if (key in report) {
+    const value = (report as Record<string, unknown>)[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function getIntegrationPath(report: IntegrationDoctorReport): string {
-  if ("hooksPath" in report) {
-    return report.hooksPath;
-  }
-  if ("settingsPath" in report) {
-    return report.settingsPath;
-  }
-  if ("hookPath" in report) {
-    return report.hookPath;
-  }
-  if ("rulePath" in report) {
-    return report.rulePath;
-  }
-  if ("steeringPath" in report) {
-    return report.steeringPath;
-  }
-  if ("conventionPath" in report) {
-    return report.conventionPath;
-  }
-  if ("instructionsPath" in report) {
-    return report.instructionsPath;
-  }
-  return report.extensionPath;
+  return (
+    getStringField(report, "hooksPath") ??
+    getStringField(report, "settingsPath") ??
+    getStringField(report, "hookPath") ??
+    getStringField(report, "rulePath") ??
+    getStringField(report, "skillPath") ??
+    getStringField(report, "configPath") ??
+    getStringField(report, "steeringPath") ??
+    getStringField(report, "conventionPath") ??
+    getStringField(report, "instructionsPath") ??
+    getStringField(report, "extensionPath") ??
+    "(unknown)"
+  );
 }
 
 function appendInstallHint(lines: string[]): void {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -29,6 +29,7 @@ import {
   runCopilotCliPostToolUseHook,
   uninstallCopilotCliHook,
 } from "../hosts/copilot-cli/index.js";
+import { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "../hosts/crush/index.js";
 import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../hosts/cursor/index.js";
 import { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "../hosts/droid/index.js";
 import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "../hosts/gemini-cli/index.js";
@@ -112,6 +113,7 @@ function printUsage(): void {
       "  tokenjuice install codebuddy [--local]",
       "  tokenjuice install continue",
       "  tokenjuice install copilot-agent [--local]",
+      "  tokenjuice install crush",
       "  tokenjuice install cursor [--local]",
       "  tokenjuice install droid [--local]",
       "  tokenjuice install gemini-cli [--local]",
@@ -135,6 +137,7 @@ function printUsage(): void {
       "  tokenjuice uninstall cline",
       "  tokenjuice uninstall continue",
       "  tokenjuice uninstall copilot-agent",
+      "  tokenjuice uninstall crush",
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall gemini-cli",
       "  tokenjuice uninstall grok-cli",
@@ -153,7 +156,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -665,6 +668,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "crush") {
+    const result = await installCrushSkill();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Skill", value: result.skillPath },
+      { label: "Beta", value: "project-local Agent Skill; Crush still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor crush" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("crush", "skill", details));
+    return 0;
+  }
+
   if (target === "cursor") {
     const result = await installCursorHook(undefined, { local: args.local });
     if (args.format === "json") {
@@ -997,7 +1020,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1102,6 +1125,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
       process.stdout.write("deleted empty hook file: yes\n");
     }
     process.stdout.write("enable: tokenjuice install copilot-agent\n");
+    return 0;
+  }
+
+  if (target === "crush") {
+    const result = await uninstallCrushSkill();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed crush skill: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`skill path: ${result.skillPath}\n`);
+    process.stdout.write("enable: tokenjuice install crush\n");
     return 0;
   }
 
@@ -1289,7 +1325,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1654,6 +1690,38 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     if (report.detectedCommand) {
       process.stdout.write(`configured command: ${report.detectedCommand}\n`);
     }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "crush") {
+    const report = await doctorCrushSkill();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`skill path: ${report.skillPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");
       for (const issue of report.issues) {

--- a/src/hosts/crush/index.ts
+++ b/src/hosts/crush/index.ts
@@ -1,0 +1,182 @@
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
+import { buildInstructionDoctorReportFields, instructionDoctorStatusFromIssues } from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+
+export type CrushSkillOptions = {
+  projectDir?: string;
+};
+
+export type InstallCrushSkillResult = {
+  skillPath: string;
+  backupPath?: string;
+};
+
+export type UninstallCrushSkillResult = {
+  skillPath: string;
+  removed: boolean;
+};
+
+export type CrushDoctorReport = {
+  skillPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_CRUSH_FIX_COMMAND = "tokenjuice install crush";
+const TOKENJUICE_CRUSH_MARKER = "tokenjuice terminal output compaction";
+const TOKENJUICE_CRUSH_ADVISORY =
+  "Crush support is beta and skill-based; it guides command usage but does not intercept or rewrite shell output.";
+const TOKENJUICE_CRUSH_REINSTALL_BACKUP_SUFFIX = ".tokenjuice.bak";
+
+function getProjectDir(options: CrushSkillOptions = {}): string {
+  return options.projectDir || process.env.CRUSH_PROJECT_DIR || process.cwd();
+}
+
+function getDefaultSkillPath(options: CrushSkillOptions = {}): string {
+  return join(getProjectDir(options), ".crush", "skills", "tokenjuice", "SKILL.md");
+}
+
+const TOKENJUICE_CRUSH_SKILL = [
+  "---",
+  "name: tokenjuice",
+  "description: Use tokenjuice to compact noisy terminal command output while preserving a raw-output escape hatch.",
+  "---",
+  "",
+  `# ${TOKENJUICE_CRUSH_MARKER}`,
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through Crush, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  "",
+  "This skill is guidance-only. Do not rewrite commands that intentionally change Crush shell state, such as `cd`, `export`, `source`, shell option changes, or activation scripts.",
+  "",
+].join("\n");
+
+async function writeCrushSkillWithoutBackup(skillPath: string): Promise<void> {
+  await mkdir(dirname(skillPath), { recursive: true });
+  const tempPath = `${skillPath}.tmp`;
+  await writeFile(tempPath, TOKENJUICE_CRUSH_SKILL, "utf8");
+  await rename(tempPath, skillPath);
+}
+
+function isTokenjuiceCrushSkillText(text: string): boolean {
+  return text.includes(TOKENJUICE_CRUSH_MARKER)
+    || text.includes(TOKENJUICE_WRAP_COMMAND)
+    || text.includes(TOKENJUICE_RAW_COMMAND);
+}
+
+export async function installCrushSkill(
+  skillPath?: string,
+  options: CrushSkillOptions = {},
+): Promise<InstallCrushSkillResult> {
+  const resolvedSkillPath = skillPath ?? getDefaultSkillPath(options);
+  const existing = await readInstructionFile(resolvedSkillPath);
+  if (existing.exists && isTokenjuiceCrushSkillText(existing.text)) {
+    if (existing.text === TOKENJUICE_CRUSH_SKILL) {
+      return { skillPath: resolvedSkillPath };
+    }
+
+    const primaryBackupPath = `${resolvedSkillPath}.bak`;
+    const primaryBackup = await readInstructionFile(primaryBackupPath);
+    const backupPath = primaryBackup.exists && !isTokenjuiceCrushSkillText(primaryBackup.text)
+      ? `${resolvedSkillPath}${TOKENJUICE_CRUSH_REINSTALL_BACKUP_SUFFIX}`
+      : primaryBackupPath;
+    await writeFile(backupPath, existing.text, "utf8");
+    await writeCrushSkillWithoutBackup(resolvedSkillPath);
+    return { skillPath: resolvedSkillPath, backupPath };
+  }
+
+  const result = await writeInstructionFile(resolvedSkillPath, TOKENJUICE_CRUSH_SKILL);
+  return {
+    skillPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallCrushSkill(skillPath = getDefaultSkillPath()): Promise<UninstallCrushSkillResult> {
+  const existing = await readInstructionFile(skillPath);
+  if (!existing.exists || !isTokenjuiceCrushSkillText(existing.text)) {
+    return { skillPath, removed: false };
+  }
+
+  const backupPath = `${skillPath}.bak`;
+  const backup = await readInstructionFile(backupPath);
+  if (backup.exists && !isTokenjuiceCrushSkillText(backup.text)) {
+    await rm(skillPath, { force: true });
+    await rename(backupPath, skillPath);
+    return { skillPath, removed: true };
+  }
+
+  const result = await removeInstructionFile(skillPath);
+  return { skillPath: result.filePath, removed: result.removed };
+}
+
+export async function doctorCrushSkill(
+  skillPath?: string,
+  options: CrushSkillOptions = {},
+): Promise<CrushDoctorReport> {
+  const resolvedSkillPath = skillPath ?? getDefaultSkillPath(options);
+  const existing = await readInstructionFile(resolvedSkillPath);
+  if (!existing.exists) {
+    return {
+      skillPath: resolvedSkillPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Crush skill is not installed"],
+        advisory: TOKENJUICE_CRUSH_ADVISORY,
+        fixCommand: TOKENJUICE_CRUSH_FIX_COMMAND,
+      }),
+    };
+  }
+  if (!isTokenjuiceCrushSkillText(existing.text)) {
+    return {
+      skillPath: resolvedSkillPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Crush skill is not installed"],
+        advisory: TOKENJUICE_CRUSH_ADVISORY,
+        fixCommand: TOKENJUICE_CRUSH_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const issues = collectGuidanceIssues(existing.text, {
+    required: [
+      {
+        requiredText: TOKENJUICE_CRUSH_MARKER,
+        missingIssue: "configured Crush skill does not look like the tokenjuice skill",
+      },
+      {
+        requiredText: TOKENJUICE_WRAP_COMMAND,
+        missingIssue: "configured Crush skill is missing tokenjuice wrap guidance",
+      },
+      {
+        requiredText: TOKENJUICE_RAW_COMMAND,
+        missingIssue: "configured Crush skill is missing the raw escape hatch",
+      },
+    ],
+    forbidden: [
+      {
+        forbiddenText: TOKENJUICE_FULL_COMMAND,
+        presentIssue: "configured Crush skill still suggests the full escape hatch",
+      },
+    ],
+  });
+
+  return {
+    skillPath: resolvedSkillPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_CRUSH_ADVISORY,
+      fixCommand: TOKENJUICE_CRUSH_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -8,6 +8,7 @@ import { doctorContinueRule } from "../continue/index.js";
 import { doctorCodexHook } from "../codex/index.js";
 import { doctorCopilotAgentHook } from "../copilot-agent/index.js";
 import { doctorCopilotCliHook } from "../copilot-cli/index.js";
+import { doctorCrushSkill } from "../crush/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
 import { doctorDroidHook } from "../droid/index.js";
 import { doctorGeminiCliHook } from "../gemini-cli/index.js";
@@ -33,6 +34,7 @@ import type { ContinueDoctorReport } from "../continue/index.js";
 import type { CodexDoctorReport, CodexHookCommandOptions } from "../codex/index.js";
 import type { CopilotAgentDoctorReport, CopilotAgentHookCommandOptions } from "../copilot-agent/index.js";
 import type { CopilotCliDoctorReport } from "../copilot-cli/index.js";
+import type { CrushDoctorReport, CrushSkillOptions } from "../crush/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
 import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
@@ -60,6 +62,7 @@ export type HookIntegrationDoctorReport = {
   cline: ClineDoctorReport;
   codebuddy: CodeBuddyDoctorReport;
   continue: ContinueDoctorReport;
+  crush: CrushDoctorReport;
   cursor: CursorDoctorReport;
   droid: DroidDoctorReport;
   "gemini-cli": GeminiCliDoctorReport;
@@ -82,7 +85,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
+export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -103,6 +106,7 @@ const hookDoctorIntegrationDoctors = {
   codebuddy: (options) => doctorCodeBuddyHook(undefined, getHookCommandOptions(options)),
   continue: () => doctorContinueRule(),
   "copilot-agent": (options) => doctorCopilotAgentHook(undefined, getHookCommandOptions(options)),
+  crush: (options) => doctorCrushSkill(undefined, getHookCommandOptions(options)),
   cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
   runCopilotCliPostToolUseHook,
   uninstallCopilotCliHook,
 } from "./hosts/copilot-cli/index.js";
+export { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "./hosts/crush/index.js";
 export { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "./hosts/cursor/index.js";
 export { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "./hosts/droid/index.js";
 export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "./hosts/gemini-cli/index.js";
@@ -206,4 +207,10 @@ export type {
   InstallCopilotCliHookResult,
   UninstallCopilotCliHookResult,
 } from "./hosts/copilot-cli/index.js";
+export type {
+  CrushDoctorReport,
+  CrushSkillOptions,
+  InstallCrushSkillResult,
+  UninstallCrushSkillResult,
+} from "./hosts/crush/index.js";
 export type { DiscoverOptions, StatsOptions, StatsReport, StatsSourceReport } from "./core/analysis.js";

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,9 +71,47 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
+  });
+
+  it("prefers rule paths over config paths for integrations that expose both", () => {
+    const report = {
+      status: "ok",
+      integrations: {
+        kilo: {
+          rulePath: "/tmp/project/.kilo/rules/tokenjuice.md",
+          configPath: "/tmp/project/kilo.jsonc",
+          status: "ok",
+          issues: [],
+          advisories: [],
+          missingPaths: [],
+          fixCommand: "tokenjuice install kilo",
+        },
+      },
+    } as unknown as HookDoctorReport;
+
+    expect(formatHookDoctorReport(report)).toContain("- path: /tmp/project/.kilo/rules/tokenjuice.md");
+    expect(formatHookDoctorReport(report)).not.toContain("- path: /tmp/project/kilo.jsonc");
+  });
+
+  it("prints skill paths for skill-backed integrations", () => {
+    const report = {
+      status: "ok",
+      integrations: {
+        crush: {
+          skillPath: "/tmp/project/.crush/skills/tokenjuice/SKILL.md",
+          status: "ok",
+          issues: [],
+          advisories: [],
+          missingPaths: [],
+          fixCommand: "tokenjuice install crush",
+        },
+      },
+    } as unknown as HookDoctorReport;
+
+    expect(formatHookDoctorReport(report)).toContain("- path: /tmp/project/.crush/skills/tokenjuice/SKILL.md");
   });
 });

--- a/test/hosts/crush.test.ts
+++ b/test/hosts/crush.test.ts
@@ -1,0 +1,241 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorCrushSkill,
+  doctorInstalledHooks,
+  installCrushSkill,
+  uninstallCrushSkill,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AMP_PROJECT_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CRUSH_PROJECT_DIR",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_HOME",
+  "HOME",
+  "OPENCODE_CONFIG_DIR",
+  "PI_CODING_AGENT_DIR",
+  "QWEN_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-crush-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("crush skill", () => {
+  it("installs a project skill with the tokenjuice escape hatch", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+
+    const result = await installCrushSkill(undefined, { projectDir: home });
+    const skill = await readFile(skillPath, "utf8");
+
+    expect(result.skillPath).toBe(skillPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(skill).toContain("name: tokenjuice");
+    expect(skill).toContain("tokenjuice terminal output compaction");
+    expect(skill).toContain("tokenjuice wrap -- <command>");
+    expect(skill).toContain("tokenjuice wrap --raw -- <command>");
+    expect(skill).toContain("guidance-only");
+    expect(skill).toContain("cd`, `export`, `source");
+    expect(skill).not.toContain("wrap --full");
+  });
+
+  it("backs up an existing skill before replacing it", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await installCrushSkill(undefined, { projectDir: home });
+    await writeFile(skillPath, "custom skill\n", "utf8");
+
+    const result = await installCrushSkill(undefined, { projectDir: home });
+
+    expect(result.backupPath).toBe(`${skillPath}.bak`);
+    await expect(readFile(`${skillPath}.bak`, "utf8")).resolves.toBe("custom skill\n");
+    await expect(readFile(skillPath, "utf8")).resolves.toContain("tokenjuice wrap --raw -- <command>");
+  });
+
+  it("does not create a backup for idempotent reinstalls", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+
+    await installCrushSkill(undefined, { projectDir: home });
+    const result = await installCrushSkill(undefined, { projectDir: home });
+
+    expect(result.backupPath).toBeUndefined();
+    await expect(access(`${skillPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("backs up edited tokenjuice skill content before reinstalling", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await installCrushSkill(undefined, { projectDir: home });
+    await writeFile(skillPath, "# tokenjuice terminal output compaction\n\ncustom tokenjuice edit\n", "utf8");
+
+    const result = await installCrushSkill(undefined, { projectDir: home });
+
+    expect(result.backupPath).toBe(`${skillPath}.bak`);
+    await expect(readFile(`${skillPath}.bak`, "utf8")).resolves.toContain("custom tokenjuice edit");
+    await expect(readFile(skillPath, "utf8")).resolves.toContain("tokenjuice wrap --raw -- <command>");
+  });
+
+  it("does not restore tokenjuice guidance with an edited marker on uninstall", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await installCrushSkill(undefined, { projectDir: home });
+    await writeFile(skillPath, "---\nname: tokenjuice\n---\n\nuse `tokenjuice wrap -- <command>`\n", "utf8");
+    await installCrushSkill(undefined, { projectDir: home });
+
+    const removed = await uninstallCrushSkill(skillPath);
+
+    expect(removed.removed).toBe(true);
+    await expect(access(skillPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(`${skillPath}.bak`, "utf8")).resolves.toContain("tokenjuice wrap -- <command>");
+  });
+
+  it("restores a backed-up custom skill on uninstall", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await installCrushSkill(undefined, { projectDir: home });
+    await writeFile(skillPath, "custom skill\n", "utf8");
+    await installCrushSkill(undefined, { projectDir: home });
+    await installCrushSkill(undefined, { projectDir: home });
+
+    const removed = await uninstallCrushSkill(skillPath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(skillPath, "utf8")).resolves.toBe("custom skill\n");
+    await expect(access(`${skillPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports installed and uninstalled skill health", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+
+    await installCrushSkill(undefined, { projectDir: home });
+    const installed = await doctorCrushSkill(undefined, { projectDir: home });
+
+    expect(installed.status).toBe("ok");
+    expect(installed.skillPath).toBe(skillPath);
+    expect(installed.advisories[0]).toContain("skill-based");
+
+    const removed = await uninstallCrushSkill(skillPath);
+    const disabled = await doctorCrushSkill(undefined, { projectDir: home });
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken skills when tokenjuice guidance is stale", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await mkdir(join(home, ".crush", "skills", "tokenjuice"), { recursive: true });
+    await writeFile(
+      skillPath,
+      [
+        "---",
+        "name: tokenjuice",
+        "---",
+        "",
+        "# tokenjuice terminal output compaction",
+        "",
+        "- For noisy commands, use `tokenjuice wrap -- <command>`.",
+        "- If output looks wrong, rerun with `tokenjuice wrap --full -- <command>`.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorCrushSkill(undefined, { projectDir: home });
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Crush skill is missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Crush skill still suggests the full escape hatch");
+  });
+
+  it("treats custom skills at the tokenjuice path as disabled", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await mkdir(join(home, ".crush", "skills", "tokenjuice"), { recursive: true });
+    await writeFile(skillPath, "---\nname: tokenjuice\n---\n\ncustom skill\n", "utf8");
+
+    const doctor = await doctorCrushSkill(undefined, { projectDir: home });
+
+    expect(doctor.status).toBe("disabled");
+    expect(doctor.issues).toContain("tokenjuice Crush skill is not installed");
+  });
+
+  it("does not remove an existing skill file without tokenjuice content", async () => {
+    const home = await createTempDir();
+    const skillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    await mkdir(join(home, ".crush", "skills", "tokenjuice"), { recursive: true });
+    await writeFile(skillPath, "---\nname: tokenjuice\n---\n\ncustom skill\n", "utf8");
+
+    const removed = await uninstallCrushSkill(skillPath);
+
+    expect(removed.removed).toBe(false);
+    await expect(readFile(skillPath, "utf8")).resolves.toContain("custom skill");
+  });
+
+  it("uses CRUSH_PROJECT_DIR for the default skill file", async () => {
+    const home = await createTempDir();
+    process.env.CRUSH_PROJECT_DIR = home;
+
+    const installed = await installCrushSkill();
+    const expectedSkillPath = join(home, ".crush", "skills", "tokenjuice", "SKILL.md");
+    const doctor = await doctorCrushSkill();
+
+    expect(installed.skillPath).toBe(expectedSkillPath);
+    expect(doctor.skillPath).toBe(expectedSkillPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("passes projectDir through aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    const configHome = join(home, "home");
+    await installCrushSkill(undefined, { projectDir: home });
+    process.env.HOME = configHome;
+    process.env.FACTORY_HOME = join(configHome, ".factory");
+    process.env.CODEX_HOME = join(configHome, ".codex");
+    process.env.CLAUDE_CONFIG_DIR = join(configHome, ".claude");
+    process.env.CODEBUDDY_CONFIG_DIR = join(configHome, ".codebuddy");
+    process.env.CURSOR_HOME = join(configHome, ".cursor");
+    process.env.GEMINI_HOME = join(configHome, ".gemini");
+    process.env.GROK_HOME = join(configHome, ".grok");
+    process.env.COPILOT_HOME = join(configHome, ".copilot");
+    process.env.PI_CODING_AGENT_DIR = join(configHome, ".pi", "agent");
+    process.env.OPENCODE_CONFIG_DIR = join(configHome, ".config", "opencode");
+    process.env.AMP_PROJECT_DIR = join(configHome, "amp-project");
+    process.env.QWEN_PROJECT_DIR = join(configHome, "qwen-project");
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.crush.status).toBe("ok");
+    expect(report.integrations.crush.skillPath).toBe(join(home, ".crush", "skills", "tokenjuice", "SKILL.md"));
+  });
+});


### PR DESCRIPTION
## Summary
- replace the unsafe Crush PreToolUse hook approach with a guidance-only project Agent Skill at `.crush/skills/tokenjuice/SKILL.md`
- wire install, uninstall, direct doctor, aggregate doctor, exports, README, and docs/spec around the skill surface
- preserve custom skill content: install backs up existing non-tokenjuice content, reinstall preserves that backup, uninstall restores it, and unrelated custom skills are treated as disabled

## Why
Crush command-rewriting hooks are too easy to compose badly: they can compete with other input rewriters and break stateful shell commands. The skill path gives Crush guidance without intercepting command execution.

## Validation
- `pnpm exec vitest run test/hosts/crush.test.ts test/hosts/amp.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check origin/main...HEAD`
- isolated CLI smoke: install/doctor hooks/reinstall/uninstall restores preexisting custom Crush skill
- isolated CLI smoke: custom frontmatter-only Crush skill reports disabled in direct and aggregate doctor
- autoreview clean: no accepted/actionable findings reported
