### PR TITLE
feat(open-interpreter): add instruction integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ beta integrations:
 | <img width="48px" src="docs/client-kiro.svg" alt="Kiro" /> | [Kiro](https://kiro.dev/) | `tokenjuice install kiro` | `.kiro/steering/tokenjuice.md` |
 | <img width="48px" src="docs/client-kilo.svg" alt="Kilo Code" /> | [Kilo Code](https://kilocode.ai/) | `tokenjuice install kilo` | `kilo.jsonc` or `.kilo/kilo.jsonc` + `.kilo/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-openhands.svg" alt="OpenHands" /> | [OpenHands](https://docs.openhands.dev/) | `tokenjuice install openhands` | `.openhands/hooks.json` |
+| <img width="48px" src="docs/client-open-interpreter.svg" alt="Open Interpreter" /> | [Open Interpreter](https://www.openinterpreter.com/docs/terminal/agents_md) | `tokenjuice install open-interpreter` | `AGENTS.md` |
 | <img width="48px" src="docs/client-openwebui.svg" alt="Open WebUI" /> | [Open WebUI](https://openwebui.com/) | `tokenjuice install openwebui` | `.openwebui/tools/tokenjuice_compact.py` |
 | <img width="48px" src="docs/client-qwen-code.svg" alt="Qwen Code" /> | [Qwen Code](https://qwenlm.github.io/qwen-code-docs/) | `tokenjuice install qwen-code` | `.qwen/settings.json` |
 | <img width="48px" src="docs/client-roo.svg" alt="Roo Code" /> | [Roo Code](https://roocode.com/) | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` |
@@ -70,8 +71,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -93,9 +94,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -160,6 +161,7 @@ direct payload:
 - [Grok CLI integration](docs/grok-cli-integration.md)
 - [Kiro integration](docs/kiro-integration.md)
 - [Kilo Code integration](docs/kilo-integration.md)
+- [Open Interpreter integration](docs/open-interpreter-integration.md)
 - [Open WebUI integration](docs/openwebui-integration.md)
 - [Qwen Code integration](docs/qwen-code-integration.md)
 - [Roo Code integration](docs/roo-integration.md)

--- a/docs/client-open-interpreter.svg
+++ b/docs/client-open-interpreter.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Open Interpreter</title>
+  <desc id="desc">Open Interpreter client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#101820"/>
+  <path d="M24 28h48v12H58v28H38V40H24z" fill="#F5F7FA"/>
+  <path d="M24 56h12v12H24zM60 56h12v12H60z" fill="#32D0AA"/>
+  <path d="M42 28h12v40H42z" fill="#32D0AA" opacity=".85"/>
+</svg>

--- a/docs/open-interpreter-integration.md
+++ b/docs/open-interpreter-integration.md
@@ -1,0 +1,46 @@
+# Open Interpreter integration
+
+`tokenjuice install open-interpreter` inserts a marker-delimited instruction block
+into `AGENTS.md` at the current git/project root.
+
+Open Interpreter reads project `AGENTS.md` files as team norms before sessions, so
+tokenjuice uses that native guidance surface instead of trying to intercept the
+terminal. This is intentionally beta and instruction-based: Open Interpreter
+still owns command execution, approvals, and output delivery.
+
+## Commands
+
+```bash
+tokenjuice install open-interpreter
+tokenjuice doctor open-interpreter
+tokenjuice uninstall open-interpreter
+```
+
+By default tokenjuice resolves the current git root and updates
+`<git-root>/AGENTS.md`. Set `OPEN_INTERPRETER_PROJECT_DIR=/path/to/project` to
+target a specific project directory during tests or scripted installs.
+
+## Installed guidance
+
+The managed block tells Open Interpreter to:
+
+- use `tokenjuice wrap -- <command>` for noisy terminal commands,
+- treat compacted tokenjuice output as authoritative,
+- use `tokenjuice wrap --raw -- <command>` only when raw bytes are required.
+
+The managed markers are host-specific:
+
+```markdown
+<!-- tokenjuice:open-interpreter begin -->
+...
+<!-- tokenjuice:open-interpreter end -->
+```
+
+That lets Open Interpreter share `AGENTS.md` with other agent instruction blocks
+without one install replacing another host's tokenjuice guidance.
+
+## Scope
+
+`tokenjuice install open-interpreter` manages only project-local `AGENTS.md`
+files inside the current git/project root. Global Open Interpreter instructions
+such as `~/.openinterpreter/AGENTS.md` remain user-managed.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -177,6 +177,7 @@ tokenjuice install crush
 tokenjuice install cursor
 tokenjuice install grok-cli
 tokenjuice install goose
+tokenjuice install open-interpreter
 tokenjuice install openwebui
 tokenjuice install pi
 tokenjuice install opencode
@@ -188,6 +189,7 @@ tokenjuice doctor opencode
 tokenjuice doctor crush
 tokenjuice doctor grok-cli
 tokenjuice doctor goose
+tokenjuice doctor open-interpreter
 tokenjuice doctor openwebui
 tokenjuice doctor qwen-code
 tokenjuice doctor ruler
@@ -226,6 +228,7 @@ supported host hooks:
 | Kilo Code | `tokenjuice install kilo` | `kilo.jsonc` or `.kilo/kilo.jsonc` + `.kilo/rules/tokenjuice.md` | ✴️ Beta. Registers a workspace rule that tells Kilo Code to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Kilo Code rules do not intercept tool output; see `docs/kilo-integration.md` |
 | OpenCode | `tokenjuice install opencode` | `~/.config/opencode/plugins/tokenjuice.js` | Installs a project-agnostic plugin that is auto-loaded on OpenCode session start; `tokenjuice install opencode --local` bundles the plugin from the current repo source |
 | OpenHands | `tokenjuice install openhands` | `.openhands/hooks.json` | ✴️ Beta. Uses a project-local `PostToolUse` hook for `terminal` output; compacted context is injected alongside the original output; `tokenjuice install openhands --local` is available for repo-local verification; see `docs/openhands-integration.md` |
+| Open Interpreter | `tokenjuice install open-interpreter` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block into the current git/project root that tells Open Interpreter to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Open Interpreter `AGENTS.md` instructions do not intercept tool output; global Open Interpreter instructions remain user-managed; see `docs/open-interpreter-integration.md` |
 | Open WebUI | `tokenjuice install openwebui` | `.openwebui/tools/tokenjuice_compact.py` | ✴️ Beta. Exports a reviewable Workspace Tool source file for manual administrator import; the tool compacts provided terminal output through `tokenjuice reduce-json` and does not execute user commands; see `docs/openwebui-integration.md` |
 | pi | `tokenjuice install pi` | `~/.pi/agent/extensions/tokenjuice.js` | `tokenjuice install pi --local` forces the extension bundle to be rebuilt from the current repo source and adds `/tj` controls inside pi |
 | Qwen Code | `tokenjuice install qwen-code` | `.qwen/settings.json` | ✴️ Beta. Uses a project-local `PostToolUse` hook for shell tools; compacted context is injected alongside the original output; `tokenjuice install qwen-code --local` is available for repo-local verification; see `docs/qwen-code-integration.md` |
@@ -235,7 +238,7 @@ supported host hooks:
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor openwebui`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor open-interpreter`, `tokenjuice doctor openwebui`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,6 +43,7 @@ import {
   installOpenCodeExtension,
   uninstallOpenCodeExtension,
 } from "../hosts/opencode/index.js";
+import { doctorOpenInterpreterInstructions, installOpenInterpreterInstructions, uninstallOpenInterpreterInstructions } from "../hosts/open-interpreter/index.js";
 import { doctorOpenHandsHook, installOpenHandsHook, runOpenHandsPostToolUseHook, uninstallOpenHandsHook } from "../hosts/openhands/index.js";
 import { doctorOpenWebUITool, installOpenWebUITool, uninstallOpenWebUITool } from "../hosts/openwebui/index.js";
 import { doctorPiExtension, installPiExtension } from "../hosts/pi/index.js";
@@ -126,6 +127,7 @@ function printUsage(): void {
       "  tokenjuice install kiro",
       "  tokenjuice install kilo",
       "  tokenjuice install openhands [--local]",
+      "  tokenjuice install open-interpreter",
       "  tokenjuice install openwebui",
       "  tokenjuice install pi [--local]",
       "  tokenjuice install opencode [--local]",
@@ -152,6 +154,7 @@ function printUsage(): void {
       "  tokenjuice uninstall kiro",
       "  tokenjuice uninstall kilo",
       "  tokenjuice uninstall openhands",
+      "  tokenjuice uninstall open-interpreter",
       "  tokenjuice uninstall openwebui",
       "  tokenjuice uninstall opencode",
       "  tokenjuice uninstall qwen-code",
@@ -165,7 +168,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|qwen-code|roo|ruler|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -865,6 +868,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "open-interpreter" || target === "openinterpreter") {
+    const result = await installOpenInterpreterInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Instructions", value: result.instructionsPath },
+      { label: "Beta", value: "instruction-based guidance; Open Interpreter still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor open-interpreter" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("open-interpreter", "instructions", details));
+    return 0;
+  }
+
   if (target === "openwebui") {
     const result = await installOpenWebUITool();
     if (args.format === "json") {
@@ -1091,7 +1114,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, openwebui, pi, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1305,6 +1328,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "open-interpreter" || target === "openinterpreter") {
+    const result = await uninstallOpenInterpreterInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed open-interpreter instructions: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
+    process.stdout.write("enable: tokenjuice install open-interpreter\n");
+    return 0;
+  }
+
   if (target === "openwebui") {
     const result = await uninstallOpenWebUITool();
     if (args.format === "json") {
@@ -1435,7 +1471,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, openwebui, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, opencode, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -2089,6 +2125,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     }
 
     process.stdout.write(`tool path: ${report.toolPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "open-interpreter" || args.positionals[0] === "openinterpreter") {
+    const report = await doctorOpenInterpreterInstructions();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
     process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -46,6 +46,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("openhands")) {
     return "openhands";
   }
+  if (source.startsWith("openinterpreter") || source.startsWith("open-interpreter")) {
+    return "open-interpreter";
+  }
   if (source.startsWith("openwebui") || source.startsWith("open-webui")) {
     return "openwebui";
   }

--- a/src/hosts/open-interpreter/index.ts
+++ b/src/hosts/open-interpreter/index.ts
@@ -1,0 +1,444 @@
+import { readdir, realpath, stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type OpenInterpreterInstructionsOptions = {
+  projectDir?: string;
+  scanProjectTree?: boolean;
+};
+
+export type InstallOpenInterpreterInstructionsResult = {
+  instructionsPath: string;
+  instructionsPaths?: string[];
+  backupPath?: string;
+};
+
+export type UninstallOpenInterpreterInstructionsResult = {
+  instructionsPath: string;
+  removedPaths?: string[];
+  removed: boolean;
+};
+
+export type OpenInterpreterDoctorReport = {
+  instructionsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_OPEN_INTERPRETER_FIX_COMMAND = "tokenjuice install open-interpreter";
+const TOKENJUICE_OPEN_INTERPRETER_BEGIN = "<!-- tokenjuice:open-interpreter begin -->";
+const TOKENJUICE_OPEN_INTERPRETER_END = "<!-- tokenjuice:open-interpreter end -->";
+const TOKENJUICE_OPEN_INTERPRETER_ADVISORY = "Open Interpreter support is beta and instruction-based; it guides command usage through project AGENTS.md but does not intercept tool output. tokenjuice manages AGENTS.md files inside the current git/project root; global Open Interpreter instructions remain user-managed.";
+
+function getExplicitProjectDir(options: OpenInterpreterInstructionsOptions = {}): string | undefined {
+  return options.projectDir || process.env.OPEN_INTERPRETER_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: OpenInterpreterInstructionsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? resolve(process.cwd());
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+async function isInsideOrEqualPath(childPath: string, parentPath: string): Promise<boolean> {
+  const child = await canonicalPath(childPath);
+  const parent = await canonicalPath(parentPath);
+  const relativePath = relative(parent, child);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+async function findParentTokenjuiceInstructionPaths(startDir: string, boundaryDir: string): Promise<string[]> {
+  let current = resolve(startDir);
+  const boundary = resolve(boundaryDir);
+  const paths: string[] = [];
+  while (true) {
+    if (!await isInsideOrEqualPath(current, boundary)) {
+      return paths;
+    }
+
+    const instructionsPath = join(current, "AGENTS.md");
+    const existing = await readInstructionFile(instructionsPath);
+    if (existing.exists && (existing.text.includes(TOKENJUICE_OPEN_INTERPRETER_BEGIN) || existing.text.includes(TOKENJUICE_OPEN_INTERPRETER_END))) {
+      paths.push(instructionsPath);
+    }
+
+    if (current === boundary) {
+      return paths;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return paths;
+    }
+    current = parent;
+  }
+}
+
+const OPEN_INTERPRETER_SCAN_SKIP_DIRS = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
+
+async function findDescendantTokenjuiceInstructionPaths(projectDir: string): Promise<string[]> {
+  const paths: string[] = [];
+  const rootDir = resolve(projectDir);
+
+  async function visit(dir: string): Promise<void> {
+    if (dir !== rootDir && await hasGitMetadata(dir)) {
+      return;
+    }
+
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(dir, entry.name);
+      if (entry.isFile() && entry.name === "AGENTS.md") {
+        const existing = await readInstructionFile(entryPath);
+        if (existing.text.includes(TOKENJUICE_OPEN_INTERPRETER_BEGIN) || existing.text.includes(TOKENJUICE_OPEN_INTERPRETER_END)) {
+          paths.push(entryPath);
+        }
+        continue;
+      }
+
+      if (entry.isDirectory() && !OPEN_INTERPRETER_SCAN_SKIP_DIRS.has(entry.name)) {
+        await visit(entryPath);
+      }
+    }
+  }
+
+  await visit(rootDir);
+  return paths;
+}
+
+async function uniqueCanonicalPaths(paths: string[]): Promise<string[]> {
+  const seen = new Set<string>();
+  const uniquePaths: string[] = [];
+  for (const path of paths) {
+    const key = await canonicalPath(path);
+    if (!seen.has(key)) {
+      seen.add(key);
+      uniquePaths.push(path);
+    }
+  }
+  return uniquePaths;
+}
+
+async function getDefaultInstructionPaths(
+  options: OpenInterpreterInstructionsOptions = {},
+  preferExistingTokenjuiceBlocks = false,
+  includeRootWithExistingBlocks = false,
+): Promise<string[]> {
+  const scanProjectTree = options.scanProjectTree !== false;
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    const projectDir = resolve(explicitProjectDir);
+    const rootInstructionsPath = join(projectDir, "AGENTS.md");
+    if (preferExistingTokenjuiceBlocks) {
+      const existing = await isInsideOrEqualPath(resolve(process.cwd()), projectDir)
+        ? await findParentTokenjuiceInstructionPaths(process.cwd(), projectDir)
+        : [];
+      const descendantExisting = includeRootWithExistingBlocks && scanProjectTree
+        ? await findDescendantTokenjuiceInstructionPaths(projectDir)
+        : [];
+      if (existing.length > 0 || descendantExisting.length > 0) {
+        return includeRootWithExistingBlocks
+          ? await uniqueCanonicalPaths([rootInstructionsPath, ...existing, ...descendantExisting])
+          : existing;
+      }
+    }
+    return [rootInstructionsPath];
+  }
+
+  const projectDir = await resolveProjectDir(options);
+  if (preferExistingTokenjuiceBlocks) {
+    const existing = await findParentTokenjuiceInstructionPaths(process.cwd(), projectDir);
+    const descendantExisting = includeRootWithExistingBlocks && scanProjectTree
+      ? await findDescendantTokenjuiceInstructionPaths(projectDir)
+      : [];
+    if (existing.length > 0 || descendantExisting.length > 0) {
+      return includeRootWithExistingBlocks
+        ? await uniqueCanonicalPaths([join(projectDir, "AGENTS.md"), ...existing, ...descendantExisting])
+        : existing;
+    }
+  }
+
+  return [join(projectDir, "AGENTS.md")];
+}
+
+async function getDefaultUninstallInstructionPaths(options: OpenInterpreterInstructionsOptions = {}): Promise<string[]> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    const projectDir = resolve(explicitProjectDir);
+    const rootInstructionsPath = join(projectDir, "AGENTS.md");
+    const descendantExisting = await findDescendantTokenjuiceInstructionPaths(projectDir);
+    if (await isInsideOrEqualPath(resolve(process.cwd()), projectDir)) {
+      const existing = await findParentTokenjuiceInstructionPaths(process.cwd(), projectDir);
+      if (existing.length > 0) {
+        return await uniqueCanonicalPaths([...existing, ...descendantExisting]);
+      }
+    }
+    if (descendantExisting.length > 0) {
+      return await uniqueCanonicalPaths(descendantExisting);
+    }
+    return [rootInstructionsPath];
+  }
+
+  const projectDir = await resolveProjectDir(options);
+  const rootInstructionsPath = join(projectDir, "AGENTS.md");
+  const descendantExisting = await findDescendantTokenjuiceInstructionPaths(projectDir);
+  const existing = await findParentTokenjuiceInstructionPaths(process.cwd(), projectDir);
+  if (existing.length > 0 || descendantExisting.length > 0) {
+    return await uniqueCanonicalPaths([...existing, ...descendantExisting]);
+  }
+  return [rootInstructionsPath];
+}
+
+const TOKENJUICE_OPEN_INTERPRETER_BLOCK = [
+  TOKENJUICE_OPEN_INTERPRETER_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through Open Interpreter, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_OPEN_INTERPRETER_END,
+].join("\n");
+
+const TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_OPEN_INTERPRETER_BEGIN,
+  endMarker: TOKENJUICE_OPEN_INTERPRETER_END,
+  block: TOKENJUICE_OPEN_INTERPRETER_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_OPEN_INTERPRETER_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_OPEN_INTERPRETER_END, beginIndex + TOKENJUICE_OPEN_INTERPRETER_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_OPEN_INTERPRETER_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_OPEN_INTERPRETER_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_OPEN_INTERPRETER_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installOpenInterpreterInstructions(
+  instructionsPath?: string,
+  options: OpenInterpreterInstructionsOptions = {},
+): Promise<InstallOpenInterpreterInstructionsResult> {
+  const resolvedInstructionsPaths = instructionsPath ? [instructionsPath] : await getDefaultInstructionPaths(options, true, true);
+  for (const resolvedInstructionsPath of resolvedInstructionsPaths) {
+    const existing = await readInstructionFile(resolvedInstructionsPath);
+    const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG);
+    if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+      throw new Error(
+        `cannot safely repair malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice install open-interpreter`,
+      );
+    }
+  }
+
+  const results = [];
+  for (const resolvedInstructionsPath of resolvedInstructionsPaths) {
+    results.push(await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG));
+  }
+  const result = results[0]!;
+  const instructionsPaths = results.map((entry) => entry.filePath);
+  return {
+    instructionsPath: result.filePath,
+    ...(instructionsPaths.length > 1 ? { instructionsPaths } : {}),
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallOpenInterpreterInstructions(
+  instructionsPath?: string,
+  options: OpenInterpreterInstructionsOptions = {},
+): Promise<UninstallOpenInterpreterInstructionsResult> {
+  const resolvedInstructionsPaths = instructionsPath ? [instructionsPath] : await getDefaultUninstallInstructionPaths(options);
+  for (const resolvedInstructionsPath of resolvedInstructionsPaths) {
+    const existing = await readInstructionFile(resolvedInstructionsPath);
+    const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG);
+    if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+      throw new Error(
+        `cannot safely uninstall malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall open-interpreter`,
+      );
+    }
+  }
+
+  const results = [];
+  for (const resolvedInstructionsPath of resolvedInstructionsPaths) {
+    results.push(await uninstallMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG));
+  }
+  const removedPaths = results.filter((result) => result.removed).map((result) => result.filePath);
+  const firstResult = results[0]!;
+  return {
+    instructionsPath: firstResult.filePath,
+    ...(removedPaths.length > 0 ? { removedPaths } : {}),
+    removed: removedPaths.length > 0,
+  };
+}
+
+async function inspectOpenInterpreterInstructionsPath(resolvedInstructionsPath: string): Promise<OpenInterpreterDoctorReport> {
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_OPEN_INTERPRETER_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      instructionsPath: resolvedInstructionsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Open Interpreter instructions are not installed"],
+        advisory: TOKENJUICE_OPEN_INTERPRETER_ADVISORY,
+        fixCommand: TOKENJUICE_OPEN_INTERPRETER_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Open Interpreter instructions",
+    repairCommand: TOKENJUICE_OPEN_INTERPRETER_FIX_COMMAND,
+  });
+  const malformedMarkerIssues = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount) && markerIssues.length === 0
+    ? ["configured Open Interpreter instructions have malformed tokenjuice markers"]
+    : [];
+  const issues = [
+    ...markerIssues,
+    ...malformedMarkerIssues,
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured Open Interpreter instructions are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured Open Interpreter instructions are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured Open Interpreter instructions still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    instructionsPath: resolvedInstructionsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_OPEN_INTERPRETER_ADVISORY,
+      fixCommand: hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)
+        ? "remove unmatched tokenjuice markers from AGENTS.md, then run tokenjuice install open-interpreter"
+        : TOKENJUICE_OPEN_INTERPRETER_FIX_COMMAND,
+    }),
+  };
+}
+
+export async function doctorOpenInterpreterInstructions(
+  instructionsPath?: string,
+  options: OpenInterpreterInstructionsOptions = {},
+): Promise<OpenInterpreterDoctorReport> {
+  const resolvedInstructionsPaths = instructionsPath ? [instructionsPath] : await getDefaultInstructionPaths(options, true, true);
+  const reports = [];
+  for (const resolvedInstructionsPath of resolvedInstructionsPaths) {
+    reports.push(await inspectOpenInterpreterInstructionsPath(resolvedInstructionsPath));
+  }
+
+  const brokenReport = reports.find((report) => report.status === "broken");
+  if (brokenReport) {
+    return brokenReport;
+  }
+
+  if (!instructionsPath && reports.length > 1 && reports[0]?.status === "disabled") {
+    return {
+      instructionsPath: reports[0].instructionsPath,
+      status: "warn",
+      issues: ["tokenjuice Open Interpreter root instructions are not installed, but nested tokenjuice instructions exist"],
+      advisories: [TOKENJUICE_OPEN_INTERPRETER_ADVISORY],
+      fixCommand: TOKENJUICE_OPEN_INTERPRETER_FIX_COMMAND,
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  return reports.find((report) => report.status === "warn")
+    ?? reports.find((report) => report.status === "ok")
+    ?? reports[0]!;
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -18,6 +18,7 @@ import { doctorJunieInstructions } from "../junie/index.js";
 import { doctorKiroSteering } from "../kiro/index.js";
 import { doctorKiloRule } from "../kilo/index.js";
 import { doctorOpenHandsHook } from "../openhands/index.js";
+import { doctorOpenInterpreterInstructions } from "../open-interpreter/index.js";
 import { doctorOpenWebUITool } from "../openwebui/index.js";
 import { doctorPiExtension } from "../pi/index.js";
 import { doctorQwenCodeHook } from "../qwen-code/index.js";
@@ -46,6 +47,7 @@ import type { GrokCliDoctorReport, GrokCliHookCommandOptions } from "../grok-cli
 import type { JunieDoctorReport } from "../junie/index.js";
 import type { KiroDoctorReport } from "../kiro/index.js";
 import type { KiloDoctorReport } from "../kilo/index.js";
+import type { OpenInterpreterDoctorReport, OpenInterpreterInstructionsOptions } from "../open-interpreter/index.js";
 import type { OpenHandsDoctorReport } from "../openhands/index.js";
 import type { OpenWebUIDoctorReport, OpenWebUIToolOptions } from "../openwebui/index.js";
 import type { PiDoctorReport } from "../pi/index.js";
@@ -78,6 +80,7 @@ export type HookIntegrationDoctorReport = {
   kiro: KiroDoctorReport;
   kilo: KiloDoctorReport;
   openhands: OpenHandsDoctorReport;
+  "open-interpreter": OpenInterpreterDoctorReport;
   openwebui: OpenWebUIDoctorReport;
   pi: PiDoctorReport;
   "qwen-code": QwenCodeDoctorReport;
@@ -94,7 +97,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & OpenWebUIToolOptions & QwenCodeHookCommandOptions & RulerRuleOptions;
+export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & QwenCodeHookCommandOptions & RulerRuleOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -125,6 +128,7 @@ const hookDoctorIntegrationDoctors = {
   kiro: () => doctorKiroSteering(),
   kilo: () => doctorKiloRule(),
   openhands: (options) => doctorOpenHandsHook(undefined, getHookCommandOptions(options)),
+  "open-interpreter": (options) => doctorOpenInterpreterInstructions(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),
   openwebui: (options) => doctorOpenWebUITool(undefined, getHookCommandOptions(options)),
   pi: () => doctorPiExtension(),
   "qwen-code": (options) => doctorQwenCodeHook(undefined, options),

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstru
 export { doctorKiroSteering, installKiroSteering, uninstallKiroSteering } from "./hosts/kiro/index.js";
 export { doctorKiloRule, installKiloRule, uninstallKiloRule } from "./hosts/kilo/index.js";
 export { doctorOpenHandsHook, installOpenHandsHook, runOpenHandsPostToolUseHook, uninstallOpenHandsHook } from "./hosts/openhands/index.js";
+export { doctorOpenInterpreterInstructions, installOpenInterpreterInstructions, uninstallOpenInterpreterInstructions } from "./hosts/open-interpreter/index.js";
 export { doctorOpenWebUITool, installOpenWebUITool, uninstallOpenWebUITool } from "./hosts/openwebui/index.js";
 export { doctorRooInstructions, installRooInstructions, uninstallRooInstructions } from "./hosts/roo/index.js";
 export {
@@ -174,6 +175,12 @@ export type {
   OpenHandsHookCommandOptions,
   UninstallOpenHandsHookResult,
 } from "./hosts/openhands/index.js";
+export type {
+  InstallOpenInterpreterInstructionsResult,
+  OpenInterpreterDoctorReport,
+  OpenInterpreterInstructionsOptions,
+  UninstallOpenInterpreterInstructionsResult,
+} from "./hosts/open-interpreter/index.js";
 export type {
   InstallOpenWebUIToolResult,
   OpenWebUIDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, openwebui, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, openwebui, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/open-interpreter.test.ts
+++ b/test/hosts/open-interpreter.test.ts
@@ -1,0 +1,456 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorOpenInterpreterInstructions,
+  installOpenInterpreterInstructions,
+  uninstallOpenInterpreterInstructions,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CRUSH_PROJECT_DIR",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_HOME",
+  "HOME",
+  "JUNIE_PROJECT_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "OPENWEBUI_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-open-interpreter-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("open-interpreter instructions", () => {
+  it("installs a host-specific marker-delimited AGENTS.md instruction block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    const result = await installOpenInterpreterInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(result.instructionsPath).toBe(instructionsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(instructions).toContain("<!-- tokenjuice:open-interpreter begin -->");
+    expect(instructions).toContain("tokenjuice terminal output compaction");
+    expect(instructions).toContain("When running terminal commands through Open Interpreter");
+    expect(instructions).toContain("tokenjuice wrap -- <command>");
+    expect(instructions).toContain("tokenjuice wrap --raw -- <command>");
+    expect(instructions).not.toContain("wrap --full");
+  });
+
+  it("coexists with other tokenjuice AGENTS.md blocks", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "<!-- tokenjuice:begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through Amp, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installOpenInterpreterInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("<!-- tokenjuice:begin -->");
+    expect(instructions).toContain("When running terminal commands through Amp");
+    expect(instructions).toContain("<!-- tokenjuice:open-interpreter begin -->");
+    expect(instructions).toContain("When running terminal commands through Open Interpreter");
+  });
+
+  it("backs up existing project instructions before replacing its own block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await installOpenInterpreterInstructions(instructionsPath);
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const result = await installOpenInterpreterInstructions(instructionsPath);
+
+    expect(result.backupPath).toBe(`${instructionsPath}.bak`);
+    await expect(readFile(`${instructionsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    await expect(readFile(instructionsPath, "utf8")).resolves.toContain("<!-- tokenjuice:open-interpreter begin -->");
+  });
+
+  it("reports installed and uninstalled instruction health", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    await installOpenInterpreterInstructions(instructionsPath);
+    const installed = await doctorOpenInterpreterInstructions(instructionsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("instruction-based");
+
+    const removed = await uninstallOpenInterpreterInstructions(instructionsPath);
+    const disabled = await doctorOpenInterpreterInstructions(instructionsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(instructionsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports broken instructions with unmatched Open Interpreter tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:open-interpreter begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorOpenInterpreterInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("reports broken instructions when marker counts are malformed but guidance is present", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "tokenjuice wrap -- <command>",
+        "tokenjuice wrap --raw -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorOpenInterpreterInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Open Interpreter instructions have malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("uses OPEN_INTERPRETER_PROJECT_DIR for the default AGENTS.md path", async () => {
+    const home = await createTempDir();
+    process.env.OPEN_INTERPRETER_PROJECT_DIR = home;
+
+    const installed = await installOpenInterpreterInstructions();
+    const expectedInstructionsPath = join(home, "AGENTS.md");
+    const doctor = await doctorOpenInterpreterInstructions();
+
+    expect(installed.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("defaults to the git root AGENTS.md from nested directories", async () => {
+    const home = await createTempDir();
+    await mkdir(join(home, ".git"));
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installOpenInterpreterInstructions();
+    const root = await realpath(home);
+
+    expect(installed.instructionsPath).toBe(join(root, "AGENTS.md"));
+    await expect(readFile(join(root, "AGENTS.md"), "utf8")).resolves.toContain("Open Interpreter");
+  });
+
+  it("keeps the root install target when repairing nested tokenjuice instructions", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "stale tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const installed = await installOpenInterpreterInstructions();
+    const afterInstall = await doctorOpenInterpreterInstructions();
+    const root = await realpath(home);
+    const nested = await realpath(nestedDir);
+
+    expect(installed.instructionsPaths).toEqual([
+      join(root, "AGENTS.md"),
+      join(nested, "AGENTS.md"),
+    ]);
+    expect(afterInstall.status).toBe("ok");
+    await expect(readFile(join(root, "AGENTS.md"), "utf8")).resolves.toContain("Open Interpreter");
+    await expect(readFile(join(nested, "AGENTS.md"), "utf8")).resolves.not.toContain("wrap --full");
+  });
+
+  it("reports nested-only tokenjuice instructions as missing root guidance", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await installOpenInterpreterInstructions(join(nestedDir, "AGENTS.md"));
+    process.chdir(nestedDir);
+
+    const doctor = await doctorOpenInterpreterInstructions();
+    const root = await realpath(home);
+
+    expect(doctor.status).toBe("warn");
+    expect(doctor.instructionsPath).toBe(join(root, "AGENTS.md"));
+    expect(doctor.issues).toContain("tokenjuice Open Interpreter root instructions are not installed, but nested tokenjuice instructions exist");
+    expect(doctor.fixCommand).toBe("tokenjuice install open-interpreter");
+  });
+
+  it("reports broken nested tokenjuice instructions before missing root guidance", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "tokenjuice wrap -- <command>",
+        "tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const doctor = await doctorOpenInterpreterInstructions();
+    const nested = await realpath(nestedDir);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.instructionsPath).toBe(join(nested, "AGENTS.md"));
+    expect(doctor.issues).toContain("configured Open Interpreter instructions are missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Open Interpreter instructions still suggest the full escape hatch");
+  });
+
+  it("uses explicit projectDir as the AGENTS.md scan boundary", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    await installOpenInterpreterInstructions(undefined, { projectDir: home });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "stale tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+    process.chdir(nestedDir);
+
+    const beforeRepair = await doctorOpenInterpreterInstructions(undefined, { projectDir: home });
+    const repaired = await installOpenInterpreterInstructions(undefined, { projectDir: home });
+    const afterRepair = await doctorOpenInterpreterInstructions(undefined, { projectDir: home });
+    const removed = await uninstallOpenInterpreterInstructions(undefined, { projectDir: home });
+
+    expect(beforeRepair.status).toBe("broken");
+    expect(beforeRepair.instructionsPath).toBe(join(await realpath(nestedDir), "AGENTS.md"));
+    expect(repaired.instructionsPaths).toEqual([
+      join(home, "AGENTS.md"),
+      join(await realpath(nestedDir), "AGENTS.md"),
+    ]);
+    expect(afterRepair.status).toBe("ok");
+    expect(removed.removedPaths).toEqual([
+      join(await realpath(nestedDir), "AGENTS.md"),
+      join(await realpath(home), "AGENTS.md"),
+    ]);
+    await expect(access(join(home, "AGENTS.md"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(nestedDir, "AGENTS.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("scans explicit projectDir descendants when launched outside the project", async () => {
+    const home = await createTempDir();
+    const outside = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    await installOpenInterpreterInstructions(undefined, { projectDir: home });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "stale tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+    process.chdir(outside);
+
+    const beforeRepair = await doctorOpenInterpreterInstructions(undefined, { projectDir: home });
+    const repaired = await installOpenInterpreterInstructions(undefined, { projectDir: home });
+    const afterRepair = await doctorOpenInterpreterInstructions(undefined, { projectDir: home });
+
+    expect(beforeRepair.status).toBe("broken");
+    expect(beforeRepair.instructionsPath).toBe(join(nestedDir, "AGENTS.md"));
+    expect(repaired.instructionsPaths).toEqual([
+      join(home, "AGENTS.md"),
+      join(nestedDir, "AGENTS.md"),
+    ]);
+    expect(afterRepair.status).toBe("ok");
+  });
+
+  it("removes nested managed instructions when uninstalling from the git root", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await installOpenInterpreterInstructions(join(home, "AGENTS.md"));
+    await installOpenInterpreterInstructions(join(nestedDir, "AGENTS.md"));
+    process.chdir(home);
+
+    const removed = await uninstallOpenInterpreterInstructions();
+
+    expect(removed.removedPaths).toEqual([
+      join(await realpath(home), "AGENTS.md"),
+      join(await realpath(nestedDir), "AGENTS.md"),
+    ]);
+    await expect(access(join(home, "AGENTS.md"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(nestedDir, "AGENTS.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not uninstall managed instructions from nested git projects", async () => {
+    const home = await createTempDir();
+    const nestedRepoDir = join(home, "vendor", "tool");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(join(nestedRepoDir, ".git"), { recursive: true });
+    await installOpenInterpreterInstructions(join(home, "AGENTS.md"));
+    await installOpenInterpreterInstructions(join(nestedRepoDir, "AGENTS.md"));
+    process.chdir(home);
+
+    const removed = await uninstallOpenInterpreterInstructions();
+
+    expect(removed.removedPaths).toEqual([
+      join(await realpath(home), "AGENTS.md"),
+    ]);
+    await expect(access(join(home, "AGENTS.md"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(nestedRepoDir, "AGENTS.md"), "utf8")).resolves.toContain("tokenjuice:open-interpreter begin");
+  });
+
+  it("reports descendant-only managed instructions from the git root", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await installOpenInterpreterInstructions(join(nestedDir, "AGENTS.md"));
+    process.chdir(home);
+
+    const doctor = await doctorOpenInterpreterInstructions();
+
+    expect(doctor.status).toBe("warn");
+    expect(doctor.instructionsPath).toBe(join(await realpath(home), "AGENTS.md"));
+    expect(doctor.issues).toContain("tokenjuice Open Interpreter root instructions are not installed, but nested tokenjuice instructions exist");
+  });
+
+  it("reports broken descendant managed instructions from the git root", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(join(home, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "tokenjuice wrap -- <command>",
+        "tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+    process.chdir(home);
+
+    const doctor = await doctorOpenInterpreterInstructions();
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.instructionsPath).toBe(join(await realpath(nestedDir), "AGENTS.md"));
+    expect(doctor.issues).toContain("configured Open Interpreter instructions are missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Open Interpreter instructions still suggest the full escape hatch");
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await installOpenInterpreterInstructions(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations["open-interpreter"].instructionsPath).toBe(join(home, "AGENTS.md"));
+    expect(report.integrations["open-interpreter"].status).toBe("ok");
+  });
+
+  it("does not scan descendant instructions during aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    const nestedDir = join(home, "packages", "app");
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(
+      join(nestedDir, "AGENTS.md"),
+      [
+        "<!-- tokenjuice:open-interpreter begin -->",
+        "stale tokenjuice wrap --full -- <command>",
+        "<!-- tokenjuice:open-interpreter end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const direct = await doctorOpenInterpreterInstructions(undefined, { projectDir: home });
+    const aggregate = await doctorInstalledHooks({ projectDir: home });
+
+    expect(direct.status).toBe("broken");
+    expect(aggregate.integrations["open-interpreter"].instructionsPath).toBe(join(home, "AGENTS.md"));
+    expect(aggregate.integrations["open-interpreter"].status).toBe("disabled");
+  });
+});


### PR DESCRIPTION
## Summary
- add an Open Interpreter `AGENTS.md` instruction integration using host-specific marker blocks
- resolve the default instructions file at the git/project root, while honoring `OPEN_INTERPRETER_PROJECT_DIR` and `projectDir`
- repair stale nested managed Open Interpreter blocks, preserve user `AGENTS.md` content, and avoid crossing nested git roots
- wire `tokenjuice install open-interpreter`, `uninstall open-interpreter`, `doctor open-interpreter`, aggregate doctor output, source normalization, exports, README, and spec/docs
- keep aggregate `doctor hooks` fast by disabling descendant tree scans for Open Interpreter there; direct `doctor open-interpreter` still performs the deeper scan

## Validation
- `pnpm exec vitest run test/hosts/open-interpreter.test.ts test/hosts/openwebui.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `git diff --check`
- `pnpm build`
- isolated built CLI smoke: `install open-interpreter`, `doctor open-interpreter`, aggregate `doctor hooks`, `uninstall open-interpreter`
- isolated built CLI smoke: root uninstall removes same-project nested managed `AGENTS.md` blocks while preserving nested git project blocks
- isolated built CLI smoke: explicit `OPEN_INTERPRETER_PROJECT_DIR` launched outside the project detects and repairs broken descendant instructions
- isolated built CLI smoke: aggregate `doctor hooks` does not perform the descendant Open Interpreter scan while direct `doctor open-interpreter` does
- privacy scan over `git diff origin/main...HEAD` for private paths, private IPs, and smoke temp names
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main ...` clean after fixing accepted findings
