### PR TITLE
feat(augment): add rule-based integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ beta integrations:
 | --- | --- | --- | --- |
 | <img width="48px" src="docs/client-aider.svg" alt="Aider" /> | [Aider](https://aider.chat/) | `tokenjuice install aider` | `CONVENTIONS.tokenjuice.md` |
 | <img width="48px" src="docs/client-amp.svg" alt="Amp" /> | [Amp](https://ampcode.com/manual) | `tokenjuice install amp` | `AGENTS.md` / `AGENT.md` / `CLAUDE.md` |
+| <img width="48px" src="docs/client-augment.svg" alt="Augment" /> | [Augment](https://docs.augmentcode.com/cli/rules) | `tokenjuice install augment` | `.augment/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-avante.png" alt="Avante" /> | [Avante.nvim](https://github.com/yetone/avante.nvim) | `tokenjuice install avante` | `avante.md` |
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
@@ -72,8 +73,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amp|augment|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -95,9 +96,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amp|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amp|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amp|augment|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -154,6 +155,7 @@ direct payload:
 - [rules](docs/rules.md)
 - [integration playbook](docs/integration-playbook.md)
 - [Amp integration](docs/amp-integration.md)
+- [Augment integration](docs/augment-integration.md)
 - [GitHub Copilot coding agent integration](docs/copilot-agent-integration.md)
 - [Crush integration](docs/crush-integration.md)
 - [Cursor integration](docs/cursor-integration.md)

--- a/docs/augment-integration.md
+++ b/docs/augment-integration.md
@@ -1,0 +1,31 @@
+# Augment integration
+
+Augment support is beta.
+
+`tokenjuice install augment` writes an always-applied workspace rule to
+`.augment/rules/tokenjuice.md` in the current git/project root. Auggie and the
+Augment IDE extensions load workspace rules from `.augment/rules/*.md`, and
+`type: always_apply` rules are included in every prompt.
+
+## Install
+
+```bash
+tokenjuice install augment
+tokenjuice doctor augment
+```
+
+## Behavior
+
+- The rule tells Augment and Auggie to prefer `tokenjuice wrap -- <command>` for
+  noisy terminal commands.
+- The rule tells Augment to treat compacted output as authoritative.
+- The only documented escape hatch is `tokenjuice wrap --raw -- <command>`.
+- Existing `.augment/rules/tokenjuice.md` content is backed up before install.
+- `AUGMENT_PROJECT_DIR` can override the project root for tests and scripted
+  installs.
+
+## Current beta caveat
+
+Augment workspace rules are prompt guidance, not command hooks. This integration
+does not intercept or rewrite shell output; it gives Augment a stable project
+rule to follow when it decides how to run terminal commands.

--- a/docs/client-augment.svg
+++ b/docs/client-augment.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Augment</title>
+  <desc id="desc">Augment client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#111827"/>
+  <path d="M48 18 76 76H62l-5-12H38l-5 12H20z" fill="#F8FAFC"/>
+  <path d="M43 52h10l-5-13z" fill="#111827"/>
+  <path d="M23 76h50v8H23z" fill="#75F0B3"/>
+</svg>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,6 +173,7 @@ install host wiring when tokenjuice can own it directly:
 tokenjuice install codex
 tokenjuice install claude-code
 tokenjuice install codebuddy
+tokenjuice install augment
 tokenjuice install crush
 tokenjuice install cursor
 tokenjuice install grok-cli
@@ -187,6 +188,7 @@ tokenjuice install ruler
 tokenjuice doctor hooks
 tokenjuice doctor pi
 tokenjuice doctor opencode
+tokenjuice doctor augment
 tokenjuice doctor crush
 tokenjuice doctor grok-cli
 tokenjuice doctor goose
@@ -212,6 +214,7 @@ supported host hooks:
 | --- | --- | --- | --- |
 | Aider | `tokenjuice install aider` | `CONVENTIONS.tokenjuice.md` | ✴️ Beta. Installs a convention file that tells Aider to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Aider conventions do not intercept command output; load with `aider --read CONVENTIONS.tokenjuice.md`; see `docs/aider-integration.md` |
 | Amp | `tokenjuice install amp` | `AGENTS.md`, or existing `AGENT.md` / `CLAUDE.md` fallback | ✴️ Beta. Inserts marker-delimited instruction blocks inside the current git/project root that tell Amp to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Amp instruction files do not intercept command output; parent/user/system Amp instructions remain user-managed; see `docs/amp-integration.md` |
+| Augment | `tokenjuice install augment` | `.augment/rules/tokenjuice.md` | ✴️ Beta. Installs an `always_apply` workspace rule that tells Augment and Auggie to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Augment rules do not intercept tool output; see `docs/augment-integration.md` |
 | Avante.nvim | `tokenjuice install avante` | `avante.md` | ✴️ Beta. Inserts a marker-delimited instruction block that tells Avante to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Avante instructions do not intercept tool output; see `docs/avante-integration.md` |
 | Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Uses `PreToolUse` Bash input rewriting to route commands through `tokenjuice wrap` without bypassing Claude Code's own approval prompt; preserves unrelated hooks and migrates older Tokenjuice `PostToolUse` entries; `tokenjuice install claude-code --local` is available for repo-local verification |
 | Cline | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` | ✴️ Beta. Installs a global `PostToolUse` hook script for `execute_command`; enable it in Cline's Hooks tab after install; compacted context is injected through `contextModification`; `tokenjuice install cline --local` is available for repo-local verification; see `docs/cline-integration.md` |
@@ -241,7 +244,7 @@ supported host hooks:
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor open-interpreter`, `tokenjuice doctor openwebui`, `tokenjuice doctor plandex`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor open-interpreter`, `tokenjuice doctor openwebui`, `tokenjuice doctor plandex`, `tokenjuice doctor grok-cli`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amp`, `tokenjuice doctor augment`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Cursor, Droid, Gemini CLI, Grok CLI, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import { runWrappedCommand } from "../core/wrap.js";
 import type { WrapResult } from "../types.js";
 import { doctorAmpInstructions, installAmpInstructions, uninstallAmpInstructions } from "../hosts/amp/index.js";
 import { doctorAiderConvention, installAiderConvention, uninstallAiderConvention } from "../hosts/aider/index.js";
+import { doctorAugmentRule, installAugmentRule, uninstallAugmentRule } from "../hosts/augment/index.js";
 import { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "../hosts/avante/index.js";
 import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "../hosts/claude-code/index.js";
 import { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "../hosts/cline/index.js";
@@ -118,6 +119,7 @@ function printUsage(): void {
       "  tokenjuice <command> ... [--trace]",
       "  tokenjuice install aider",
       "  tokenjuice install amp",
+      "  tokenjuice install augment",
       "  tokenjuice install avante",
       "  tokenjuice install codex [--local]",
       "  tokenjuice install claude-code [--local]",
@@ -149,6 +151,7 @@ function printUsage(): void {
       "  tokenjuice install zed",
       "  tokenjuice uninstall aider",
       "  tokenjuice uninstall amp",
+      "  tokenjuice uninstall augment",
       "  tokenjuice uninstall avante",
       "  tokenjuice uninstall codex",
       "  tokenjuice uninstall cline",
@@ -178,7 +181,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amp|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amp|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-cli|junie|kiro|kilo|openhands|open-interpreter|openwebui|pi|opencode|plandex|qwen-code|roo|ruler|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -542,6 +545,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
       details.push({ label: "Updated paths", value: result.instructionsPaths.join(", ") });
     }
     process.stdout.write(formatInstallSuccess("amp", "instructions", details));
+    return 0;
+  }
+
+  if (target === "augment") {
+    const result = await installAugmentRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Rule", value: result.rulePath },
+      { label: "Beta", value: "rule-based guidance; Augment still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor augment" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("augment", "rule", details));
     return 0;
   }
 
@@ -1145,7 +1168,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, opencode, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amp, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, opencode, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1179,6 +1202,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
       }
     }
     process.stdout.write("enable: tokenjuice install amp\n");
+    return 0;
+  }
+
+  if (target === "augment") {
+    const result = await uninstallAugmentRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed augment rule: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`rule path: ${result.rulePath}\n`);
+    process.stdout.write("enable: tokenjuice install augment\n");
     return 0;
   }
 
@@ -1515,7 +1551,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amp, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, opencode, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amp, augment, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, opencode, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -1730,6 +1766,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     }
 
     process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "augment") {
+    const report = await doctorAugmentRule();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`rule path: ${report.rulePath}\n`);
     process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");

--- a/src/core/source.ts
+++ b/src/core/source.ts
@@ -40,6 +40,9 @@ export function normalizeArtifactSource(value: unknown): string | null {
   if (source.startsWith("goose")) {
     return "goose";
   }
+  if (source.startsWith("augment") || source.startsWith("auggie")) {
+    return "augment";
+  }
   if (source.startsWith("openclaw")) {
     return "openclaw";
   }

--- a/src/hosts/augment/index.ts
+++ b/src/hosts/augment/index.ts
@@ -1,0 +1,228 @@
+import { mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { buildTokenjuiceGuidanceBullets, TOKENJUICE_FULL_COMMAND, TOKENJUICE_RAW_COMMAND, TOKENJUICE_WRAP_COMMAND } from "../shared/instruction-guidance.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+
+export type AugmentRuleOptions = {
+  projectDir?: string;
+};
+
+export type InstallAugmentRuleResult = {
+  rulePath: string;
+  backupPath?: string;
+};
+
+export type UninstallAugmentRuleResult = {
+  rulePath: string;
+  removed: boolean;
+};
+
+export type AugmentDoctorReport = {
+  rulePath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_AUGMENT_FIX_COMMAND = "tokenjuice install augment";
+const TOKENJUICE_AUGMENT_OWNERSHIP_MARKER = "<!-- tokenjuice:augment-rule -->";
+const TOKENJUICE_AUGMENT_RULE_MARKER = "tokenjuice terminal output compaction";
+const TOKENJUICE_AUGMENT_ADVISORY = "Augment support is beta and rule-based; it guides command usage but does not intercept tool output.";
+const TOKENJUICE_AUGMENT_REINSTALL_BACKUP_SUFFIX = ".tokenjuice.bak";
+
+function getProjectDir(options: AugmentRuleOptions = {}): string {
+  return options.projectDir || process.env.AUGMENT_PROJECT_DIR || "";
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: AugmentRuleOptions = {}): Promise<string> {
+  const projectDir = getProjectDir(options);
+  if (projectDir) {
+    return resolve(projectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultRulePath(options: AugmentRuleOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), ".augment", "rules", "tokenjuice.md");
+}
+
+const TOKENJUICE_AUGMENT_RULE = [
+  "---",
+  "type: always_apply",
+  "---",
+  "",
+  TOKENJUICE_AUGMENT_OWNERSHIP_MARKER,
+  "",
+  `# ${TOKENJUICE_AUGMENT_RULE_MARKER}`,
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: `- When running terminal commands through Augment or Auggie, prefer \`${TOKENJUICE_WRAP_COMMAND}\` for commands likely to produce long output.`,
+  }),
+  "",
+].join("\n");
+
+function isTokenjuiceAugmentRuleText(text: string): boolean {
+  return text.includes(TOKENJUICE_AUGMENT_OWNERSHIP_MARKER);
+}
+
+async function writeAugmentRuleWithoutBackup(rulePath: string): Promise<void> {
+  await mkdir(dirname(rulePath), { recursive: true });
+  const tempPath = `${rulePath}.tmp`;
+  await writeFile(tempPath, TOKENJUICE_AUGMENT_RULE, "utf8");
+  await rename(tempPath, rulePath);
+}
+
+export async function installAugmentRule(
+  rulePath?: string,
+  options: AugmentRuleOptions = {},
+): Promise<InstallAugmentRuleResult> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (existing.exists && isTokenjuiceAugmentRuleText(existing.text)) {
+    if (existing.text === TOKENJUICE_AUGMENT_RULE) {
+      return { rulePath: resolvedRulePath };
+    }
+
+    const primaryBackupPath = `${resolvedRulePath}.bak`;
+    const primaryBackup = await readInstructionFile(primaryBackupPath);
+    const backupPath = primaryBackup.exists && !isTokenjuiceAugmentRuleText(primaryBackup.text)
+      ? `${resolvedRulePath}${TOKENJUICE_AUGMENT_REINSTALL_BACKUP_SUFFIX}`
+      : primaryBackupPath;
+    await writeFile(backupPath, existing.text, "utf8");
+    await writeAugmentRuleWithoutBackup(resolvedRulePath);
+    return { rulePath: resolvedRulePath, backupPath };
+  }
+
+  const result = await writeInstructionFile(resolvedRulePath, TOKENJUICE_AUGMENT_RULE);
+  return {
+    rulePath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallAugmentRule(
+  rulePath?: string,
+  options: AugmentRuleOptions = {},
+): Promise<UninstallAugmentRuleResult> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (existing.exists && !isTokenjuiceAugmentRuleText(existing.text)) {
+    throw new Error(
+      `refusing to remove ${resolvedRulePath}; it does not look like the tokenjuice Augment rule. Review and remove it manually, or reinstall tokenjuice augment first.`,
+    );
+  }
+
+  const backupPath = `${resolvedRulePath}.bak`;
+  const backup = await readInstructionFile(backupPath);
+  if (existing.exists && backup.exists && !isTokenjuiceAugmentRuleText(backup.text)) {
+    await rm(resolvedRulePath, { force: true });
+    await rename(backupPath, resolvedRulePath);
+    return { rulePath: resolvedRulePath, removed: true };
+  }
+
+  const result = await removeInstructionFile(resolvedRulePath);
+  return { rulePath: result.filePath, removed: result.removed };
+}
+
+export async function doctorAugmentRule(
+  rulePath?: string,
+  options: AugmentRuleOptions = {},
+): Promise<AugmentDoctorReport> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  if (!existing.exists) {
+    return {
+      rulePath: resolvedRulePath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Augment rule is not installed"],
+        advisory: TOKENJUICE_AUGMENT_ADVISORY,
+        fixCommand: TOKENJUICE_AUGMENT_FIX_COMMAND,
+      }),
+    };
+  }
+  if (!isTokenjuiceAugmentRuleText(existing.text)) {
+    return {
+      rulePath: resolvedRulePath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Augment rule is not installed; existing rule file is not tokenjuice-managed"],
+        advisory: TOKENJUICE_AUGMENT_ADVISORY,
+        fixCommand: TOKENJUICE_AUGMENT_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const issues = collectGuidanceIssues(existing.text, {
+    required: [
+      {
+        requiredText: "type: always_apply",
+        missingIssue: "configured Augment rule file is missing always_apply frontmatter",
+      },
+      {
+        requiredText: TOKENJUICE_AUGMENT_OWNERSHIP_MARKER,
+        missingIssue: "configured Augment rule file is missing the tokenjuice ownership marker",
+      },
+      {
+        requiredText: TOKENJUICE_AUGMENT_RULE_MARKER,
+        missingIssue: "configured Augment rule file does not look like the tokenjuice rule",
+      },
+      {
+        requiredText: TOKENJUICE_WRAP_COMMAND,
+        missingIssue: "configured Augment rule file is missing tokenjuice wrap guidance",
+      },
+      {
+        requiredText: TOKENJUICE_RAW_COMMAND,
+        missingIssue: "configured Augment rule file is missing the raw escape hatch",
+      },
+    ],
+    forbidden: [
+      {
+        forbiddenText: TOKENJUICE_FULL_COMMAND,
+        presentIssue: "configured Augment rule file still suggests the full escape hatch",
+      },
+    ],
+  });
+
+  return {
+    rulePath: resolvedRulePath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_AUGMENT_ADVISORY,
+      fixCommand: TOKENJUICE_AUGMENT_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -1,5 +1,6 @@
 import { doctorAiderConvention } from "../aider/index.js";
 import { doctorAmpInstructions } from "../amp/index.js";
+import { doctorAugmentRule } from "../augment/index.js";
 import { doctorAvanteInstructions } from "../avante/index.js";
 import { doctorClaudeCodeHook } from "../claude-code/index.js";
 import { doctorClineHook } from "../cline/index.js";
@@ -31,6 +32,7 @@ import { doctorZedInstructions } from "../zed/index.js";
 
 import type { AiderDoctorReport } from "../aider/index.js";
 import type { AmpDoctorReport, AmpInstructionsOptions } from "../amp/index.js";
+import type { AugmentDoctorReport, AugmentRuleOptions } from "../augment/index.js";
 import type { AvanteDoctorReport } from "../avante/index.js";
 import type { ClaudeCodeDoctorReport, ClaudeCodeHookCommandOptions } from "../claude-code/index.js";
 import type { ClineDoctorReport } from "../cline/index.js";
@@ -65,6 +67,7 @@ export type HookHealthStatus = "ok" | "warn" | "broken" | "disabled";
 export type HookIntegrationDoctorReport = {
   aider: AiderDoctorReport;
   amp: AmpDoctorReport;
+  augment: AugmentDoctorReport;
   avante: AvanteDoctorReport;
   codex: CodexDoctorReport;
   "copilot-agent": CopilotAgentDoctorReport;
@@ -100,7 +103,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmpInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QwenCodeHookCommandOptions & RulerRuleOptions;
+export type HookDoctorCommandOptions = AmpInstructionsOptions & AugmentRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokCliHookCommandOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QwenCodeHookCommandOptions & RulerRuleOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -114,6 +117,7 @@ type HookDoctorIntegrationDoctors = {
 const hookDoctorIntegrationDoctors = {
   aider: () => doctorAiderConvention(),
   amp: (options) => doctorAmpInstructions(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),
+  augment: (options) => doctorAugmentRule(undefined, getHookCommandOptions(options)),
   avante: () => doctorAvanteInstructions(),
   codex: (options) => doctorCodexHook(undefined, options),
   "claude-code": (options) => doctorClaudeCodeHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts
 export { classifyExecution } from "./core/classify.js";
 export { normalizeCommandSignature, normalizeEffectiveCommandSignature, normalizeExecutionInput, tokenizeCommand } from "./core/command.js";
 export { doctorAmpInstructions, installAmpInstructions, uninstallAmpInstructions } from "./hosts/amp/index.js";
+export { doctorAugmentRule, installAugmentRule, uninstallAugmentRule } from "./hosts/augment/index.js";
 export { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "./hosts/avante/index.js";
 export { doctorAiderConvention, installAiderConvention, uninstallAiderConvention } from "./hosts/aider/index.js";
 export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "./hosts/claude-code/index.js";
@@ -96,6 +97,12 @@ export type {
   InstallAmpInstructionsResult,
   UninstallAmpInstructionsResult,
 } from "./hosts/amp/index.js";
+export type {
+  AugmentDoctorReport,
+  AugmentRuleOptions,
+  InstallAugmentRuleResult,
+  UninstallAugmentRuleResult,
+} from "./hosts/augment/index.js";
 export type {
   AiderConventionOptions,
   AiderDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amp, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amp, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-cli, junie, kiro, kilo, openhands, open-interpreter, openwebui, pi, plandex, qwen-code, roo, ruler, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/augment.test.ts
+++ b/test/hosts/augment.test.ts
@@ -1,0 +1,321 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { doctorAugmentRule, doctorInstalledHooks, installAugmentRule, uninstallAugmentRule } from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CRUSH_PROJECT_DIR",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GOOSE_PROJECT_DIR",
+  "GROK_HOME",
+  "HOME",
+  "JUNIE_PROJECT_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "OPENWEBUI_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-augment-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("augment rules", () => {
+  it("installs an always-applied workspace rule", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+
+    const result = await installAugmentRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.rulePath).toBe(rulePath);
+    expect(result.backupPath).toBeUndefined();
+    expect(rule).toContain("type: always_apply");
+    expect(rule).toContain("<!-- tokenjuice:augment-rule -->");
+    expect(rule).toContain("tokenjuice terminal output compaction");
+    expect(rule).toContain("terminal commands through Augment or Auggie");
+    expect(rule).toContain("tokenjuice wrap -- <command>");
+    expect(rule).toContain("tokenjuice wrap --raw -- <command>");
+    expect(rule).not.toContain("wrap --full");
+  });
+
+  it("backs up an existing rule file before replacing it", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await installAugmentRule(rulePath);
+    await writeFile(rulePath, "# local Augment rule\n\n- keep this\n", "utf8");
+
+    const result = await installAugmentRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.backupPath).toBe(`${rulePath}.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("keep this");
+    expect(rule).toContain("tokenjuice terminal output compaction");
+    expect(rule).not.toContain("keep this");
+  });
+
+  it("restores a backed-up custom rule on uninstall", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom local rule\n", "utf8");
+    await installAugmentRule(rulePath);
+
+    const removed = await uninstallAugmentRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(rulePath, "utf8")).resolves.toBe("# custom local rule\n");
+    await expect(access(`${rulePath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a custom backup when repairing tokenjuice-owned rules", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom local rule\n", "utf8");
+    await installAugmentRule(rulePath);
+    await writeFile(
+      rulePath,
+      [
+        "---",
+        "type: agent_requested",
+        "---",
+        "",
+        "<!-- tokenjuice:augment-rule -->",
+        "",
+        "# tokenjuice terminal output compaction",
+        "",
+        "- Prefer `tokenjuice wrap -- <command>`.",
+        "- If output looks wrong, rerun with `tokenjuice wrap --full -- <command>`.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const repaired = await installAugmentRule(rulePath);
+
+    expect(repaired.backupPath).toBe(`${rulePath}.tokenjuice.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toBe("# custom local rule\n");
+    await expect(readFile(`${rulePath}.tokenjuice.bak`, "utf8")).resolves.toContain("wrap --full");
+  });
+
+  it("reports installed and uninstalled rule health", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+
+    await installAugmentRule(rulePath);
+    const installed = await doctorAugmentRule(rulePath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("rule-based");
+
+    const removed = await uninstallAugmentRule(rulePath);
+    const disabled = await doctorAugmentRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken rules missing tokenjuice guidance", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "---",
+        "type: agent_requested",
+        "---",
+        "",
+        "<!-- tokenjuice:augment-rule -->",
+        "",
+        "# tokenjuice terminal output compaction",
+        "",
+        "- Prefer `tokenjuice wrap -- <command>`.",
+        "- If output looks wrong, rerun with `tokenjuice wrap --full -- <command>`.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorAugmentRule(rulePath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Augment rule file is missing always_apply frontmatter");
+    expect(doctor.issues).toContain("configured Augment rule file is missing the raw escape hatch");
+    expect(doctor.issues).toContain("configured Augment rule file still suggests the full escape hatch");
+  });
+
+  it("treats unowned rule files as disabled", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom local rule\n", "utf8");
+
+    const doctor = await doctorAugmentRule(rulePath);
+
+    expect(doctor.status).toBe("disabled");
+    expect(doctor.issues).toContain("tokenjuice Augment rule is not installed; existing rule file is not tokenjuice-managed");
+  });
+
+  it("refuses to remove a non-tokenjuice rule file", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom local rule\n", "utf8");
+
+    await expect(uninstallAugmentRule(rulePath)).rejects.toThrow(
+      "does not look like the tokenjuice Augment rule",
+    );
+
+    await expect(readFile(rulePath, "utf8")).resolves.toBe("# custom local rule\n");
+  });
+
+  it("does not claim custom rules that mention tokenjuice commands", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom note\n\n- use tokenjuice wrap -- <command>\n", "utf8");
+
+    const doctor = await doctorAugmentRule(rulePath);
+
+    expect(doctor.status).toBe("disabled");
+    await expect(uninstallAugmentRule(rulePath)).rejects.toThrow(
+      "does not look like the tokenjuice Augment rule",
+    );
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("custom note");
+  });
+
+  it("does not claim custom rules that use the tokenjuice heading", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".augment", "rules"), { recursive: true });
+    await writeFile(rulePath, "# tokenjuice terminal output compaction\n\n- custom rule\n", "utf8");
+
+    const doctor = await doctorAugmentRule(rulePath);
+
+    expect(doctor.status).toBe("disabled");
+    await expect(uninstallAugmentRule(rulePath)).rejects.toThrow(
+      "does not look like the tokenjuice Augment rule",
+    );
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("custom rule");
+  });
+
+  it("uses AUGMENT_PROJECT_DIR for the default rule file", async () => {
+    const home = await createTempDir();
+    process.env.AUGMENT_PROJECT_DIR = home;
+
+    const installed = await installAugmentRule();
+    const expectedRulePath = join(home, ".augment", "rules", "tokenjuice.md");
+    const doctor = await doctorAugmentRule();
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(doctor.rulePath).toBe(expectedRulePath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("passes projectDir through aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    const configHome = join(home, "home");
+    await mkdir(configHome, { recursive: true });
+    process.env.HOME = configHome;
+    process.env.FACTORY_HOME = join(configHome, ".factory");
+    process.env.CODEX_HOME = join(configHome, ".codex");
+    process.env.CLAUDE_CONFIG_DIR = join(configHome, ".claude");
+    process.env.CODEBUDDY_CONFIG_DIR = join(configHome, ".codebuddy");
+    process.env.CURSOR_HOME = join(configHome, ".cursor");
+    process.env.GEMINI_HOME = join(configHome, ".gemini");
+    process.env.GROK_HOME = join(configHome, ".grok");
+    process.env.COPILOT_HOME = join(configHome, ".copilot");
+    process.env.PI_CODING_AGENT_DIR = join(configHome, ".pi", "agent");
+    process.env.OPENCODE_CONFIG_DIR = join(configHome, ".config", "opencode");
+    process.env.CLINE_HOOKS_DIR = join(configHome, "Cline", "Hooks");
+    await installAugmentRule(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.augment.status).toBe("ok");
+    expect(report.integrations.augment.rulePath).toBe(join(home, ".augment", "rules", "tokenjuice.md"));
+  });
+
+  it("uses the nearest git root for the default rule file", async () => {
+    const repo = await createTempDir();
+    const nestedDir = join(repo, "src", "nested");
+    await mkdir(join(repo, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installAugmentRule();
+    const expectedRulePath = join(await realpath(repo), ".augment", "rules", "tokenjuice.md");
+    const doctor = await doctorAugmentRule();
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(doctor.rulePath).toBe(expectedRulePath);
+    expect(doctor.status).toBe("ok");
+    await expect(access(join(nestedDir, ".augment", "rules", "tokenjuice.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes the default rule file when uninstalling", async () => {
+    const home = await createTempDir();
+    process.env.AUGMENT_PROJECT_DIR = home;
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+
+    await installAugmentRule();
+    await uninstallAugmentRule();
+
+    await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("uses projectDir when uninstalling the default rule file", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".augment", "rules", "tokenjuice.md");
+
+    await installAugmentRule(undefined, { projectDir: home });
+    const removed = await uninstallAugmentRule(undefined, { projectDir: home });
+
+    expect(removed.rulePath).toBe(rulePath);
+    expect(removed.removed).toBe(true);
+    await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary
- add an Augment/Auggie `.augment/rules/tokenjuice.md` always-apply rule integration
- resolve the default rule file at the git/project root, while honoring `AUGMENT_PROJECT_DIR` and `projectDir`
- add a unique tokenjuice ownership marker so custom rules with similar prose are not claimed
- distinguish generated, stale tokenjuice-owned, and custom rule files so doctor/uninstall are safe
- restore backed-up custom rules on uninstall and preserve custom `.bak` files during reinstall/repair
- wire `tokenjuice install augment`, `uninstall augment`, `doctor augment`, aggregate doctor output, source normalization, exports, README, and spec/docs

## Validation
- `pnpm exec vitest run test/hosts/augment.test.ts test/hosts/plandex.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `git diff --check`
- `pnpm build`
- isolated built CLI smoke: `install augment`, `doctor augment`, aggregate `doctor hooks`, `uninstall augment`
- isolated built CLI smoke: custom rule files are treated as disabled and refused on uninstall
- isolated built CLI smoke: stale tokenjuice-owned rules are repairable/removable
- isolated built CLI smoke: uninstall restores a custom `.bak`, and reinstall repair preserves the user backup
- privacy scan over `git diff origin/main...HEAD` for private paths, private IPs, and smoke temp names
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main ...` clean after fixing accepted findings
