### PR TITLE
feat(gptme): add instruction integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a beta Builder Projects rule integration.
 - Add a beta Devin for Terminal PreToolUse hook integration.
 - Add a beta Firebase Studio AI-rules integration.
+- Add a beta gptme instruction integration.
 - Add a beta Jules instruction integration.
 - Add a beta Kimi Code CLI PostToolUse hook integration.
 - Add a beta Mistral Vibe instruction integration.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ beta integrations:
 | <img width="48px" src="docs/client-goose.svg" alt="Goose" /> | [Goose](https://goose-docs.ai/) | `tokenjuice install goose` | `.goosehints` |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" /> | [Grok Build](https://docs.x.ai/build/overview) | `tokenjuice install grok-build` | `AGENTS.md` |
 | <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
+| <img width="48px" src="docs/client-gptme.svg" alt="gptme" /> | [gptme](https://gptme.org/docs/prompts.html) | `tokenjuice install gptme` | `AGENTS.md` |
 | <img width="48px" src="docs/client-copilot.png" alt="GitHub Copilot coding agent" /> | [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) | `tokenjuice install copilot-agent` | `.github/hooks/tokenjuice-agent.json` |
 | <img width="48px" src="docs/client-junie.svg" alt="Junie" /> | [Junie](https://junie.jetbrains.com/docs/junie-cli-usage.html) | `tokenjuice install junie` | `.junie/AGENTS.md` |
 | <img width="48px" src="docs/client-jules.svg" alt="Jules" /> | [Jules](https://jules.google/docs/) | `tokenjuice install jules` | `AGENTS.md` |
@@ -87,8 +88,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -110,9 +111,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -181,6 +182,7 @@ direct payload:
 - [Goose integration](docs/goose-integration.md)
 - [Grok Build integration](docs/grok-build-integration.md)
 - [Grok CLI integration](docs/grok-cli-integration.md)
+- [gptme integration](docs/gptme-integration.md)
 - [Kimi integration](docs/kimi-integration.md)
 - [Kiro integration](docs/kiro-integration.md)
 - [Kilo Code integration](docs/kilo-integration.md)

--- a/docs/client-gptme.svg
+++ b/docs/client-gptme.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">gptme</title>
+  <desc id="desc">gptme client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#111827"/>
+  <path d="M22 48c0-15 11-25 27-25 8 0 15 2 20 7l-8 9c-3-3-7-4-12-4-8 0-13 5-13 13 0 9 6 14 14 14 3 0 6-1 8-2v-6H48V43h23v24c-6 5-14 8-23 8-16 0-26-11-26-27Z" fill="#F8FAFC"/>
+  <path d="M21 80h54v7H21z" fill="#22C55E"/>
+</svg>

--- a/docs/gptme-integration.md
+++ b/docs/gptme-integration.md
@@ -1,0 +1,41 @@
+# gptme integration
+
+gptme support is beta.
+
+`tokenjuice install gptme` inserts a marker-delimited instruction block into
+`AGENTS.md` at the current git/project root. gptme discovers agent instruction
+files from the home directory down to the workspace, including `AGENTS.md`,
+`CLAUDE.md`, `COPILOT.md`, `GEMINI.md`, `.github/copilot-instructions.md`,
+`.cursorrules`, and `.windsurfrules`.
+
+```bash
+tokenjuice install gptme
+tokenjuice doctor gptme
+tokenjuice uninstall gptme
+```
+
+By default tokenjuice resolves the nearest git root and writes `AGENTS.md`.
+Set `GPTME_PROJECT_DIR=/path/to/repo` to target a specific repository in
+scripts or tests.
+
+The installed block tells gptme to use:
+
+```bash
+tokenjuice wrap -- <command>
+```
+
+for noisy terminal commands, and to reserve:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+for commands where exact output bytes are required.
+
+This is guidance-only. gptme still owns command execution, permissions,
+and prompt loading; tokenjuice does not intercept or rewrite gptme tool output.
+
+`doctor gptme` reports `ok` when the root `AGENTS.md` block exists, contains the
+`tokenjuice wrap` guidance, and does not advertise the older `--full` escape
+hatch. Malformed tokenjuice markers are reported as `broken` so project memory
+is not rewritten unsafely.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -183,6 +183,7 @@ tokenjuice install devin
 tokenjuice install firebase-studio
 tokenjuice install grok-build
 tokenjuice install grok-cli
+tokenjuice install gptme
 tokenjuice install goose
 tokenjuice install jules
 tokenjuice install kimi
@@ -211,6 +212,7 @@ tokenjuice doctor devin
 tokenjuice doctor firebase-studio
 tokenjuice doctor grok-build
 tokenjuice doctor grok-cli
+tokenjuice doctor gptme
 tokenjuice doctor goose
 tokenjuice doctor jules
 tokenjuice doctor kimi
@@ -262,6 +264,7 @@ supported host hooks:
 | Goose | `tokenjuice install goose` | `.goosehints` | ✴️ Beta. Inserts a marker-delimited hints block that tells Goose to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Goose hints do not intercept tool output; restart the Goose session after install; see `docs/goose-integration.md` |
 | Grok Build | `tokenjuice install grok-build` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block into the current git/project root that tells Grok Build to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Grok Build instructions do not intercept command output; see `docs/grok-build-integration.md` |
 | Grok CLI | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` | ✴️ Beta. Uses a user-level `PostToolUse` hook for the `bash` tool; compacted context is injected alongside the original output; `tokenjuice install grok-cli --local` is available for repo-local verification; see `docs/grok-cli-integration.md` |
+| gptme | `tokenjuice install gptme` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block into the current git/project root that tells gptme to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because gptme agent instruction files do not intercept tool output; see `docs/gptme-integration.md` |
 | GitHub Copilot coding agent | `tokenjuice install copilot-agent` | `.github/hooks/tokenjuice-agent.json` | Uses a repo-local `postToolUse` hook for shell output so Copilot coding agent receives compacted terminal output; `tokenjuice install copilot-agent --local` is available for repo-local verification; see `docs/copilot-agent-integration.md` |
 | GitHub Copilot CLI | `tokenjuice install copilot-cli` | `~/.copilot/hooks/tokenjuice-cli.json` | Uses `postToolUse` shell output rewriting on the `bash` tool (matcher `"shell"`) to compact command output before it returns to the agent. Honors `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the VS Code Copilot Chat install. After install, run `tokenjuice doctor copilot-cli --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |
 | Junie | `tokenjuice install junie` | `.junie/AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block that tells Junie to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Junie instructions do not intercept tool output; see `docs/junie-integration.md` |

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,6 +43,7 @@ import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, u
 import { doctorGooseHints, installGooseHints, uninstallGooseHints } from "../hosts/goose/index.js";
 import { doctorGrokBuildInstructions, installGrokBuildInstructions, uninstallGrokBuildInstructions } from "../hosts/grok-build/index.js";
 import { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "../hosts/grok-cli/index.js";
+import { doctorGptmeInstructions, installGptmeInstructions, uninstallGptmeInstructions } from "../hosts/gptme/index.js";
 import { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "../hosts/junie/index.js";
 import { doctorJulesInstructions, installJulesInstructions, uninstallJulesInstructions } from "../hosts/jules/index.js";
 import { doctorKimiHook, installKimiHook, runKimiPostToolUseHook, uninstallKimiHook } from "../hosts/kimi/index.js";
@@ -153,6 +154,7 @@ function printUsage(): void {
       "  tokenjuice install goose",
       "  tokenjuice install grok-build",
       "  tokenjuice install grok-cli [--local]",
+      "  tokenjuice install gptme",
       "  tokenjuice install junie",
       "  tokenjuice install jules",
       "  tokenjuice install kimi [--local]",
@@ -196,6 +198,7 @@ function printUsage(): void {
       "  tokenjuice uninstall goose",
       "  tokenjuice uninstall grok-build",
       "  tokenjuice uninstall grok-cli",
+      "  tokenjuice uninstall gptme",
       "  tokenjuice uninstall junie",
       "  tokenjuice uninstall jules",
       "  tokenjuice uninstall kimi",
@@ -223,7 +226,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -939,6 +942,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "gptme") {
+    const result = await installGptmeInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Instructions", value: result.instructionsPath },
+      { label: "Beta", value: "instruction-based guidance; gptme still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor gptme" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("gptme", "instructions", details));
+    return 0;
+  }
+
   if (target === "grok-build") {
     const result = await installGrokBuildInstructions();
     if (args.format === "json") {
@@ -1493,7 +1516,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1702,6 +1725,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed grok-cli entries: ${result.removed}\n`);
     process.stdout.write(`settings path: ${result.settingsPath}\n`);
     process.stdout.write("enable: tokenjuice install grok-cli\n");
+    return 0;
+  }
+
+  if (target === "gptme") {
+    const result = await uninstallGptmeInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed gptme instructions: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
+    process.stdout.write("enable: tokenjuice install gptme\n");
     return 0;
   }
 
@@ -2058,7 +2094,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -2871,6 +2907,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("missing paths:\n");
       for (const path of report.missingPaths) {
         process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "gptme") {
+    const report = await doctorGptmeInstructions();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
       }
     }
     if (report.advisories.length > 0) {

--- a/src/hosts/gptme/index.ts
+++ b/src/hosts/gptme/index.ts
@@ -1,0 +1,224 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type GptmeInstructionsOptions = {
+  projectDir?: string;
+};
+
+export type InstallGptmeInstructionsResult = {
+  instructionsPath: string;
+  backupPath?: string;
+};
+
+export type UninstallGptmeInstructionsResult = {
+  instructionsPath: string;
+  removed: boolean;
+};
+
+export type GptmeDoctorReport = {
+  instructionsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_GPTME_FIX_COMMAND = "tokenjuice install gptme";
+const TOKENJUICE_GPTME_BEGIN = "<!-- tokenjuice:gptme begin -->";
+const TOKENJUICE_GPTME_END = "<!-- tokenjuice:gptme end -->";
+const TOKENJUICE_GPTME_ADVISORY = "gptme support is beta and instruction-based; it guides command usage through project AGENTS.md but does not intercept tool output.";
+
+function getExplicitProjectDir(options: GptmeInstructionsOptions = {}): string | undefined {
+  return options.projectDir || process.env.GPTME_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: GptmeInstructionsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultInstructionsPath(options: GptmeInstructionsOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), "AGENTS.md");
+}
+
+const TOKENJUICE_GPTME_BLOCK = [
+  TOKENJUICE_GPTME_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through gptme, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_GPTME_END,
+].join("\n");
+
+const TOKENJUICE_GPTME_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_GPTME_BEGIN,
+  endMarker: TOKENJUICE_GPTME_END,
+  block: TOKENJUICE_GPTME_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_GPTME_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_GPTME_END, beginIndex + TOKENJUICE_GPTME_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_GPTME_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_GPTME_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_GPTME_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installGptmeInstructions(
+  instructionsPath?: string,
+  options: GptmeInstructionsOptions = {},
+): Promise<InstallGptmeInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GPTME_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely repair malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice install gptme`,
+    );
+  }
+
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_GPTME_BLOCK_CONFIG);
+  return {
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallGptmeInstructions(
+  instructionsPath?: string,
+  options: GptmeInstructionsOptions = {},
+): Promise<UninstallGptmeInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GPTME_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely uninstall malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall gptme`,
+    );
+  }
+
+  const result = await uninstallMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_GPTME_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
+}
+
+export async function doctorGptmeInstructions(
+  instructionsPath?: string,
+  options: GptmeInstructionsOptions = {},
+): Promise<GptmeDoctorReport> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GPTME_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      instructionsPath: resolvedInstructionsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice gptme instructions are not installed"],
+        advisory: TOKENJUICE_GPTME_ADVISORY,
+        fixCommand: TOKENJUICE_GPTME_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "gptme instructions",
+    repairCommand: TOKENJUICE_GPTME_FIX_COMMAND,
+  });
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured gptme instructions have malformed tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured gptme instructions are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured gptme instructions are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured gptme instructions still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    instructionsPath: resolvedInstructionsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_GPTME_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from AGENTS.md, then run tokenjuice install gptme"
+        : TOKENJUICE_GPTME_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -21,6 +21,7 @@ import { doctorGeminiCliHook } from "../gemini-cli/index.js";
 import { doctorGooseHints } from "../goose/index.js";
 import { doctorGrokBuildInstructions } from "../grok-build/index.js";
 import { doctorGrokCliHook } from "../grok-cli/index.js";
+import { doctorGptmeInstructions } from "../gptme/index.js";
 import { doctorJunieInstructions } from "../junie/index.js";
 import { doctorJulesInstructions } from "../jules/index.js";
 import { doctorKimiHook } from "../kimi/index.js";
@@ -67,6 +68,7 @@ import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
 import type { GooseDoctorReport, GooseHintsOptions } from "../goose/index.js";
 import type { GrokBuildDoctorReport, GrokBuildInstructionsOptions } from "../grok-build/index.js";
 import type { GrokCliDoctorReport, GrokCliHookCommandOptions } from "../grok-cli/index.js";
+import type { GptmeDoctorReport, GptmeInstructionsOptions } from "../gptme/index.js";
 import type { JunieDoctorReport } from "../junie/index.js";
 import type { JulesDoctorReport, JulesInstructionsOptions } from "../jules/index.js";
 import type { KimiDoctorReport, KimiHookCommandOptions } from "../kimi/index.js";
@@ -115,6 +117,7 @@ export type HookIntegrationDoctorReport = {
   goose: GooseDoctorReport;
   "grok-build": GrokBuildDoctorReport;
   "grok-cli": GrokCliDoctorReport;
+  gptme: GptmeDoctorReport;
   junie: JunieDoctorReport;
   jules: JulesDoctorReport;
   kimi: KimiDoctorReport;
@@ -145,7 +148,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TraeRuleOptions & WarpInstructionsOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TraeRuleOptions & WarpInstructionsOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -179,6 +182,7 @@ const hookDoctorIntegrationDoctors = {
   goose: (options) => doctorGooseHints(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),
   "grok-build": (options) => doctorGrokBuildInstructions(undefined, getHookCommandOptions(options)),
   "grok-cli": (options) => doctorGrokCliHook(undefined, getHookCommandOptions(options)),
+  gptme: (options) => doctorGptmeInstructions(undefined, getHookCommandOptions(options)),
   junie: () => doctorJunieInstructions(),
   jules: (options) => doctorJulesInstructions(undefined, getHookCommandOptions(options)),
   kimi: (options) => doctorKimiHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, u
 export { doctorGooseHints, installGooseHints, uninstallGooseHints } from "./hosts/goose/index.js";
 export { doctorGrokBuildInstructions, installGrokBuildInstructions, uninstallGrokBuildInstructions } from "./hosts/grok-build/index.js";
 export { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "./hosts/grok-cli/index.js";
+export { doctorGptmeInstructions, installGptmeInstructions, uninstallGptmeInstructions } from "./hosts/gptme/index.js";
 export { doctorJunieInstructions, installJunieInstructions, uninstallJunieInstructions } from "./hosts/junie/index.js";
 export { doctorJulesInstructions, installJulesInstructions, uninstallJulesInstructions } from "./hosts/jules/index.js";
 export { doctorKimiHook, installKimiHook, runKimiPostToolUseHook, uninstallKimiHook } from "./hosts/kimi/index.js";
@@ -203,6 +204,12 @@ export type {
   InstallGrokCliHookResult,
   UninstallGrokCliHookResult,
 } from "./hosts/grok-cli/index.js";
+export type {
+  GptmeDoctorReport,
+  GptmeInstructionsOptions,
+  InstallGptmeInstructionsResult,
+  UninstallGptmeInstructionsResult,
+} from "./hosts/gptme/index.js";
 export type {
   InstallJunieInstructionsResult,
   JunieDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/gptme.test.ts
+++ b/test/hosts/gptme.test.ts
@@ -1,0 +1,230 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorGptmeInstructions,
+  installGptmeInstructions,
+  uninstallGptmeInstructions,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "BUILDER_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_BUILD_PROJECT_DIR",
+  "GPTME_PROJECT_DIR",
+  "HOME",
+  "JULES_PROJECT_DIR",
+  "JUNIE_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "ROVO_DEV_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-gptme-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("gptme instructions", () => {
+  it("installs a host-specific marker-delimited AGENTS.md instruction block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    const result = await installGptmeInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(result.instructionsPath).toBe(instructionsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(instructions).toContain("<!-- tokenjuice:gptme begin -->");
+    expect(instructions).toContain("tokenjuice terminal output compaction");
+    expect(instructions).toContain("When running terminal commands through gptme");
+    expect(instructions).toContain("tokenjuice wrap -- <command>");
+    expect(instructions).toContain("tokenjuice wrap --raw -- <command>");
+    expect(instructions).not.toContain("wrap --full");
+  });
+
+  it("coexists with other tokenjuice AGENTS.md blocks", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "<!-- tokenjuice:jules begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through Jules, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:jules end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installGptmeInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("<!-- tokenjuice:jules begin -->");
+    expect(instructions).toContain("When running terminal commands through Jules");
+    expect(instructions).toContain("<!-- tokenjuice:gptme begin -->");
+    expect(instructions).toContain("When running terminal commands through gptme");
+  });
+
+  it("backs up existing project instructions before replacing its own block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await installGptmeInstructions(instructionsPath);
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const result = await installGptmeInstructions(instructionsPath);
+
+    expect(result.backupPath).toBe(`${instructionsPath}.bak`);
+    await expect(readFile(`${instructionsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    await expect(readFile(instructionsPath, "utf8")).resolves.toContain("<!-- tokenjuice:gptme begin -->");
+  });
+
+  it("reports installed and uninstalled instruction health", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    await installGptmeInstructions(instructionsPath);
+    const installed = await doctorGptmeInstructions(instructionsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("instruction-based");
+
+    const removed = await uninstallGptmeInstructions(instructionsPath);
+    const disabled = await doctorGptmeInstructions(instructionsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(instructionsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports broken instructions with unmatched gptme tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:gptme begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorGptmeInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("reports broken instructions with nested gptme tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "<!-- tokenjuice:gptme begin -->",
+        "<!-- tokenjuice:gptme begin -->",
+        "## tokenjuice terminal output compaction",
+        "",
+        "- When running terminal commands through gptme, prefer `tokenjuice wrap -- <command>`.",
+        "- Use `tokenjuice wrap --raw -- <command>` only when exact raw output bytes are required.",
+        "<!-- tokenjuice:gptme end -->",
+        "<!-- tokenjuice:gptme end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorGptmeInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured gptme instructions have malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+    await expect(installGptmeInstructions(instructionsPath)).rejects.toThrow("cannot safely repair malformed tokenjuice markers");
+    await expect(uninstallGptmeInstructions(instructionsPath)).rejects.toThrow(
+      "cannot safely uninstall malformed tokenjuice markers",
+    );
+  });
+
+  it("uses GPTME_PROJECT_DIR for the default AGENTS.md path", async () => {
+    const home = await createTempDir();
+    process.env.GPTME_PROJECT_DIR = home;
+
+    const installed = await installGptmeInstructions();
+    const expectedInstructionsPath = join(home, "AGENTS.md");
+    const doctor = await doctorGptmeInstructions();
+
+    expect(installed.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("defaults to the git root AGENTS.md from nested directories", async () => {
+    const home = await createTempDir();
+    await mkdir(join(home, ".git"));
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installGptmeInstructions();
+    const root = await realpath(home);
+
+    expect(installed.instructionsPath).toBe(join(root, "AGENTS.md"));
+    await expect(readFile(join(root, "AGENTS.md"), "utf8")).resolves.toContain("gptme");
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await installGptmeInstructions(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations["gptme"].instructionsPath).toBe(join(home, "AGENTS.md"));
+    expect(report.integrations["gptme"].status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add a beta `gptme` instruction integration that manages a marker-delimited root `AGENTS.md` block for gptme terminal-output guidance
- resolve the default target from `GPTME_PROJECT_DIR` or the nearest git/project root, and wire install, uninstall, doctor, aggregate doctor, exports, docs, changelog, and CLI host lists
- report malformed gptme tokenjuice marker structures as broken before install/uninstall refuse unsafe rewrites

## Validation
- `pnpm exec vitest run test/hosts/gptme.test.ts test/cli/doctor-output.test.ts` (2 files, 13 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- built CLI smoke: `install gptme`, `doctor gptme`, `uninstall gptme`, disabled doctor state
- `git diff --check origin/main...HEAD && git diff --check`
- privacy scan over `git diff origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean: no accepted/actionable findings)

## Review notes
- rebased onto current `origin/main` after Rovo landed and verified aggregate doctor option types keep gptme plus current shared hook options intact.
