### PR TITLE
feat(ruler): add source rule integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ beta integrations:
 | <img width="48px" src="docs/client-openhands.svg" alt="OpenHands" /> | [OpenHands](https://docs.openhands.dev/) | `tokenjuice install openhands` | `.openhands/hooks.json` |
 | <img width="48px" src="docs/client-qwen-code.svg" alt="Qwen Code" /> | [Qwen Code](https://qwenlm.github.io/qwen-code-docs/) | `tokenjuice install qwen-code` | `.qwen/settings.json` |
 | <img width="48px" src="docs/client-roo.svg" alt="Roo Code" /> | [Roo Code](https://roocode.com/) | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` |
+| <img width="48px" src="docs/client-ruler.svg" alt="Ruler" /> | [Ruler](https://github.com/intellectronica/ruler) | `tokenjuice install ruler` | `.ruler/tokenjuice.md` |
 | <img width="48px" src="docs/client-windsurf.svg" alt="Windsurf" /> | [Windsurf](https://windsurf.com/) | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-zed.svg" alt="Zed" /> | [Zed](https://zed.dev/docs/ai/rules.html) | `tokenjuice install zed` | `.rules` |
 
@@ -68,8 +69,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -91,9 +92,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -160,6 +161,7 @@ direct payload:
 - [Kilo Code integration](docs/kilo-integration.md)
 - [Qwen Code integration](docs/qwen-code-integration.md)
 - [Roo Code integration](docs/roo-integration.md)
+- [Ruler integration](docs/ruler-integration.md)
 - [Windsurf integration](docs/windsurf-integration.md)
 - [security](SECURITY.md)
 

--- a/docs/client-ruler.svg
+++ b/docs/client-ruler.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Ruler</title>
+  <desc id="desc">Simple Ruler integration mark</desc>
+  <rect width="96" height="96" rx="18" fill="#f8fafc"/>
+  <path d="M20 64 64 20l12 12-44 44H20V64Z" fill="#e0f2fe" stroke="#0f172a" stroke-width="6" stroke-linejoin="round"/>
+  <path d="M36 60 30 54M46 50l-6-6M56 40l-6-6" stroke="#0f766e" stroke-width="5" stroke-linecap="round"/>
+  <path d="m66 18 12 12" stroke="#f59e0b" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/docs/ruler-integration.md
+++ b/docs/ruler-integration.md
@@ -1,0 +1,31 @@
+# Ruler integration
+
+Ruler support is beta.
+
+`tokenjuice install ruler` writes `.ruler/tokenjuice.md` in the current git
+root, or in `RULER_PROJECT_DIR` when set. Ruler treats Markdown files under
+`.ruler/` as source rules and propagates them to configured coding agents when
+you run `ruler apply`.
+
+## Install
+
+```bash
+tokenjuice install ruler
+ruler apply
+tokenjuice doctor ruler
+```
+
+## Behavior
+
+- The source rule tells downstream agents to prefer `tokenjuice wrap -- <command>`
+  for terminal commands likely to produce long output.
+- The source rule tells downstream agents to treat compacted output as
+  authoritative.
+- The only documented escape hatch is `tokenjuice wrap --raw -- <command>`.
+- Existing `.ruler/tokenjuice.md` content is backed up before install.
+
+## Current beta caveat
+
+Ruler is a propagation layer, not a command runtime. This integration does not
+intercept shell output; it gives Ruler one tokenjuice rule source that can be
+distributed to the agents already configured in `ruler.toml`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -180,6 +180,7 @@ tokenjuice install goose
 tokenjuice install pi
 tokenjuice install opencode
 tokenjuice install qwen-code
+tokenjuice install ruler
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice doctor opencode
@@ -187,6 +188,7 @@ tokenjuice doctor crush
 tokenjuice doctor grok-cli
 tokenjuice doctor goose
 tokenjuice doctor qwen-code
+tokenjuice doctor ruler
 tokenjuice install codex --local
 tokenjuice install claude-code --local
 tokenjuice install codebuddy --local
@@ -225,6 +227,7 @@ supported host hooks:
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
 | Qwen Code | `tokenjuice install qwen-code` | `.qwen/settings.json` | ✴️ Beta. Uses a project-local `PostToolUse` hook for shell tools; compacted context is injected alongside the original output; `tokenjuice install qwen-code --local` is available for repo-local verification; see `docs/qwen-code-integration.md` |
 | Roo Code | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` | ✴️ Beta. Inserts a marker-delimited workspace rule that tells Roo to use `tokenjuice wrap` for noisy `execute_command` terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Roo workspace rules do not intercept tool output; see `docs/roo-integration.md` |
+| Ruler | `tokenjuice install ruler` | `.ruler/tokenjuice.md` | ✴️ Beta. Installs a Ruler source rule that tells configured coding agents to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Ruler propagates rules rather than intercepting command output; run `ruler apply` after install; see `docs/ruler-integration.md` |
 | VS Code Copilot Chat | `tokenjuice install vscode-copilot` | `~/.copilot/hooks/tokenjuice-vscode.json` | Uses `preToolUse` shell input rewriting on the `run_in_terminal` tool to route commands through `tokenjuice wrap`. Requires `chat.useHooks` enabled and a trusted workspace. Ignores `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the Copilot CLI install. After install, run `tokenjuice doctor vscode-copilot --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -47,6 +47,7 @@ import { doctorOpenHandsHook, installOpenHandsHook, runOpenHandsPostToolUseHook,
 import { doctorPiExtension, installPiExtension } from "../hosts/pi/index.js";
 import { doctorQwenCodeHook, installQwenCodeHook, runQwenCodePostToolUseHook, uninstallQwenCodeHook } from "../hosts/qwen-code/index.js";
 import { doctorRooInstructions, installRooInstructions, uninstallRooInstructions } from "../hosts/roo/index.js";
+import { doctorRulerRule, installRulerRule, uninstallRulerRule } from "../hosts/ruler/index.js";
 import {
   doctorVscodeCopilotHook,
   getVscodeCopilotInstructionsSnippet,
@@ -128,6 +129,7 @@ function printUsage(): void {
       "  tokenjuice install opencode [--local]",
       "  tokenjuice install qwen-code [--local]",
       "  tokenjuice install roo",
+      "  tokenjuice install ruler",
       "  tokenjuice install vscode-copilot [--local]",
       "  tokenjuice install copilot-cli [--local]",
       "  tokenjuice install windsurf",
@@ -151,6 +153,7 @@ function printUsage(): void {
       "  tokenjuice uninstall opencode",
       "  tokenjuice uninstall qwen-code",
       "  tokenjuice uninstall roo",
+      "  tokenjuice uninstall ruler",
       "  tokenjuice uninstall vscode-copilot",
       "  tokenjuice uninstall copilot-cli",
       "  tokenjuice uninstall windsurf",
@@ -159,7 +162,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -938,6 +941,27 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "ruler") {
+    const result = await installRulerRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Rule", value: result.rulePath },
+      { label: "Beta", value: "rule-based guidance; run ruler apply to propagate it" },
+      { label: "Apply", value: "ruler apply" },
+      { label: "Verify", value: "tokenjuice doctor ruler" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("ruler", "rule", details));
+    return 0;
+  }
+
   if (target === "vscode-copilot") {
     const result = await installVscodeCopilotHook(undefined, { local: args.local });
     if (args.format === "json") {
@@ -1044,7 +1068,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1297,6 +1321,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "ruler") {
+    const result = await uninstallRulerRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed ruler rule: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`rule path: ${result.rulePath}\n`);
+    process.stdout.write("enable: tokenjuice install ruler\n");
+    return 0;
+  }
+
   if (target === "vscode-copilot") {
     const result = await uninstallVscodeCopilotHook();
     if (args.format === "json") {
@@ -1362,7 +1399,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -2082,6 +2119,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     }
 
     process.stdout.write(`rules path: ${report.instructionsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "ruler") {
+    const report = await doctorRulerRule();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`rule path: ${report.rulePath}\n`);
     process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -55,6 +55,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("qwen")) {
     return "qwen-code";
   }
+  if (source.startsWith("ruler")) {
+    return "ruler";
+  }
   if (source === "direct" || source === "tokenjuice" || source === "wrap") {
     return DEFAULT_CLI_ARTIFACT_SOURCE;
   }

--- a/src/hosts/ruler/index.ts
+++ b/src/hosts/ruler/index.ts
@@ -1,0 +1,212 @@
+import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+
+export type RulerRuleOptions = {
+  projectDir?: string;
+};
+
+export type InstallRulerRuleResult = {
+  rulePath: string;
+  backupPath?: string;
+};
+
+export type UninstallRulerRuleResult = {
+  rulePath: string;
+  removed: boolean;
+};
+
+export type RulerDoctorReport = {
+  rulePath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_RULER_FIX_COMMAND = "tokenjuice install ruler";
+const TOKENJUICE_RULER_RULE_MARKER = "tokenjuice terminal output compaction";
+const TOKENJUICE_RULER_ADVISORY = "Ruler support is beta and rule-based; run `ruler apply` after install so Ruler propagates the rule to configured agents.";
+const TOKENJUICE_RULER_REINSTALL_BACKUP_SUFFIX = ".tokenjuice.bak";
+
+function getExplicitProjectDir(options: RulerRuleOptions = {}): string | undefined {
+  return options.projectDir || process.env.RULER_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: RulerRuleOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? resolve(process.cwd());
+}
+
+async function getDefaultRulePath(options: RulerRuleOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), ".ruler", "tokenjuice.md");
+}
+
+const TOKENJUICE_RULER_RULE = [
+  "# tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: `- When Ruler propagates this rule to coding agents, prefer \`${TOKENJUICE_WRAP_COMMAND}\` for terminal commands likely to produce long output.`,
+  }),
+  "- After editing this source rule, run `ruler apply` so configured agents receive the updated guidance.",
+  "",
+].join("\n");
+
+async function writeRulerRuleWithoutBackup(rulePath: string): Promise<void> {
+  await mkdir(dirname(rulePath), { recursive: true });
+  const tempPath = `${rulePath}.tmp`;
+  await writeFile(tempPath, TOKENJUICE_RULER_RULE, "utf8");
+  await rename(tempPath, rulePath);
+}
+
+function isTokenjuiceRulerRuleText(text: string): boolean {
+  return text.includes(TOKENJUICE_RULER_RULE_MARKER);
+}
+
+export async function installRulerRule(
+  rulePath?: string,
+  options: RulerRuleOptions = {},
+): Promise<InstallRulerRuleResult> {
+  const resolvedRulePath = rulePath ?? await getDefaultRulePath(options);
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (existing.exists && isTokenjuiceRulerRuleText(existing.text)) {
+    if (existing.text === TOKENJUICE_RULER_RULE) {
+      return { rulePath: resolvedRulePath };
+    }
+
+    const primaryBackupPath = `${resolvedRulePath}.bak`;
+    const primaryBackup = await readInstructionFile(primaryBackupPath);
+    const backupPath = primaryBackup.exists && !isTokenjuiceRulerRuleText(primaryBackup.text)
+      ? `${resolvedRulePath}${TOKENJUICE_RULER_REINSTALL_BACKUP_SUFFIX}`
+      : primaryBackupPath;
+    await writeFile(backupPath, existing.text, "utf8");
+    await writeRulerRuleWithoutBackup(resolvedRulePath);
+    return { rulePath: resolvedRulePath, backupPath };
+  }
+
+  const result = await writeInstructionFile(resolvedRulePath, TOKENJUICE_RULER_RULE);
+  return {
+    rulePath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallRulerRule(
+  rulePath?: string,
+  options: RulerRuleOptions = {},
+): Promise<UninstallRulerRuleResult> {
+  const resolvedRulePath = rulePath ?? await getDefaultRulePath(options);
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (!existing.exists || !isTokenjuiceRulerRuleText(existing.text)) {
+    return { rulePath: resolvedRulePath, removed: false };
+  }
+
+  const backupPath = `${resolvedRulePath}.bak`;
+  const backup = await readInstructionFile(backupPath);
+  if (backup.exists && !isTokenjuiceRulerRuleText(backup.text)) {
+    await rm(resolvedRulePath, { force: true });
+    await rename(backupPath, resolvedRulePath);
+    return { rulePath: resolvedRulePath, removed: true };
+  }
+
+  const result = await removeInstructionFile(resolvedRulePath);
+  return { rulePath: result.filePath, removed: result.removed };
+}
+
+export async function doctorRulerRule(
+  rulePath?: string,
+  options: RulerRuleOptions = {},
+): Promise<RulerDoctorReport> {
+  const resolvedRulePath = rulePath ?? await getDefaultRulePath(options);
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (!existing.exists) {
+    return {
+      rulePath: resolvedRulePath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Ruler rule is not installed"],
+        advisory: TOKENJUICE_RULER_ADVISORY,
+        fixCommand: TOKENJUICE_RULER_FIX_COMMAND,
+      }),
+    };
+  }
+  if (!isTokenjuiceRulerRuleText(existing.text)) {
+    return {
+      rulePath: resolvedRulePath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Ruler rule is not installed"],
+        advisory: TOKENJUICE_RULER_ADVISORY,
+        fixCommand: TOKENJUICE_RULER_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const issues = collectGuidanceIssues(existing.text, {
+    required: [
+      {
+        requiredText: TOKENJUICE_RULER_RULE_MARKER,
+        missingIssue: "configured Ruler rule file does not look like the tokenjuice rule",
+      },
+      {
+        requiredText: TOKENJUICE_WRAP_COMMAND,
+        missingIssue: "configured Ruler rule file is missing tokenjuice wrap guidance",
+      },
+      {
+        requiredText: TOKENJUICE_RAW_COMMAND,
+        missingIssue: "configured Ruler rule file is missing the raw escape hatch",
+      },
+    ],
+    forbidden: [
+      {
+        forbiddenText: TOKENJUICE_FULL_COMMAND,
+        presentIssue: "configured Ruler rule file still suggests the full escape hatch",
+      },
+    ],
+  });
+
+  return {
+    rulePath: resolvedRulePath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_RULER_ADVISORY,
+      fixCommand: TOKENJUICE_RULER_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -21,6 +21,7 @@ import { doctorOpenHandsHook } from "../openhands/index.js";
 import { doctorPiExtension } from "../pi/index.js";
 import { doctorQwenCodeHook } from "../qwen-code/index.js";
 import { doctorRooInstructions } from "../roo/index.js";
+import { doctorRulerRule } from "../ruler/index.js";
 import { doctorVscodeCopilotHook } from "../vscode-copilot/index.js";
 import { doctorWindsurfRule } from "../windsurf/index.js";
 import { doctorZedInstructions } from "../zed/index.js";
@@ -48,6 +49,7 @@ import type { OpenHandsDoctorReport } from "../openhands/index.js";
 import type { PiDoctorReport } from "../pi/index.js";
 import type { QwenCodeDoctorReport, QwenCodeHookCommandOptions } from "../qwen-code/index.js";
 import type { RooDoctorReport } from "../roo/index.js";
+import type { RulerDoctorReport, RulerRuleOptions } from "../ruler/index.js";
 import type { VscodeCopilotDoctorReport } from "../vscode-copilot/index.js";
 import type { WindsurfDoctorReport } from "../windsurf/index.js";
 import type { ZedDoctorReport } from "../zed/index.js";
@@ -77,6 +79,7 @@ export type HookIntegrationDoctorReport = {
   pi: PiDoctorReport;
   "qwen-code": QwenCodeDoctorReport;
   roo: RooDoctorReport;
+  ruler: RulerDoctorReport;
   "vscode-copilot": VscodeCopilotDoctorReport;
   windsurf: WindsurfDoctorReport;
   zed: ZedDoctorReport;
@@ -88,7 +91,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions;
+export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & QwenCodeHookCommandOptions & RulerRuleOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -122,6 +125,7 @@ const hookDoctorIntegrationDoctors = {
   pi: () => doctorPiExtension(),
   "qwen-code": (options) => doctorQwenCodeHook(undefined, options),
   roo: () => doctorRooInstructions(),
+  ruler: (options) => doctorRulerRule(undefined, getHookCommandOptions(options)),
   "vscode-copilot": (options) => doctorVscodeCopilotHook(undefined, getHookCommandOptions(options)),
   windsurf: () => doctorWindsurfRule(),
   zed: () => doctorZedInstructions(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export {
   uninstallOpenCodeExtension,
 } from "./hosts/opencode/index.js";
 export { doctorQwenCodeHook, installQwenCodeHook, runQwenCodePostToolUseHook, uninstallQwenCodeHook } from "./hosts/qwen-code/index.js";
+export { doctorRulerRule, installRulerRule, uninstallRulerRule } from "./hosts/ruler/index.js";
 export { runReduceJsonCli } from "./core/cli-client.js";
 export { clearFixtureCache, loadBuiltinFixtures, verifyBuiltinFixtures } from "./core/fixtures.js";
 export { parseReduceJsonRequest } from "./core/json-protocol.js";
@@ -184,6 +185,12 @@ export type {
   RooInstructionsOptions,
   UninstallRooInstructionsResult,
 } from "./hosts/roo/index.js";
+export type {
+  InstallRulerRuleResult,
+  RulerDoctorReport,
+  RulerRuleOptions,
+  UninstallRulerRuleResult,
+} from "./hosts/ruler/index.js";
 export type {
   InstallVscodeCopilotHookResult,
   UninstallVscodeCopilotHookResult,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/ruler.test.ts
+++ b/test/hosts/ruler.test.ts
@@ -1,0 +1,265 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorRulerRule,
+  installRulerRule,
+  uninstallRulerRule,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CRUSH_PROJECT_DIR",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GOOSE_PROJECT_DIR",
+  "GROK_HOME",
+  "HOME",
+  "JUNIE_PROJECT_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-ruler-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("ruler rule", () => {
+  it("installs a Ruler source rule with the tokenjuice escape hatch", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+
+    const result = await installRulerRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.rulePath).toBe(rulePath);
+    expect(result.backupPath).toBeUndefined();
+    expect(rule).toContain("# tokenjuice terminal output compaction");
+    expect(rule).toContain("tokenjuice wrap -- <command>");
+    expect(rule).toContain("tokenjuice wrap --raw -- <command>");
+    expect(rule).toContain("ruler apply");
+    expect(rule).not.toContain("wrap --full");
+  });
+
+  it("backs up an existing source rule before replacing it", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+    await installRulerRule(rulePath);
+    await writeFile(rulePath, "custom local rule\n", "utf8");
+
+    const result = await installRulerRule(rulePath);
+
+    expect(result.backupPath).toBe(`${rulePath}.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toBe("custom local rule\n");
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("tokenjuice wrap --raw -- <command>");
+  });
+
+  it("does not create a backup for idempotent reinstalls", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+
+    await installRulerRule(rulePath);
+    const result = await installRulerRule(rulePath);
+
+    expect(result.backupPath).toBeUndefined();
+    await expect(access(`${rulePath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("restores a backed-up custom source rule on uninstall", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+    await installRulerRule(rulePath);
+    await writeFile(rulePath, "custom local rule\n", "utf8");
+    await installRulerRule(rulePath);
+    await installRulerRule(rulePath);
+
+    const removed = await uninstallRulerRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(rulePath, "utf8")).resolves.toBe("custom local rule\n");
+    await expect(access(`${rulePath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("restores custom source rules that mention tokenjuice commands", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+    await installRulerRule(rulePath);
+    await writeFile(rulePath, "custom source rule: use `tokenjuice wrap -- <command>` when useful\n", "utf8");
+    await installRulerRule(rulePath);
+
+    const removed = await uninstallRulerRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("custom source rule");
+    await expect(access(`${rulePath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports installed and uninstalled rule health", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+
+    await installRulerRule(rulePath);
+    const installed = await doctorRulerRule(rulePath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("rule-based");
+    expect(installed.advisories[0]).toContain("ruler apply");
+
+    const removed = await uninstallRulerRule(rulePath);
+    const disabled = await doctorRulerRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken rules when required tokenjuice guidance is stale", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+    await mkdir(join(home, ".ruler"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "# tokenjuice terminal output compaction",
+        "",
+        "- Prefer `tokenjuice wrap -- <command>`.",
+        "- If output looks wrong, rerun with `tokenjuice wrap --full -- <command>`.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorRulerRule(rulePath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Ruler rule file is missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Ruler rule file still suggests the full escape hatch");
+  });
+
+  it("treats custom source rule files as disabled and does not remove them", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+    await mkdir(join(home, ".ruler"), { recursive: true });
+    await writeFile(rulePath, "custom local rule\n", "utf8");
+
+    const doctor = await doctorRulerRule(rulePath);
+    const removed = await uninstallRulerRule(rulePath);
+
+    expect(doctor.status).toBe("disabled");
+    expect(removed.removed).toBe(false);
+    await expect(readFile(rulePath, "utf8")).resolves.toBe("custom local rule\n");
+  });
+
+  it("uses RULER_PROJECT_DIR for the default source rule", async () => {
+    const home = await createTempDir();
+    process.env.RULER_PROJECT_DIR = home;
+
+    const installed = await installRulerRule();
+    const expectedRulePath = join(home, ".ruler", "tokenjuice.md");
+    const doctor = await doctorRulerRule();
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(doctor.rulePath).toBe(expectedRulePath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("passes projectDir through aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    const configHome = join(home, "home");
+    await mkdir(configHome, { recursive: true });
+    process.env.HOME = configHome;
+    process.env.FACTORY_HOME = join(configHome, ".factory");
+    process.env.CODEX_HOME = join(configHome, ".codex");
+    process.env.CLAUDE_CONFIG_DIR = join(configHome, ".claude");
+    process.env.CODEBUDDY_CONFIG_DIR = join(configHome, ".codebuddy");
+    process.env.CURSOR_HOME = join(configHome, ".cursor");
+    process.env.GEMINI_HOME = join(configHome, ".gemini");
+    process.env.GROK_HOME = join(configHome, ".grok");
+    process.env.COPILOT_HOME = join(configHome, ".copilot");
+    process.env.PI_CODING_AGENT_DIR = join(configHome, ".pi", "agent");
+    process.env.OPENCODE_CONFIG_DIR = join(configHome, ".config", "opencode");
+    process.env.CLINE_HOOKS_DIR = join(configHome, "Cline", "Hooks");
+    await installRulerRule(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.ruler.status).toBe("ok");
+    expect(report.integrations.ruler.rulePath).toBe(join(home, ".ruler", "tokenjuice.md"));
+  });
+
+  it("installs into the git root when run from a nested directory", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installRulerRule();
+    const expectedRulePath = join(await realpath(home), ".ruler", "tokenjuice.md");
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(await readFile(join(home, ".ruler", "tokenjuice.md"), "utf8")).toContain("tokenjuice wrap -- <command>");
+    await expect(access(join(nestedDir, ".ruler", "tokenjuice.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the default source rule file", async () => {
+    const home = await createTempDir();
+    process.env.RULER_PROJECT_DIR = home;
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+
+    await installRulerRule();
+    await uninstallRulerRule();
+
+    await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("uses projectDir when uninstalling the default source rule file", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".ruler", "tokenjuice.md");
+
+    await installRulerRule(undefined, { projectDir: home });
+    const removed = await uninstallRulerRule(undefined, { projectDir: home });
+
+    expect(removed.rulePath).toBe(rulePath);
+    expect(removed.removed).toBe(true);
+    await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a guidance-only Ruler source rule integration at `.ruler/tokenjuice.md`
- wire install, uninstall, direct doctor, aggregate doctor, exports, README, and docs/spec
- resolve source rules from `RULER_PROJECT_DIR` or the current git root
- preserve custom `.ruler/tokenjuice.md` content: install backs it up, reinstall preserves backups, uninstall restores non-tokenjuice custom rules

## Validation
- `pnpm exec vitest run test/hosts/ruler.test.ts test/hosts/goose.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check origin/main...HEAD`
- isolated CLI smoke: install/doctor hooks/uninstall for Ruler with host homes isolated
- isolated CLI smoke: custom Ruler rule mentioning `tokenjuice wrap -- <command>` restores on uninstall
- autoreview clean: no accepted/actionable findings reported
