### PR TITLE
feat(devin): add pre-tool hook integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add a beta Amazon Q Developer CLI workspace-rule integration.
+- Add a beta Devin for Terminal PreToolUse hook integration.
 - Add a beta Kimi Code CLI PostToolUse hook integration.
 - Add a beta Mistral Vibe instruction integration.
 - Add a beta Trae project-rule integration.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ beta integrations:
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-crush.svg" alt="Crush" /> | [Crush](https://github.com/charmbracelet/crush) | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` |
+| <img width="48px" src="docs/client-devin.svg" alt="Devin" /> | [Devin for Terminal](https://cli.devin.ai/docs/extensibility/hooks/overview) | `tokenjuice install devin` | `.devin/hooks.v1.json` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
 | <img width="48px" src="docs/client-goose.svg" alt="Goose" /> | [Goose](https://goose-docs.ai/) | `tokenjuice install goose` | `.goosehints` |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" /> | [Grok Build](https://docs.x.ai/build/overview) | `tokenjuice install grok-build` | `AGENTS.md` |
@@ -80,8 +81,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|codex|cline|continue|copilot-agent|crush|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -103,9 +104,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|codex|cline|continue|copilot-agent|crush|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|codex|cline|continue|copilot-agent|crush|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -169,6 +170,7 @@ direct payload:
 - [Crush integration](docs/crush-integration.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)
+- [Devin integration](docs/devin-integration.md)
 - [Goose integration](docs/goose-integration.md)
 - [Grok Build integration](docs/grok-build-integration.md)
 - [Grok CLI integration](docs/grok-cli-integration.md)

--- a/docs/client-devin.svg
+++ b/docs/client-devin.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Devin</title>
+  <desc id="desc">Stylized Devin terminal hook icon</desc>
+  <rect width="64" height="64" rx="12" fill="#e0f2fe"/>
+  <path d="M14 18h36v28H14z" fill="#ffffff" stroke="#0f172a" stroke-width="3"/>
+  <path d="M21 27l7 5-7 5" fill="none" stroke="#2563eb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M33 38h12" stroke="#0f172a" stroke-width="4" stroke-linecap="round"/>
+  <path d="M44 14l6 6-6 6" fill="none" stroke="#0f172a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/devin-integration.md
+++ b/docs/devin-integration.md
@@ -1,0 +1,41 @@
+# Devin for Terminal integration
+
+`tokenjuice install devin` installs a project-local Devin hook in
+`.devin/hooks.v1.json`. Devin documents this standalone file as the
+recommended project hook location and uses Claude-compatible hook events.
+
+```bash
+tokenjuice install devin
+tokenjuice doctor devin
+tokenjuice uninstall devin
+```
+
+The hook targets Devin's `exec` tool with `PreToolUse`. Before Devin runs a
+shell command, tokenjuice rewrites the command to:
+
+```bash
+tokenjuice wrap --source devin -- <shell> -lc '<command>'
+```
+
+That keeps Devin's native execution and approval flow in place while routing
+long terminal output through tokenjuice compaction. Use:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+when exact output bytes are required.
+
+Pure session setup commands are not rewritten. Commands such as `cd`,
+`export`, `source .venv/bin/activate`, `nvm use`, and shell option changes
+must run in Devin's existing terminal session so their state survives for the
+next command.
+
+By default tokenjuice writes to `.devin/hooks.v1.json` in the current
+workspace. Set `DEVIN_PROJECT_DIR=/path/to/workspace` to target a specific
+workspace from scripts. `tokenjuice install devin --local` points the hook at
+the current repo build, which is useful for release verification.
+
+`doctor devin` reports `ok` when the hook is installed, points at the expected
+launcher command, and all absolute command paths exist. Stale Homebrew Cellar
+paths and missing launchers are reported as repairable issues.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -178,6 +178,7 @@ tokenjuice install antigravity
 tokenjuice install augment
 tokenjuice install crush
 tokenjuice install cursor
+tokenjuice install devin
 tokenjuice install grok-build
 tokenjuice install grok-cli
 tokenjuice install goose
@@ -199,6 +200,7 @@ tokenjuice doctor amazon-q
 tokenjuice doctor antigravity
 tokenjuice doctor augment
 tokenjuice doctor crush
+tokenjuice doctor devin
 tokenjuice doctor grok-build
 tokenjuice doctor grok-cli
 tokenjuice doctor goose
@@ -215,6 +217,7 @@ tokenjuice install codex --local
 tokenjuice install claude-code --local
 tokenjuice install codebuddy --local
 tokenjuice install cursor --local
+tokenjuice install devin --local
 tokenjuice install grok-cli --local
 tokenjuice install pi --local
 tokenjuice install opencode --local
@@ -239,6 +242,7 @@ supported host hooks:
 | Continue | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` | ✴️ Beta. Installs a workspace rule that tells Continue agents to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Continue rules do not intercept tool output; see `docs/continue-integration.md` |
 | Crush | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` | ✴️ Beta. Installs a project Agent Skill that tells Crush to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Crush hook composition and stateful shell behavior make command rewriting unsafe; see `docs/crush-integration.md` |
 | Cursor (Linux/macOS/WSL) | `tokenjuice install cursor` | `~/.cursor/hooks.json` | Uses `preToolUse` shell input rewriting to route commands through `tokenjuice wrap`; `tokenjuice install cursor --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/cursor-integration.md` |
+| Devin for Terminal | `tokenjuice install devin` | `.devin/hooks.v1.json` | ✴️ Beta. Uses project-local Claude-compatible `PreToolUse` exec input rewriting to route commands through `tokenjuice wrap`; preserves unrelated Devin hooks; `tokenjuice install devin --local` is available for repo-local verification; see `docs/devin-integration.md` |
 | Droid (Factory CLI) | `tokenjuice install droid` | `~/.factory/settings.json` | Uses a `PostToolUse` hook for the `Execute` tool to compact shell output before Droid sees it; preserves unrelated settings keys; `tokenjuice install droid --local` is available for repo-local verification |
 | Gemini CLI | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` | ✴️ Beta. Uses an `AfterTool` hook for `run_shell_command` to compact shell output before Gemini CLI sees it; `tokenjuice install gemini-cli --local` is available for repo-local verification; see `docs/gemini-cli-integration.md` |
 | Goose | `tokenjuice install goose` | `.goosehints` | ✴️ Beta. Inserts a marker-delimited hints block that tells Goose to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Goose hints do not intercept tool output; restart the Goose session after install; see `docs/goose-integration.md` |
@@ -266,7 +270,7 @@ supported host hooks:
 | Windsurf | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Cascade to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Cascade Hooks do not replace terminal command output; see `docs/windsurf-integration.md` |
 | Zed | `tokenjuice install zed` | `.rules` | ✴️ Beta. Inserts a marker-delimited rule block that tells Zed Agent to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Zed rules do not intercept tool output; see `docs/zed-integration.md` |
 
-`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor open-interpreter`, `tokenjuice doctor openwebui`, `tokenjuice doctor mistral-vibe`, `tokenjuice doctor plandex`, `tokenjuice doctor qoder`, `tokenjuice doctor trae`, `tokenjuice doctor grok-build`, `tokenjuice doctor grok-cli`, `tokenjuice doctor kimi`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amazon-q`, `tokenjuice doctor amp`, `tokenjuice doctor antigravity`, `tokenjuice doctor augment`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Crush, Cursor, Droid, Gemini CLI, Grok CLI, Kimi, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
+`tokenjuice doctor hooks` inspects installed host hooks together, including the Pi extension, spots stale Cellar-pinned Homebrew commands, and points back to the right install command for repair. `tokenjuice doctor droid`, `tokenjuice doctor pi`, `tokenjuice doctor opencode`, `tokenjuice doctor openhands`, `tokenjuice doctor open-interpreter`, `tokenjuice doctor openwebui`, `tokenjuice doctor mistral-vibe`, `tokenjuice doctor plandex`, `tokenjuice doctor qoder`, `tokenjuice doctor trae`, `tokenjuice doctor grok-build`, `tokenjuice doctor grok-cli`, `tokenjuice doctor kimi`, `tokenjuice doctor qwen-code`, `tokenjuice doctor continue`, `tokenjuice doctor aider`, `tokenjuice doctor amazon-q`, `tokenjuice doctor amp`, `tokenjuice doctor antigravity`, `tokenjuice doctor augment`, `tokenjuice doctor avante`, `tokenjuice doctor junie`, `tokenjuice doctor kiro`, `tokenjuice doctor kilo`, `tokenjuice doctor roo`, `tokenjuice doctor ruler`, `tokenjuice doctor goose`, `tokenjuice doctor windsurf`, `tokenjuice doctor zed`, `tokenjuice doctor cline`, `tokenjuice doctor crush`, `tokenjuice doctor devin`, `tokenjuice doctor vscode-copilot`, and `tokenjuice doctor copilot-cli` are the direct per-host checks. the `--local` variant expects Codex, Claude Code, Cline, CodeBuddy, Crush, Cursor, Devin, Droid, Gemini CLI, Grok CLI, Kimi, OpenHands, Qwen Code, VS Code Copilot, and Copilot CLI hooks to point at the current repo build instead of the installed launcher on `PATH`.
 
 `tokenjuice uninstall codex` removes the tokenjuice Codex PostToolUse hook from `~/.codex/hooks.json`. once removed, `tokenjuice doctor codex` and `tokenjuice doctor hooks` report that state as `disabled` instead of treating it like a broken install. `tokenjuice uninstall opencode` removes the OpenCode plugin from `~/.config/opencode/plugins/tokenjuice.js`.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -35,6 +35,7 @@ import {
 } from "../hosts/copilot-cli/index.js";
 import { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "../hosts/crush/index.js";
 import { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "../hosts/cursor/index.js";
+import { doctorDevinHook, installDevinHook, runDevinPreToolUseHook, uninstallDevinHook } from "../hosts/devin/index.js";
 import { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "../hosts/droid/index.js";
 import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "../hosts/gemini-cli/index.js";
 import { doctorGooseHints, installGooseHints, uninstallGooseHints } from "../hosts/goose/index.js";
@@ -138,6 +139,7 @@ function printUsage(): void {
       "  tokenjuice install copilot-agent [--local]",
       "  tokenjuice install crush",
       "  tokenjuice install cursor [--local]",
+      "  tokenjuice install devin [--local]",
       "  tokenjuice install droid [--local]",
       "  tokenjuice install gemini-cli [--local]",
       "  tokenjuice install goose",
@@ -174,6 +176,7 @@ function printUsage(): void {
       "  tokenjuice uninstall continue",
       "  tokenjuice uninstall copilot-agent",
       "  tokenjuice uninstall crush",
+      "  tokenjuice uninstall devin",
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall gemini-cli",
       "  tokenjuice uninstall goose",
@@ -202,7 +205,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|gemini-cli|goose|grok-build|grok-cli|junie|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|roo|ruler|trae|vscode-copilot|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -815,6 +818,27 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "devin") {
+    const result = await installDevinHook(undefined, { local: args.local });
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Hook", value: result.hooksPath },
+      { label: "Command", value: result.command },
+      { label: "Beta", value: "project-local PreToolUse hook rewrites exec commands before Devin runs them" },
+      { label: "Verify", value: `tokenjuice doctor devin${args.local ? " --local" : ""}` },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("devin", "hook", details));
+    return 0;
+  }
+
   if (target === "gemini-cli") {
     const result = await installGeminiCliHook(undefined, { local: args.local });
     if (args.format === "json") {
@@ -1331,7 +1355,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1779,6 +1803,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "devin") {
+    const result = await uninstallDevinHook();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed devin entries: ${result.removed}\n`);
+    process.stdout.write(`hooks path: ${result.hooksPath}${result.deletedFile ? " (file deleted)" : ""}\n`);
+    process.stdout.write("enable: tokenjuice install devin\n");
+    return 0;
+  }
+
   if (target === "droid") {
     const result = await uninstallDroidHook();
     if (args.format === "json") {
@@ -1805,7 +1842,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, codex, cline, continue, copilot-agent, crush, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, codex, cline, continue, copilot-agent, crush, devin, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -2384,6 +2421,42 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("issues:\n");
       for (const issue of report.issues) {
         process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "devin") {
+    const report = await doctorDevinHook(undefined, { local: args.local });
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`hooks path: ${report.hooksPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    process.stdout.write(`expected command: ${report.expectedCommand}\n`);
+    if (report.detectedCommand) {
+      process.stdout.write(`configured command: ${report.detectedCommand}\n`);
+    }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
       }
     }
     if (report.missingPaths.length > 0) {
@@ -3332,6 +3405,8 @@ async function main(): Promise<number> {
       return await runCodeBuddyPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "cursor-pre-tool-use":
       return await runCursorPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
+    case "devin-pre-tool-use":
+      return await runDevinPreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "gemini-cli-after-tool":
       return await runGeminiCliAfterToolHook(await readStdin(args.maxInputBytes));
     case "grok-cli-post-tool-use":

--- a/src/hosts/devin/index.ts
+++ b/src/hosts/devin/index.ts
@@ -1,0 +1,385 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { isSetupWrapperSegment, splitTopLevelCommandChain, tokenizeCommand } from "../../core/command.js";
+import { extractHookCommandPaths } from "../shared/hook-command.js";
+import {
+  buildWrapLauncherHookCommand,
+  buildWrappedCommand,
+  commandAlreadyWrapped,
+  isExecutableFile,
+  isRecord,
+  pathExists,
+  resolveHostShell,
+} from "../shared/pre-tool-wrap.js";
+
+type DevinHooksConfig = Record<string, unknown>;
+
+type DevinPreToolUsePayload = {
+  hook_event_name?: unknown;
+  tool_name?: unknown;
+  tool_input?: unknown;
+};
+
+type DevinExecToolInput = {
+  command?: unknown;
+  shell?: unknown;
+} & Record<string, unknown>;
+
+export type DevinHookCommandOptions = {
+  local?: boolean;
+  binaryPath?: string;
+  nodePath?: string;
+  projectDir?: string;
+};
+
+export type InstallDevinHookResult = {
+  hooksPath: string;
+  backupPath?: string;
+  command: string;
+};
+
+export type UninstallDevinHookResult = {
+  hooksPath: string;
+  removed: number;
+  deletedFile: boolean;
+};
+
+export type DevinDoctorReport = {
+  hooksPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  expectedCommand: string;
+  detectedCommand?: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_DEVIN_SUBCOMMAND = "devin-pre-tool-use";
+const TOKENJUICE_DEVIN_FIX_COMMAND = "tokenjuice install devin";
+const TOKENJUICE_DEVIN_MATCHER = "exec";
+const TOKENJUICE_DEVIN_HOOK_TIMEOUT_SECONDS = 10;
+const TOKENJUICE_DEVIN_ADVISORY = "Devin support uses Claude-compatible PreToolUse exec input rewriting to route shell commands through tokenjuice wrap.";
+
+function getProjectDir(options: DevinHookCommandOptions = {}): string {
+  return resolve(options.projectDir || process.env.DEVIN_PROJECT_DIR || process.cwd());
+}
+
+function getDefaultHooksPath(options: DevinHookCommandOptions = {}): string {
+  return join(getProjectDir(options), ".devin", "hooks.v1.json");
+}
+
+async function buildDevinHookCommand(options: DevinHookCommandOptions = {}): Promise<string> {
+  return buildWrapLauncherHookCommand({
+    ...options,
+    subcommand: TOKENJUICE_DEVIN_SUBCOMMAND,
+    hostName: "devin",
+  });
+}
+
+function getDevinFixCommand(local = false): string {
+  return local ? `${TOKENJUICE_DEVIN_FIX_COMMAND} --local` : TOKENJUICE_DEVIN_FIX_COMMAND;
+}
+
+function sanitizeDevinHooksConfig(raw: unknown): DevinHooksConfig {
+  return isRecord(raw) ? { ...raw } : {};
+}
+
+async function readDevinHooksConfig(hooksPath: string): Promise<{ config: DevinHooksConfig; exists: boolean }> {
+  try {
+    const rawText = await readFile(hooksPath, "utf8");
+    return { config: sanitizeDevinHooksConfig(JSON.parse(rawText) as unknown), exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: {}, exists: false };
+    }
+    throw new Error(`failed to read Devin hooks from ${hooksPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function loadDevinHooksConfigWithBackup(hooksPath: string): Promise<{ config: DevinHooksConfig; backupPath?: string }> {
+  try {
+    const rawText = await readFile(hooksPath, "utf8");
+    const backupPath = `${hooksPath}.bak`;
+    await writeFile(backupPath, rawText, "utf8");
+    return { config: sanitizeDevinHooksConfig(JSON.parse(rawText) as unknown), backupPath };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { config: {} };
+    }
+    throw new Error(`failed to load Devin hooks from ${hooksPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function writeDevinHooksConfig(hooksPath: string, config: DevinHooksConfig): Promise<void> {
+  await mkdir(dirname(hooksPath), { recursive: true });
+  const tempPath = `${hooksPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await rename(tempPath, hooksPath);
+}
+
+function isTokenjuiceDevinHookEntry(hook: unknown): boolean {
+  return isRecord(hook)
+    && typeof hook.command === "string"
+    && hook.command.includes(TOKENJUICE_DEVIN_SUBCOMMAND);
+}
+
+function getPreToolUseGroups(config: DevinHooksConfig): unknown[] {
+  const preToolUse = config.PreToolUse;
+  return Array.isArray(preToolUse) ? preToolUse : [];
+}
+
+function findTokenjuiceDevinHookCommand(config: DevinHooksConfig): string | undefined {
+  for (const group of getPreToolUseGroups(config)) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      continue;
+    }
+    const hook = group.hooks.find(isTokenjuiceDevinHookEntry);
+    if (isRecord(hook) && typeof hook.command === "string") {
+      return hook.command;
+    }
+  }
+  return undefined;
+}
+
+function removeTokenjuiceDevinHooks(config: DevinHooksConfig): number {
+  const preToolUse = getPreToolUseGroups(config);
+  const retainedGroups: unknown[] = [];
+  let removed = 0;
+
+  for (const group of preToolUse) {
+    if (!isRecord(group) || !Array.isArray(group.hooks)) {
+      retainedGroups.push(group);
+      continue;
+    }
+
+    const retainedHooks = group.hooks.filter((hook) => !isTokenjuiceDevinHookEntry(hook));
+    removed += group.hooks.length - retainedHooks.length;
+    if (retainedHooks.length > 0) {
+      retainedGroups.push({ ...group, hooks: retainedHooks });
+    }
+  }
+
+  if (retainedGroups.length === 0) {
+    delete config.PreToolUse;
+  } else {
+    config.PreToolUse = retainedGroups;
+  }
+  return removed;
+}
+
+function createTokenjuiceDevinHook(command: string): Record<string, unknown> {
+  return {
+    matcher: TOKENJUICE_DEVIN_MATCHER,
+    hooks: [
+      {
+        type: "command",
+        command,
+        timeout: TOKENJUICE_DEVIN_HOOK_TIMEOUT_SECONDS,
+      },
+    ],
+  };
+}
+
+function configIsEmpty(config: DevinHooksConfig): boolean {
+  return Object.keys(config).length === 0;
+}
+
+async function resolveDevinHostShell(toolInput: DevinExecToolInput): Promise<string | undefined> {
+  return resolveHostShell([
+    typeof toolInput.shell === "string" ? toolInput.shell : undefined,
+    process.env.TOKENJUICE_DEVIN_SHELL,
+    process.env.SHELL,
+    "bash",
+    "sh",
+  ]);
+}
+
+function isDevinStatefulShellSegment(argv: string[], command: string): boolean {
+  const commandName = argv[0]?.split(/[\\/]/u).pop();
+  if (!commandName) {
+    return true;
+  }
+  if (isSetupWrapperSegment(argv, command)) {
+    return true;
+  }
+
+  if (commandName === "nvm" && argv[1] === "use") {
+    return true;
+  }
+  if (
+    (commandName === "conda" || commandName === "micromamba" || commandName === "mamba")
+    && (argv[1] === "activate" || argv[1] === "deactivate")
+  ) {
+    return true;
+  }
+  if (
+    (commandName === "pyenv" || commandName === "rbenv" || commandName === "asdf")
+    && argv[1] === "shell"
+  ) {
+    return true;
+  }
+  if (
+    commandName === "shopt"
+    || commandName === "alias"
+    || commandName === "unalias"
+    || commandName === "ulimit"
+    || commandName === "umask"
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function commandOnlyMutatesDevinShellState(command: string): boolean {
+  const segments = splitTopLevelCommandChain(command);
+  return segments.length > 0
+    && segments.every((segment) => isDevinStatefulShellSegment(tokenizeCommand(segment), segment));
+}
+
+export async function installDevinHook(
+  hooksPath?: string,
+  options: DevinHookCommandOptions = {},
+): Promise<InstallDevinHookResult> {
+  const resolvedHooksPath = hooksPath ?? getDefaultHooksPath(options);
+  const { config, backupPath } = await loadDevinHooksConfigWithBackup(resolvedHooksPath);
+  const command = await buildDevinHookCommand(options);
+  removeTokenjuiceDevinHooks(config);
+  config.PreToolUse = [...getPreToolUseGroups(config), createTokenjuiceDevinHook(command)];
+
+  await writeDevinHooksConfig(resolvedHooksPath, config);
+  return {
+    hooksPath: resolvedHooksPath,
+    ...(backupPath ? { backupPath } : {}),
+    command,
+  };
+}
+
+export async function uninstallDevinHook(
+  hooksPath?: string,
+  options: DevinHookCommandOptions = {},
+): Promise<UninstallDevinHookResult> {
+  const resolvedHooksPath = hooksPath ?? getDefaultHooksPath(options);
+  const { config, exists: configExists } = await readDevinHooksConfig(resolvedHooksPath);
+  if (!configExists) {
+    return { hooksPath: resolvedHooksPath, removed: 0, deletedFile: false };
+  }
+
+  const removed = removeTokenjuiceDevinHooks(config);
+  if (removed === 0) {
+    return { hooksPath: resolvedHooksPath, removed: 0, deletedFile: false };
+  }
+
+  if (configIsEmpty(config)) {
+    await rm(resolvedHooksPath, { force: true });
+    return { hooksPath: resolvedHooksPath, removed, deletedFile: true };
+  }
+
+  await writeDevinHooksConfig(resolvedHooksPath, config);
+  return { hooksPath: resolvedHooksPath, removed, deletedFile: false };
+}
+
+export async function doctorDevinHook(
+  hooksPath?: string,
+  options: DevinHookCommandOptions = {},
+): Promise<DevinDoctorReport> {
+  const resolvedHooksPath = hooksPath ?? getDefaultHooksPath(options);
+  const expectedCommand = await buildDevinHookCommand(options);
+  const { config, exists: configExists } = await readDevinHooksConfig(resolvedHooksPath);
+  const detectedCommand = findTokenjuiceDevinHookCommand(config);
+  const fixCommand = getDevinFixCommand(options.local);
+
+  if (!configExists || !detectedCommand) {
+    return {
+      hooksPath: resolvedHooksPath,
+      status: "disabled",
+      issues: [],
+      advisories: [TOKENJUICE_DEVIN_ADVISORY],
+      fixCommand,
+      expectedCommand,
+      checkedPaths: [],
+      missingPaths: [],
+    };
+  }
+
+  const checkedPaths = extractHookCommandPaths(detectedCommand);
+  const missingPaths: string[] = [];
+  for (const path of checkedPaths) {
+    if (!(await isExecutableFile(path)) && !(path.endsWith(".js") && await pathExists(path))) {
+      missingPaths.push(path);
+    }
+  }
+
+  const issues: string[] = [];
+  if (detectedCommand !== expectedCommand) {
+    if (detectedCommand.includes("/Cellar/")) {
+      issues.push("configured Devin hook is pinned to a versioned Homebrew Cellar path");
+    } else {
+      issues.push("configured Devin hook command does not match the current recommended command");
+    }
+  }
+  if (missingPaths.length > 0) {
+    issues.push(`configured Devin hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
+  }
+
+  return {
+    hooksPath: resolvedHooksPath,
+    status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
+    issues,
+    advisories: [TOKENJUICE_DEVIN_ADVISORY],
+    fixCommand,
+    expectedCommand,
+    detectedCommand,
+    checkedPaths,
+    missingPaths,
+  };
+}
+
+export async function runDevinPreToolUseHook(rawText: string, wrapLauncher = "tokenjuice"): Promise<number> {
+  let payload: DevinPreToolUsePayload;
+  try {
+    payload = JSON.parse(rawText) as DevinPreToolUsePayload;
+  } catch {
+    return 0;
+  }
+
+  if (payload.hook_event_name !== "PreToolUse") {
+    return 0;
+  }
+  if (payload.tool_name !== "exec" || !isRecord(payload.tool_input)) {
+    return 0;
+  }
+
+  const toolInput = payload.tool_input as DevinExecToolInput;
+  const command = typeof toolInput.command === "string" ? toolInput.command : undefined;
+  if (!command || !command.trim()) {
+    return 0;
+  }
+  if (commandAlreadyWrapped(command)) {
+    return 0;
+  }
+  if (commandOnlyMutatesDevinShellState(command)) {
+    return 0;
+  }
+
+  const shellPath = await resolveDevinHostShell(toolInput);
+  if (!shellPath) {
+    return 0;
+  }
+
+  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "devin" });
+  const response = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: {
+        ...toolInput,
+        command: wrappedCommand,
+      },
+    },
+  };
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+  return 0;
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -13,6 +13,7 @@ import { doctorCopilotAgentHook } from "../copilot-agent/index.js";
 import { doctorCopilotCliHook } from "../copilot-cli/index.js";
 import { doctorCrushSkill } from "../crush/index.js";
 import { doctorCursorHook } from "../cursor/index.js";
+import { doctorDevinHook } from "../devin/index.js";
 import { doctorDroidHook } from "../droid/index.js";
 import { doctorGeminiCliHook } from "../gemini-cli/index.js";
 import { doctorGooseHints } from "../goose/index.js";
@@ -52,6 +53,7 @@ import type { CopilotAgentDoctorReport, CopilotAgentHookCommandOptions } from ".
 import type { CopilotCliDoctorReport } from "../copilot-cli/index.js";
 import type { CrushDoctorReport, CrushSkillOptions } from "../crush/index.js";
 import type { CursorDoctorReport } from "../cursor/index.js";
+import type { DevinDoctorReport, DevinHookCommandOptions } from "../devin/index.js";
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
 import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
 import type { GooseDoctorReport, GooseHintsOptions } from "../goose/index.js";
@@ -93,6 +95,7 @@ export type HookIntegrationDoctorReport = {
   continue: ContinueDoctorReport;
   crush: CrushDoctorReport;
   cursor: CursorDoctorReport;
+  devin: DevinDoctorReport;
   droid: DroidDoctorReport;
   "gemini-cli": GeminiCliDoctorReport;
   goose: GooseDoctorReport;
@@ -124,7 +127,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DroidHookCommandOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & RulerRuleOptions & TraeRuleOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & RulerRuleOptions & TraeRuleOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -150,6 +153,7 @@ const hookDoctorIntegrationDoctors = {
   "copilot-agent": (options) => doctorCopilotAgentHook(undefined, getHookCommandOptions(options)),
   crush: (options) => doctorCrushSkill(undefined, getHookCommandOptions(options)),
   cursor: (options) => doctorCursorHook(undefined, getHookCommandOptions(options)),
+  devin: (options) => doctorDevinHook(undefined, getHookCommandOptions(options)),
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
   goose: (options) => doctorGooseHints(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
 } from "./hosts/copilot-cli/index.js";
 export { doctorCrushSkill, installCrushSkill, uninstallCrushSkill } from "./hosts/crush/index.js";
 export { doctorCursorHook, installCursorHook, runCursorPreToolUseHook } from "./hosts/cursor/index.js";
+export { doctorDevinHook, installDevinHook, runDevinPreToolUseHook, uninstallDevinHook } from "./hosts/devin/index.js";
 export { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "./hosts/droid/index.js";
 export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "./hosts/gemini-cli/index.js";
 export { doctorGooseHints, installGooseHints, uninstallGooseHints } from "./hosts/goose/index.js";
@@ -304,4 +305,10 @@ export type {
   InstallCrushSkillResult,
   UninstallCrushSkillResult,
 } from "./hosts/crush/index.js";
+export type {
+  DevinDoctorReport,
+  DevinHookCommandOptions,
+  InstallDevinHookResult,
+  UninstallDevinHookResult,
+} from "./hosts/devin/index.js";
 export type { DiscoverOptions, StatsOptions, StatsReport, StatsSourceReport } from "./core/analysis.js";

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, gemini-cli, goose, grok-build, grok-cli, junie, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, roo, ruler, trae, vscode-copilot, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/devin.test.ts
+++ b/test/hosts/devin.test.ts
@@ -1,0 +1,265 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorDevinHook,
+  doctorInstalledHooks,
+  installDevinHook,
+  runDevinPreToolUseHook,
+  uninstallDevinHook,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "DEVIN_PROJECT_DIR",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_BUILD_PROJECT_DIR",
+  "HOME",
+  "JUNIE_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "MISTRAL_VIBE_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QODER_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "TRAE_PROJECT_DIR",
+  "TOKENJUICE_DEVIN_SHELL",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-devin-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function captureStdout(run: () => Promise<number>): Promise<{ code: number; output: string }> {
+  let output = "";
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const code = await run();
+    return { code, output };
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("devin hook", () => {
+  it("installs a project-local PreToolUse hook in .devin/hooks.v1.json", async () => {
+    const projectDir = await createTempDir();
+
+    const result = await installDevinHook(undefined, { projectDir, local: true });
+    const parsed = JSON.parse(await readFile(join(projectDir, ".devin", "hooks.v1.json"), "utf8")) as {
+      PreToolUse: Array<{ matcher?: string; hooks: Array<{ type: string; command: string; timeout?: number }> }>;
+    };
+
+    expect(result.hooksPath).toBe(join(projectDir, ".devin", "hooks.v1.json"));
+    expect(result.backupPath).toBeUndefined();
+    expect(parsed.PreToolUse).toHaveLength(1);
+    expect(parsed.PreToolUse[0]?.matcher).toBe("exec");
+    expect(parsed.PreToolUse[0]?.hooks[0]?.type).toBe("command");
+    expect(parsed.PreToolUse[0]?.hooks[0]?.command).toContain("devin-pre-tool-use");
+    expect(parsed.PreToolUse[0]?.hooks[0]?.command).toContain("--wrap-launcher");
+    expect(parsed.PreToolUse[0]?.hooks[0]?.timeout).toBe(10);
+  });
+
+  it("preserves unrelated Devin hooks and replaces only its own entry", async () => {
+    const projectDir = await createTempDir();
+    const hooksPath = join(projectDir, ".devin", "hooks.v1.json");
+    await installDevinHook(undefined, { projectDir, local: true });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        PreToolUse: [
+          {
+            matcher: "edit",
+            hooks: [{ type: "command", command: "./scripts/check-edit.sh", timeout: 5 }],
+          },
+          {
+            matcher: "exec",
+            hooks: [{ type: "command", command: "tokenjuice devin-pre-tool-use --old", timeout: 1 }],
+          },
+        ],
+        SessionStart: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: "./scripts/setup.sh" }],
+          },
+        ],
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await installDevinHook(undefined, { projectDir, local: true });
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      PreToolUse: Array<{ matcher?: string; hooks: Array<{ command: string; timeout?: number }> }>;
+      SessionStart: unknown[];
+    };
+
+    expect(result.backupPath).toBe(`${hooksPath}.bak`);
+    expect(parsed.SessionStart).toHaveLength(1);
+    expect(parsed.PreToolUse).toHaveLength(2);
+    expect(parsed.PreToolUse[0]?.matcher).toBe("edit");
+    expect(parsed.PreToolUse[1]?.matcher).toBe("exec");
+    expect(parsed.PreToolUse[1]?.hooks[0]?.command).toContain("devin-pre-tool-use");
+    expect(parsed.PreToolUse[1]?.hooks[0]?.command).not.toContain("--old");
+    expect(parsed.PreToolUse[1]?.hooks[0]?.timeout).toBe(10);
+  });
+
+  it("reports installed and uninstalled hook health", async () => {
+    const projectDir = await createTempDir();
+
+    await installDevinHook(undefined, { projectDir, local: true });
+    const installed = await doctorDevinHook(undefined, { projectDir, local: true });
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("PreToolUse exec");
+
+    const removed = await uninstallDevinHook(undefined, { projectDir });
+    const disabled = await doctorDevinHook(undefined, { projectDir, local: true });
+
+    expect(removed.removed).toBe(1);
+    expect(removed.deletedFile).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("uses DEVIN_PROJECT_DIR for the default hooks path", async () => {
+    const projectDir = await createTempDir();
+    process.env.DEVIN_PROJECT_DIR = projectDir;
+
+    const installed = await installDevinHook(undefined, { local: true });
+    const doctor = await doctorDevinHook(undefined, { local: true });
+
+    expect(installed.hooksPath).toBe(join(projectDir, ".devin", "hooks.v1.json"));
+    expect(doctor.hooksPath).toBe(join(projectDir, ".devin", "hooks.v1.json"));
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("rewrites Devin exec commands through tokenjuice wrap", async () => {
+    process.env.TOKENJUICE_DEVIN_SHELL = "sh";
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "exec",
+      tool_input: {
+        command: "pnpm test",
+        shell_id: "main",
+      },
+    });
+
+    const result = await captureStdout(async () => await runDevinPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+    const parsed = JSON.parse(result.output) as {
+      hookSpecificOutput: {
+        hookEventName: string;
+        updatedInput: {
+          command: string;
+          shell_id: string;
+        };
+      };
+    };
+
+    expect(result.code).toBe(0);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(parsed.hookSpecificOutput.updatedInput.shell_id).toBe("main");
+    expect(parsed.hookSpecificOutput.updatedInput.command).toContain("/usr/local/bin/tokenjuice wrap --source devin --");
+    expect(parsed.hookSpecificOutput.updatedInput.command).toContain(" -lc 'pnpm test'");
+  });
+
+  it("does not double-wrap commands that already use tokenjuice wrap", async () => {
+    process.env.TOKENJUICE_DEVIN_SHELL = "sh";
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "exec",
+      tool_input: {
+        command: "tokenjuice wrap -- pnpm test",
+      },
+    });
+
+    const result = await captureStdout(async () => await runDevinPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+
+    expect(result.code).toBe(0);
+    expect(result.output).toBe("");
+  });
+
+  it("leaves state-mutating Devin shell commands in the host session", async () => {
+    process.env.TOKENJUICE_DEVIN_SHELL = "sh";
+    const commands = [
+      "cd packages/cli",
+      "export NODE_ENV=test",
+      "source .venv/bin/activate",
+      "nvm use",
+      "set -e",
+      "cd packages/cli && export NODE_ENV=test",
+    ];
+
+    for (const command of commands) {
+      const payload = JSON.stringify({
+        hook_event_name: "PreToolUse",
+        tool_name: "exec",
+        tool_input: { command, shell_id: "main" },
+      });
+
+      const result = await captureStdout(async () => await runDevinPreToolUseHook(payload, "/usr/local/bin/tokenjuice"));
+
+      expect(result.code).toBe(0);
+      expect(result.output).toBe("");
+    }
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const projectDir = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = projectDir;
+    }
+    await installDevinHook(undefined, { projectDir, local: true });
+
+    const report = await doctorInstalledHooks({ projectDir, local: true });
+
+    expect(report.integrations.devin.hooksPath).toBe(join(projectDir, ".devin", "hooks.v1.json"));
+    expect(report.integrations.devin.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add Devin for Terminal as a project-local PreToolUse `exec` integration using `.devin/hooks.v1.json`
- route noisy exec commands through `tokenjuice wrap --source devin` while preserving pure shell-session setup commands like `cd`, `export`, `source`, and `nvm use`
- wire install, uninstall, doctor, aggregate doctor output, README, spec, changelog, and integration docs

## Validation
- pnpm exec vitest run test/hosts/devin.test.ts test/cli/doctor-output.test.ts
- pnpm typecheck
- pnpm build
- built CLI smoke: install / doctor / PreToolUse rewrite / stateful command passthrough / uninstall / disabled doctor with DEVIN_PROJECT_DIR
- git diff --check origin/main...HEAD && git diff --check
- privacy scan over branch diff
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main: clean, no accepted/actionable findings

## Review Notes
- Accepted autoreview finding: pure state-mutating shell commands must not be wrapped because Devin exec sessions carry `shell_id`; fixed with passthrough detection plus tests/docs.