### PR TITLE
feat(goose): add hints integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ beta integrations:
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-crush.svg" alt="Crush" /> | [Crush](https://github.com/charmbracelet/crush) | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
+| <img width="48px" src="docs/client-goose.svg" alt="Goose" /> | [Goose](https://goose-docs.ai/) | `tokenjuice install goose` | `.goosehints` |
 | <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot coding agent" /> | [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) | `tokenjuice install copilot-agent` | `.github/hooks/tokenjuice-agent.json` |
 | <img width="48px" src="docs/client-junie.svg" alt="Junie" /> | [Junie](https://junie.jetbrains.com/docs/junie-cli-usage.html) | `tokenjuice install junie` | `.junie/AGENTS.md` |
@@ -67,8 +68,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -90,9 +91,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -153,6 +154,7 @@ direct payload:
 - [Crush integration](docs/crush-integration.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)
+- [Goose integration](docs/goose-integration.md)
 - [Grok CLI integration](docs/grok-cli-integration.md)
 - [Kiro integration](docs/kiro-integration.md)
 - [Kilo Code integration](docs/kilo-integration.md)

--- a/docs/client-goose.svg
+++ b/docs/client-goose.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Goose</title>
+  <desc id="desc">Simple Goose integration mark</desc>
+  <rect width="96" height="96" rx="18" fill="#f8fafc"/>
+  <path d="M31 57c0-15 9-27 24-27 9 0 16 5 20 12" fill="none" stroke="#0f172a" stroke-width="8" stroke-linecap="round"/>
+  <path d="M26 62c12 8 27 10 42 4" fill="none" stroke="#0f766e" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="62" cy="36" r="4" fill="#0f172a"/>
+  <path d="M74 42l12 2-11 7" fill="none" stroke="#f59e0b" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/goose-integration.md
+++ b/docs/goose-integration.md
@@ -1,0 +1,34 @@
+# Goose integration
+
+Goose support is beta.
+
+`tokenjuice install goose` inserts a marker-delimited hints block into
+`.goosehints` at the workspace root. Goose loads `.goosehints` as project
+context, so this gives the agent stable guidance for using tokenjuice when it
+runs terminal commands.
+
+## Install
+
+```bash
+tokenjuice install goose
+tokenjuice doctor goose
+```
+
+Restart the Goose session after installing or changing `.goosehints` so Goose
+loads the updated hints.
+
+## Behavior
+
+- The hints block tells Goose to prefer `tokenjuice wrap -- <command>` for
+  terminal commands likely to produce long output.
+- The hints block tells Goose to treat compacted output as authoritative.
+- The only documented escape hatch is `tokenjuice wrap --raw -- <command>`.
+- Existing `.goosehints` content is backed up before install and preserved
+  around the tokenjuice block.
+
+## Current beta caveat
+
+Goose hints are prompt guidance, not command hooks. Goose has lifecycle hooks,
+but this integration does not rely on them because the documented hooks surface
+does not guarantee shell output replacement. It gives Goose a stable project
+hint to follow when it decides how to run terminal commands.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -176,6 +176,7 @@ tokenjuice install codebuddy
 tokenjuice install crush
 tokenjuice install cursor
 tokenjuice install grok-cli
+tokenjuice install goose
 tokenjuice install pi
 tokenjuice install opencode
 tokenjuice install qwen-code
@@ -184,6 +185,7 @@ tokenjuice doctor pi
 tokenjuice doctor opencode
 tokenjuice doctor crush
 tokenjuice doctor grok-cli
+tokenjuice doctor goose
 tokenjuice doctor qwen-code
 tokenjuice install codex --local
 tokenjuice install claude-code --local
@@ -212,6 +214,7 @@ supported host hooks:
 | Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; `tokenjuice install cursor --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
 | Droid (Factory CLI) | `tokenjuice install droid` | `~/.factory/settings.json` | Uses a `PostToolUse` hook for the `Execute` tool to compact shell output before Droid sees it; preserves unrelated settings keys; `tokenjuice install droid --local` is available for repo-local verification |
 | Gemini CLI | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` | ✴️ Beta. Uses an `AfterTool` hook for `run_shell_command` to compact shell output before Gemini CLI sees it; `tokenjuice install gemini-cli --local` is available for repo-local verification; see `docs/gemini-cli-integration.md` |
+| Goose | `tokenjuice install goose` | `.goosehints` | ✴️ Beta. Inserts a marker-delimited hints block that tells Goose to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Goose hints do not intercept tool output; restart the Goose session after install; see `docs/goose-integration.md` |
 | Grok CLI | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` | ✴️ Beta. Uses a user-level `PostToolUse` hook for the `bash` tool; compacted context is injected alongside the original output; `tokenjuice install grok-cli --local` is available for repo-local verification; see `docs/grok-cli-integration.md` |
 | GitHub Copilot CLI | `tokenjuice install copilot-cli` | `~/.copilot/hooks/tokenjuice-cli.json` | Uses `postToolUse` shell output rewriting on the `bash` tool (matcher `"shell"`) to compact command output before it returns to the agent. Honors `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the VS Code Copilot Chat install. After install, run `tokenjuice doctor copilot-cli --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |
 | Junie | `tokenjuice install junie` | `.junie/AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block that tells Junie to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Junie instructions do not intercept tool output; see `docs/junie-integration.md` |

--- a/src/cli/doctor-output.ts
+++ b/src/cli/doctor-output.ts
@@ -18,6 +18,7 @@ function getIntegrationPath(report: IntegrationDoctorReport): string {
     getStringField(report, "hooksPath") ??
     getStringField(report, "settingsPath") ??
     getStringField(report, "hookPath") ??
+    getStringField(report, "hintsPath") ??
     getStringField(report, "rulePath") ??
     getStringField(report, "skillPath") ??
     getStringField(report, "configPath") ??

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -33,6 +33,7 @@ import { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "../hos
 import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../hosts/cursor/index.js";
 import { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "../hosts/droid/index.js";
 import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "../hosts/gemini-cli/index.js";
+import { doctorGooseHints, installGooseHints, uninstallGooseHints } from "../hosts/goose/index.js";
 import { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "../hosts/grok-cli/index.js";
 import { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "../hosts/junie/index.js";
 import { doctorKiroSteering, installKiroSteering, uninstallKiroSteering } from "../hosts/kiro/index.js";
@@ -117,6 +118,7 @@ function printUsage(): void {
       "  tokenjuice install cursor [--local]",
       "  tokenjuice install droid [--local]",
       "  tokenjuice install gemini-cli [--local]",
+      "  tokenjuice install goose",
       "  tokenjuice install grok-cli [--local]",
       "  tokenjuice install junie",
       "  tokenjuice install kiro",
@@ -140,6 +142,7 @@ function printUsage(): void {
       "  tokenjuice uninstall crush",
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall gemini-cli",
+      "  tokenjuice uninstall goose",
       "  tokenjuice uninstall grok-cli",
       "  tokenjuice uninstall junie",
       "  tokenjuice uninstall kiro",
@@ -156,7 +159,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -750,6 +753,27 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "goose") {
+    const result = await installGooseHints();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Hints", value: result.hintsPath },
+      { label: "Beta", value: "hints-based guidance; Goose still owns command execution" },
+      { label: "Reload", value: "restart Goose so the updated .goosehints file is loaded" },
+      { label: "Verify", value: "tokenjuice doctor goose" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("goose", "hints", details));
+    return 0;
+  }
+
   if (target === "junie") {
     const result = await installJunieInstructions();
     if (args.format === "json") {
@@ -1020,7 +1044,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1164,6 +1188,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed grok-cli entries: ${result.removed}\n`);
     process.stdout.write(`settings path: ${result.settingsPath}\n`);
     process.stdout.write("enable: tokenjuice install grok-cli\n");
+    return 0;
+  }
+
+  if (target === "goose") {
+    const result = await uninstallGooseHints();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed goose hints: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`hints path: ${result.hintsPath}\n`);
+    process.stdout.write("enable: tokenjuice install goose\n");
     return 0;
   }
 
@@ -1325,7 +1362,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1870,6 +1907,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("missing paths:\n");
       for (const path of report.missingPaths) {
         process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "goose") {
+    const report = await doctorGooseHints();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`hints path: ${report.hintsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
       }
     }
     if (report.advisories.length > 0) {

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -37,6 +37,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("grok")) {
     return "grok-cli";
   }
+  if (source.startsWith("goose")) {
+    return "goose";
+  }
   if (source.startsWith("openclaw")) {
     return "openclaw";
   }

--- a/src/hosts/goose/index.ts
+++ b/src/hosts/goose/index.ts
@@ -1,0 +1,375 @@
+import { readdir, realpath, stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import { buildTokenjuiceGuidanceBullets } from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+import {
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+
+export type GooseHintsOptions = {
+  projectDir?: string;
+  scanProjectTree?: boolean;
+};
+
+export type InstallGooseHintsResult = {
+  hintsPath: string;
+  hintsPaths?: string[];
+  backupPath?: string;
+};
+
+export type UninstallGooseHintsResult = {
+  hintsPath: string;
+  removedPaths?: string[];
+  removed: boolean;
+};
+
+export type GooseDoctorReport = {
+  hintsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_GOOSE_FIX_COMMAND = "tokenjuice install goose";
+const TOKENJUICE_GOOSE_BEGIN = "<!-- tokenjuice:begin -->";
+const TOKENJUICE_GOOSE_END = "<!-- tokenjuice:end -->";
+const TOKENJUICE_GOOSE_ADVISORY = "Goose support is beta and hints-based; it guides command usage but does not intercept tool output.";
+const GOOSE_HINTS_FILENAME = ".goosehints";
+const GOOSE_HINTS_SCAN_SKIP_DIRS = new Set([".git", "node_modules"]);
+
+function getExplicitProjectDir(options: GooseHintsOptions = {}): string | undefined {
+  return options.projectDir || process.env.GOOSE_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: GooseHintsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+async function isInsideOrEqualPath(childPath: string, parentPath: string): Promise<boolean> {
+  const child = await canonicalPath(childPath);
+  const parent = await canonicalPath(parentPath);
+  const relativePath = relative(parent, child);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+async function uniqueCanonicalPaths(paths: string[]): Promise<string[]> {
+  const seen = new Set<string>();
+  const uniquePaths: string[] = [];
+  for (const path of paths) {
+    const key = await canonicalPath(path);
+    if (!seen.has(key)) {
+      seen.add(key);
+      uniquePaths.push(path);
+    }
+  }
+  return uniquePaths;
+}
+
+function getHintsPathForDir(dir: string): string {
+  return join(resolve(dir), GOOSE_HINTS_FILENAME);
+}
+
+async function getTokenjuiceHintsPathInDir(dir: string): Promise<string | undefined> {
+  const hintsPath = getHintsPathForDir(dir);
+  const existing = await readInstructionFile(hintsPath);
+  return existing.exists && (existing.text.includes(TOKENJUICE_GOOSE_BEGIN) || existing.text.includes(TOKENJUICE_GOOSE_END))
+    ? hintsPath
+    : undefined;
+}
+
+async function findParentTokenjuiceHintsPaths(startDir: string, boundaryDir: string): Promise<string[]> {
+  let current = resolve(startDir);
+  const boundary = resolve(boundaryDir);
+  const paths: string[] = [];
+  while (await isInsideOrEqualPath(current, boundary)) {
+    const hintsPath = await getTokenjuiceHintsPathInDir(current);
+    if (hintsPath) {
+      paths.push(hintsPath);
+    }
+    if (await isInsideOrEqualPath(boundary, current)) {
+      return paths;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return paths;
+    }
+    current = parent;
+  }
+  return paths;
+}
+
+async function findProjectTokenjuiceHintsPaths(projectDir: string): Promise<string[]> {
+  const root = resolve(projectDir);
+  const paths: string[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    const hintsPath = await getTokenjuiceHintsPathInDir(dir);
+    if (hintsPath) {
+      paths.push(hintsPath);
+    }
+
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || GOOSE_HINTS_SCAN_SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      const childDir = join(dir, entry.name);
+      if (await hasGitMetadata(childDir)) {
+        continue;
+      }
+      await visit(childDir);
+    }
+  }
+
+  await visit(root);
+  return paths;
+}
+
+function shouldScanProjectTree(options: GooseHintsOptions): boolean {
+  return options.scanProjectTree !== false;
+}
+
+async function getDefaultHintsPaths(
+  options: GooseHintsOptions = {},
+  preferExistingTokenjuiceBlocks = false,
+  includeRootWithExistingBlocks = false,
+): Promise<string[]> {
+  const projectDir = await resolveProjectDir(options);
+  const rootHintsPath = getHintsPathForDir(projectDir);
+  const existingHintsPaths: string[] = [];
+  const cwdIsInsideProject = await isInsideOrEqualPath(process.cwd(), projectDir);
+  if (preferExistingTokenjuiceBlocks && cwdIsInsideProject) {
+    existingHintsPaths.push(...await findParentTokenjuiceHintsPaths(process.cwd(), projectDir));
+  }
+  if (preferExistingTokenjuiceBlocks && shouldScanProjectTree(options)) {
+    existingHintsPaths.push(...await findProjectTokenjuiceHintsPaths(projectDir));
+  }
+  if (existingHintsPaths.length > 0) {
+    const paths = includeRootWithExistingBlocks ? [rootHintsPath, ...existingHintsPaths] : existingHintsPaths;
+    return uniqueCanonicalPaths(paths);
+  }
+  return [rootHintsPath];
+}
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_GOOSE_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_GOOSE_END, beginIndex + TOKENJUICE_GOOSE_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_GOOSE_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_GOOSE_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_GOOSE_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+const TOKENJUICE_GOOSE_BLOCK = [
+  TOKENJUICE_GOOSE_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets(),
+  "- Restart your Goose session after changing this file so the updated hints are loaded.",
+  TOKENJUICE_GOOSE_END,
+].join("\n");
+
+const TOKENJUICE_GOOSE_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_GOOSE_BEGIN,
+  endMarker: TOKENJUICE_GOOSE_END,
+  block: TOKENJUICE_GOOSE_BLOCK,
+};
+
+export async function installGooseHints(
+  hintsPath?: string,
+  options: GooseHintsOptions = {},
+): Promise<InstallGooseHintsResult> {
+  const resolvedHintsPaths = hintsPath ? [hintsPath] : await getDefaultHintsPaths(options, true, true);
+  for (const resolvedHintsPath of resolvedHintsPaths) {
+    const existing = await readInstructionFile(resolvedHintsPath);
+    const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GOOSE_BLOCK_CONFIG);
+    if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+      throw new Error(
+        `cannot safely repair malformed tokenjuice markers in ${resolvedHintsPath}; remove the dangling marker manually, then rerun tokenjuice install goose`,
+      );
+    }
+  }
+
+  const results = [];
+  for (const resolvedHintsPath of resolvedHintsPaths) {
+    results.push(await installMarkerDelimitedBlock(resolvedHintsPath, TOKENJUICE_GOOSE_BLOCK_CONFIG));
+  }
+  const result = results[0]!;
+  const hintsPaths = results.map((entry) => entry.filePath);
+  return {
+    hintsPath: result.filePath,
+    ...(hintsPaths.length > 1 ? { hintsPaths } : {}),
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallGooseHints(
+  hintsPath?: string,
+  options: GooseHintsOptions = {},
+): Promise<UninstallGooseHintsResult> {
+  const resolvedHintsPaths = hintsPath ? [hintsPath] : await getDefaultHintsPaths(options, true);
+  for (const resolvedHintsPath of resolvedHintsPaths) {
+    const existing = await readInstructionFile(resolvedHintsPath);
+    const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GOOSE_BLOCK_CONFIG);
+    if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+      throw new Error(
+        `cannot safely uninstall malformed tokenjuice markers in ${resolvedHintsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall goose`,
+      );
+    }
+  }
+
+  const results = [];
+  for (const resolvedHintsPath of resolvedHintsPaths) {
+    results.push(await uninstallMarkerDelimitedBlock(resolvedHintsPath, TOKENJUICE_GOOSE_BLOCK_CONFIG));
+  }
+  const removedPaths = results.filter((result) => result.removed).map((result) => result.filePath);
+  const result = results[0]!;
+  return {
+    hintsPath: result.filePath,
+    ...(removedPaths.length > 0 ? { removedPaths } : {}),
+    removed: removedPaths.length > 0,
+  };
+}
+
+async function inspectGooseHintsPath(resolvedHintsPath: string): Promise<GooseDoctorReport> {
+  const existing = await readInstructionFile(resolvedHintsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GOOSE_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      hintsPath: resolvedHintsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Goose hints are not installed"],
+        advisory: TOKENJUICE_GOOSE_ADVISORY,
+        fixCommand: TOKENJUICE_GOOSE_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Goose hints",
+    repairCommand: TOKENJUICE_GOOSE_FIX_COMMAND,
+  });
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured Goose hints have unmatched tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured Goose hints are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured Goose hints are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured Goose hints still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    hintsPath: resolvedHintsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_GOOSE_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from .goosehints, then run tokenjuice install goose"
+        : TOKENJUICE_GOOSE_FIX_COMMAND,
+    }),
+  };
+}
+
+export async function doctorGooseHints(
+  hintsPath?: string,
+  options: GooseHintsOptions = {},
+): Promise<GooseDoctorReport> {
+  const resolvedHintsPaths = hintsPath ? [hintsPath] : await getDefaultHintsPaths(options, true);
+  const reports = [];
+  for (const resolvedHintsPath of resolvedHintsPaths) {
+    reports.push(await inspectGooseHintsPath(resolvedHintsPath));
+  }
+
+  return reports.find((report) => report.status === "broken")
+    ?? reports.find((report) => report.status === "warn")
+    ?? reports.find((report) => report.status === "ok")
+    ?? reports[0]!;
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -12,6 +12,7 @@ import { doctorCrushSkill } from "../crush/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
 import { doctorDroidHook } from "../droid/index.js";
 import { doctorGeminiCliHook } from "../gemini-cli/index.js";
+import { doctorGooseHints } from "../goose/index.js";
 import { doctorGrokCliHook } from "../grok-cli/index.js";
 import { doctorJunieInstructions } from "../junie/index.js";
 import { doctorKiroSteering } from "../kiro/index.js";
@@ -38,6 +39,7 @@ import type { CrushDoctorReport, CrushSkillOptions } from "../crush/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
 import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
+import type { GooseDoctorReport, GooseHintsOptions } from "../goose/index.js";
 import type { GrokCliDoctorReport, GrokCliHookCommandOptions } from "../grok-cli/index.js";
 import type { JunieDoctorReport } from "../junie/index.js";
 import type { KiroDoctorReport } from "../kiro/index.js";
@@ -66,6 +68,7 @@ export type HookIntegrationDoctorReport = {
   cursor: CursorDoctorReport;
   droid: DroidDoctorReport;
   "gemini-cli": GeminiCliDoctorReport;
+  goose: GooseDoctorReport;
   "grok-cli": GrokCliDoctorReport;
   junie: JunieDoctorReport;
   kiro: KiroDoctorReport;
@@ -85,7 +88,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
+export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -110,6 +113,7 @@ const hookDoctorIntegrationDoctors = {
   cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
+  goose: (options) => doctorGooseHints(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),
   "grok-cli": (options) => doctorGrokCliHook(undefined, getHookCommandOptions(options)),
   junie: () => doctorJunieInstructions(),
   kiro: () => doctorKiroSteering(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "./host
 export { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "./hosts/cursor/index.js";
 export { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "./hosts/droid/index.js";
 export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "./hosts/gemini-cli/index.js";
+export { doctorGooseHints, installGooseHints, uninstallGooseHints } from "./hosts/goose/index.js";
 export { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "./hosts/grok-cli/index.js";
 export { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "./hosts/junie/index.js";
 export { doctorKiroSteering, installKiroSteering, uninstallKiroSteering } from "./hosts/kiro/index.js";
@@ -135,6 +136,12 @@ export type {
   InstallGeminiCliHookResult,
   UninstallGeminiCliHookResult,
 } from "./hosts/gemini-cli/index.js";
+export type {
+  GooseDoctorReport,
+  GooseHintsOptions,
+  InstallGooseHintsResult,
+  UninstallGooseHintsResult,
+} from "./hosts/goose/index.js";
 export type {
   GrokCliDoctorReport,
   GrokCliHookCommandOptions,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/goose.test.ts
+++ b/test/hosts/goose.test.ts
@@ -1,0 +1,389 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorGooseHints,
+  doctorInstalledHooks,
+  installGooseHints,
+  uninstallGooseHints,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CRUSH_PROJECT_DIR",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GOOSE_PROJECT_DIR",
+  "GROK_HOME",
+  "HOME",
+  "JUNIE_PROJECT_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-goose-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("goose hints", () => {
+  function countTokenjuiceBlocks(text: string): number {
+    return text.match(/<!-- tokenjuice:begin -->/gu)?.length ?? 0;
+  }
+
+  it("installs a marker-delimited hints block", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+
+    const result = await installGooseHints(hintsPath);
+    const hints = await readFile(hintsPath, "utf8");
+
+    expect(result.hintsPath).toBe(hintsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(hints).toContain("<!-- tokenjuice:begin -->");
+    expect(hints).toContain("tokenjuice terminal output compaction");
+    expect(hints).toContain("tokenjuice wrap -- <command>");
+    expect(hints).toContain("tokenjuice wrap --raw -- <command>");
+    expect(hints).toContain("Restart your Goose session");
+    expect(hints).not.toContain("wrap --full");
+  });
+
+  it("preserves existing hints and backs them up", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await installGooseHints(hintsPath);
+    await writeFile(hintsPath, "# project hints\n\n- keep this\n", "utf8");
+
+    const result = await installGooseHints(hintsPath);
+    const hints = await readFile(hintsPath, "utf8");
+
+    expect(result.backupPath).toBe(`${hintsPath}.bak`);
+    await expect(readFile(`${hintsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    expect(hints).toContain("- keep this");
+    expect(hints).toContain("<!-- tokenjuice:begin -->");
+  });
+
+  it("replaces stale tokenjuice hints without duplicating the block", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await writeFile(
+      hintsPath,
+      [
+        "# project hints",
+        "",
+        "- keep this",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "another stale tokenjuice block",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installGooseHints(hintsPath);
+    const hints = await readFile(hintsPath, "utf8");
+
+    expect(hints).toContain("- keep this");
+    expect(hints).not.toContain("stale tokenjuice block");
+    expect(countTokenjuiceBlocks(hints)).toBe(1);
+  });
+
+  it("reports installed and uninstalled hints health", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+
+    await installGooseHints(hintsPath);
+    const installed = await doctorGooseHints(hintsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("hints-based");
+
+    const removed = await uninstallGooseHints(hintsPath);
+    const disabled = await doctorGooseHints(hintsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken hints with unmatched tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await writeFile(hintsPath, "<!-- tokenjuice:begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorGooseHints(hintsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+  });
+
+  it("reports a healthy tokenjuice block with extra dangling markers as broken", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await installGooseHints(hintsPath);
+    const healthyHints = await readFile(hintsPath, "utf8");
+    await writeFile(hintsPath, `${healthyHints}\n<!-- tokenjuice:begin -->\n`, "utf8");
+
+    const doctor = await doctorGooseHints(hintsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Goose hints have unmatched tokenjuice markers");
+    await expect(installGooseHints(hintsPath)).rejects.toThrow("cannot safely repair malformed tokenjuice markers");
+    await expect(uninstallGooseHints(hintsPath)).rejects.toThrow("cannot safely uninstall malformed tokenjuice markers");
+  });
+
+  it("reports stale guidance as broken", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await writeFile(
+      hintsPath,
+      [
+        "<!-- tokenjuice:begin -->",
+        "## tokenjuice terminal output compaction",
+        "",
+        "- old guidance says to run tokenjuice wrap --full -- <command>.",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorGooseHints(hintsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Goose hints are missing tokenjuice wrap guidance");
+    expect(doctor.issues).toContain("configured Goose hints are missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Goose hints still suggest the full escape hatch");
+  });
+
+  it("leaves unrelated hints untouched when uninstall finds no tokenjuice block", async () => {
+    const home = await createTempDir();
+    const hintsPath = join(home, ".goosehints");
+    await writeFile(hintsPath, "# project hints\n\n- keep this\n", "utf8");
+
+    const removed = await uninstallGooseHints(hintsPath);
+    const hints = await readFile(hintsPath, "utf8");
+
+    expect(removed.removed).toBe(false);
+    expect(hints).toBe("# project hints\n\n- keep this\n");
+  });
+
+  it("uses GOOSE_PROJECT_DIR for the default hints file", async () => {
+    const home = await createTempDir();
+    process.env.GOOSE_PROJECT_DIR = home;
+
+    const installed = await installGooseHints();
+    const expectedHintsPath = join(home, ".goosehints");
+    const doctor = await doctorGooseHints();
+
+    expect(installed.hintsPath).toBe(expectedHintsPath);
+    expect(doctor.hintsPath).toBe(expectedHintsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("passes projectDir through aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    const configHome = join(home, "home");
+    await mkdir(configHome, { recursive: true });
+    process.env.HOME = configHome;
+    process.env.FACTORY_HOME = join(configHome, ".factory");
+    process.env.CODEX_HOME = join(configHome, ".codex");
+    process.env.CLAUDE_CONFIG_DIR = join(configHome, ".claude");
+    process.env.CODEBUDDY_CONFIG_DIR = join(configHome, ".codebuddy");
+    process.env.CURSOR_HOME = join(configHome, ".cursor");
+    process.env.GEMINI_HOME = join(configHome, ".gemini");
+    process.env.GROK_HOME = join(configHome, ".grok");
+    process.env.COPILOT_HOME = join(configHome, ".copilot");
+    process.env.PI_CODING_AGENT_DIR = join(configHome, ".pi", "agent");
+    process.env.OPENCODE_CONFIG_DIR = join(configHome, ".config", "opencode");
+    process.env.CLINE_HOOKS_DIR = join(configHome, "Cline", "Hooks");
+    await installGooseHints(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.goose.status).toBe("ok");
+    expect(report.integrations.goose.hintsPath).toBe(join(home, ".goosehints"));
+  });
+
+  it("installs into the git root when run from a nested directory", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installGooseHints();
+    const expectedHintsPath = join(await realpath(home), ".goosehints");
+
+    expect(installed.hintsPath).toBe(expectedHintsPath);
+    expect(await readFile(join(home, ".goosehints"), "utf8")).toContain("tokenjuice wrap -- <command>");
+    await expect(access(join(nestedDir, ".goosehints"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps the root install target when repairing a nested tokenjuice block", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, ".goosehints"),
+      "<!-- tokenjuice:begin -->\nstale tokenjuice wrap --full -- <command>\n<!-- tokenjuice:end -->\n",
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const installed = await installGooseHints();
+    const afterInstall = await doctorGooseHints();
+
+    expect(installed.hintsPaths).toEqual([
+      join(await realpath(home), ".goosehints"),
+      join(await realpath(nestedDir), ".goosehints"),
+    ]);
+    expect(afterInstall.status).toBe("ok");
+    expect(await readFile(join(home, ".goosehints"), "utf8")).toContain("tokenjuice wrap -- <command>");
+    expect(await readFile(join(nestedDir, ".goosehints"), "utf8")).not.toContain("wrap --full");
+  });
+
+  it("uses explicit projectDir as the parent-chain scan boundary", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    await installGooseHints(undefined, { projectDir: home });
+    await writeFile(
+      join(nestedDir, ".goosehints"),
+      "<!-- tokenjuice:begin -->\nstale tokenjuice wrap --full -- <command>\n<!-- tokenjuice:end -->\n",
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const beforeRepair = await doctorGooseHints(undefined, { projectDir: home });
+    const repaired = await installGooseHints(undefined, { projectDir: home });
+    const afterRepair = await doctorGooseHints(undefined, { projectDir: home });
+
+    expect(beforeRepair.status).toBe("broken");
+    expect(beforeRepair.hintsPath).toBe(join(await realpath(nestedDir), ".goosehints"));
+    expect(repaired.hintsPaths).toEqual([
+      join(home, ".goosehints"),
+      join(await realpath(nestedDir), ".goosehints"),
+    ]);
+    expect(afterRepair.status).toBe("ok");
+    expect(await readFile(join(nestedDir, ".goosehints"), "utf8")).not.toContain("wrap --full");
+  });
+
+  it("repairs and removes tokenjuice hints elsewhere in the project tree from the root", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, ".goosehints"),
+      "<!-- tokenjuice:begin -->\nstale tokenjuice wrap --full -- <command>\n<!-- tokenjuice:end -->\n",
+      "utf8",
+    );
+    process.chdir(home);
+
+    const beforeRepair = await doctorGooseHints();
+    const repaired = await installGooseHints();
+    const afterRepair = await doctorGooseHints();
+    const removed = await uninstallGooseHints();
+    const disabled = await doctorGooseHints();
+
+    expect(beforeRepair.status).toBe("broken");
+    expect(beforeRepair.hintsPath).toBe(join(await realpath(nestedDir), ".goosehints"));
+    expect(repaired.hintsPaths).toEqual([
+      join(await realpath(home), ".goosehints"),
+      join(await realpath(nestedDir), ".goosehints"),
+    ]);
+    expect(afterRepair.status).toBe("ok");
+    expect(removed.removedPaths).toEqual([
+      join(await realpath(home), ".goosehints"),
+      join(await realpath(nestedDir), ".goosehints"),
+    ]);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(join(home, ".goosehints"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(nestedDir, ".goosehints"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("repairs and removes loaded parent-chain tokenjuice hints from nested directories", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await installGooseHints(join(home, ".goosehints"));
+    await writeFile(
+      join(nestedDir, ".goosehints"),
+      "<!-- tokenjuice:begin -->\nstale tokenjuice wrap --full -- <command>\n<!-- tokenjuice:end -->\n",
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const beforeRepair = await doctorGooseHints();
+    const repaired = await installGooseHints();
+    const removed = await uninstallGooseHints();
+    const disabled = await doctorGooseHints();
+
+    expect(beforeRepair.status).toBe("broken");
+    expect(beforeRepair.hintsPath).toBe(join(await realpath(nestedDir), ".goosehints"));
+    expect(repaired.hintsPaths).toEqual([
+      join(await realpath(home), ".goosehints"),
+      join(await realpath(nestedDir), ".goosehints"),
+    ]);
+    expect(removed.removedPaths).toEqual([
+      join(await realpath(nestedDir), ".goosehints"),
+      join(await realpath(home), ".goosehints"),
+    ]);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(join(home, ".goosehints"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(nestedDir, ".goosehints"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the default hints file when only tokenjuice content remains", async () => {
+    const home = await createTempDir();
+    process.env.GOOSE_PROJECT_DIR = home;
+    const hintsPath = join(home, ".goosehints");
+
+    await installGooseHints();
+    await uninstallGooseHints(hintsPath);
+
+    await expect(access(hintsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a guidance-only Goose integration using a marker-delimited `.goosehints` block
- wire install, uninstall, direct doctor, aggregate doctor, exports, README, and docs/spec
- repair/remove tokenjuice-marked nested `.goosehints` files in direct Goose commands while keeping aggregate doctor scanning bounded
- validate malformed marker handling before writes so broken blocks require manual cleanup instead of unsafe edits

## Validation
- `pnpm exec vitest run test/hosts/goose.test.ts test/hosts/crush.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check origin/main...HEAD`
- isolated CLI smoke: install/doctor hooks/uninstall/disabled for Goose with host homes isolated
- autoreview clean: no accepted/actionable findings reported
