### PR TITLE
feat(tabnine): add project context integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add a beta Mistral Vibe instruction integration.
 - Add a beta Replit Agent instruction integration.
 - Add a beta Rovo Dev CLI project-memory integration.
+- Add a beta Tabnine CLI project-context integration.
 - Add a beta Trae project-rule integration.
 - Add a beta Warp project-rules integration.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ beta integrations:
 | <img width="48px" src="docs/client-roo.svg" alt="Roo Code" /> | [Roo Code](https://roocode.com/) | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-rovo.svg" alt="Rovo" /> | [Rovo Dev CLI](https://support.atlassian.com/rovo/docs/use-memory-in-rovo-dev-cli/) | `tokenjuice install rovo` | `AGENTS.md` |
 | <img width="48px" src="docs/client-ruler.svg" alt="Ruler" /> | [Ruler](https://github.com/intellectronica/ruler) | `tokenjuice install ruler` | `.ruler/tokenjuice.md` |
+| <img width="48px" src="docs/client-tabnine.svg" alt="Tabnine" /> | [Tabnine CLI](https://docs.tabnine.com/main/getting-started/tabnine-cli/features/cli-commands) | `tokenjuice install tabnine` | `TABNINE.md` |
 | <img width="48px" src="docs/client-trae.svg" alt="Trae" /> | [Trae](https://traeide.com/) | `tokenjuice install trae` | `.trae/rules/project_rules.md` |
 | <img width="48px" src="docs/client-warp.svg" alt="Warp" /> | [Warp](https://docs.warp.dev/agent-platform/capabilities/rules) | `tokenjuice install warp` | `AGENTS.md` / `WARP.md` |
 | <img width="48px" src="docs/client-windsurf.svg" alt="Windsurf" /> | [Windsurf](https://windsurf.com/) | `tokenjuice install windsurf` | `.windsurf/rules/tokenjuice.md` |
@@ -88,8 +89,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -111,9 +112,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -196,6 +197,7 @@ direct payload:
 - [Roo Code integration](docs/roo-integration.md)
 - [Rovo integration](docs/rovo-integration.md)
 - [Ruler integration](docs/ruler-integration.md)
+- [Tabnine integration](docs/tabnine-integration.md)
 - [Trae integration](docs/trae-integration.md)
 - [Warp integration](docs/warp-integration.md)
 - [Windsurf integration](docs/windsurf-integration.md)

--- a/docs/client-tabnine.svg
+++ b/docs/client-tabnine.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Tabnine</title>
+  <desc id="desc">Tabnine client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#111827"/>
+  <path d="M20 25h56v13H55v38H41V38H20V25Z" fill="#F8FAFC"/>
+  <path d="M18 80h60v7H18z" fill="#10B981"/>
+</svg>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -198,6 +198,7 @@ tokenjuice install qwen-code
 tokenjuice install replit
 tokenjuice install rovo
 tokenjuice install ruler
+tokenjuice install tabnine
 tokenjuice install trae
 tokenjuice install warp
 tokenjuice doctor hooks
@@ -225,6 +226,7 @@ tokenjuice doctor qwen-code
 tokenjuice doctor replit
 tokenjuice doctor rovo
 tokenjuice doctor ruler
+tokenjuice doctor tabnine
 tokenjuice doctor trae
 tokenjuice doctor warp
 tokenjuice install codex --local
@@ -285,6 +287,7 @@ supported host hooks:
 | Roo Code | `tokenjuice install roo` | `.roo/rules/tokenjuice.md` | ✴️ Beta. Inserts a marker-delimited workspace rule that tells Roo to use `tokenjuice wrap` for noisy `execute_command` terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Roo workspace rules do not intercept tool output; see `docs/roo-integration.md` |
 | Rovo Dev CLI | `tokenjuice install rovo` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited project memory block into the current git/project root that tells Rovo Dev CLI to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Rovo Dev memory files do not intercept tool output; see `docs/rovo-integration.md` |
 | Ruler | `tokenjuice install ruler` | `.ruler/tokenjuice.md` | ✴️ Beta. Installs a Ruler source rule that tells configured coding agents to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Ruler propagates rules rather than intercepting command output; run `ruler apply` after install; see `docs/ruler-integration.md` |
+| Tabnine CLI | `tokenjuice install tabnine` | `TABNINE.md` | ✴️ Beta. Inserts a marker-delimited project context block into the current git/project root that tells Tabnine CLI to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Tabnine context files do not intercept tool output; see `docs/tabnine-integration.md` |
 | Trae | `tokenjuice install trae` | `.trae/rules/project_rules.md` | ✴️ Beta. Inserts a marker-delimited project rule block that tells Trae to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Trae `.rules` files do not intercept command output; see `docs/trae-integration.md` |
 | Warp | `tokenjuice install warp` | `AGENTS.md` / `WARP.md` | ✴️ Beta. Inserts a marker-delimited project rules block into the current git/project root that tells Warp to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; fresh installs write `WARP.md` when that file already exists because Warp gives it priority over `AGENTS.md`, while existing tokenjuice Warp blocks in `AGENTS.md` continue to be managed there until explicitly removed; guidance-only, because Warp rules do not intercept tool output; see `docs/warp-integration.md` |
 | VS Code Copilot Chat | `tokenjuice install vscode-copilot` | `~/.copilot/hooks/tokenjuice-vscode.json` | Uses `PreToolUse` shell input rewriting on the `runTerminalCommand` tool to route commands through `tokenjuice wrap`; still accepts the legacy `run_in_terminal` tool name and installs a matcher for both names so the shared hooks dir does not wake the hook for unrelated Copilot CLI tools. Requires `chat.useHooks` enabled and a trusted workspace. Ignores `COPILOT_HOME`; the shared `~/.copilot/hooks/` dir is used with a per-host filename to coexist with the Copilot CLI install. After install, run `tokenjuice doctor vscode-copilot --print-instructions` and paste the snippet into the repo's `.github/copilot-instructions.md` (or `AGENTS.md`) so the agent treats compacted output as authoritative and only prefixes `tokenjuice wrap --raw --` when raw bytes are required. |

--- a/docs/tabnine-integration.md
+++ b/docs/tabnine-integration.md
@@ -1,0 +1,40 @@
+# Tabnine integration
+
+Tabnine support is beta.
+
+`tokenjuice install tabnine` inserts a marker-delimited instruction block into
+`TABNINE.md` at the current git/project root. Tabnine CLI documents
+`TABNINE.md` as a persistent, hierarchical context file for always-on project
+knowledge.
+
+```bash
+tokenjuice install tabnine
+tokenjuice doctor tabnine
+tokenjuice uninstall tabnine
+```
+
+By default tokenjuice resolves the nearest git root and writes `TABNINE.md`.
+Set `TABNINE_PROJECT_DIR=/path/to/repo` to target a specific repository in
+scripts or tests.
+
+The installed block tells Tabnine to use:
+
+```bash
+tokenjuice wrap -- <command>
+```
+
+for noisy terminal commands, and to reserve:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+for commands where exact output bytes are required.
+
+This is guidance-only. Tabnine CLI still owns command execution, permissions,
+and prompt loading; tokenjuice does not intercept or rewrite Tabnine CLI tool output.
+
+`doctor tabnine` reports `ok` when the root `TABNINE.md` block exists, contains the
+`tokenjuice wrap` guidance, and does not advertise the older `--full` escape
+hatch. Malformed tokenjuice markers are reported as `broken` so project context
+is not rewritten unsafely.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -66,6 +66,7 @@ import { doctorReplitInstructions, installReplitInstructions, uninstallReplitIns
 import { doctorRooInstructions, installRooInstructions, uninstallRooInstructions } from "../hosts/roo/index.js";
 import { doctorRovoInstructions, installRovoInstructions, uninstallRovoInstructions } from "../hosts/rovo/index.js";
 import { doctorRulerRule, installRulerRule, uninstallRulerRule } from "../hosts/ruler/index.js";
+import { doctorTabnineInstructions, installTabnineInstructions, uninstallTabnineInstructions } from "../hosts/tabnine/index.js";
 import { doctorTraeRule, installTraeRule, uninstallTraeRule } from "../hosts/trae/index.js";
 import {
   doctorVscodeCopilotHook,
@@ -173,6 +174,7 @@ function printUsage(): void {
       "  tokenjuice install roo",
       "  tokenjuice install rovo",
       "  tokenjuice install ruler",
+      "  tokenjuice install tabnine",
       "  tokenjuice install trae",
       "  tokenjuice install vscode-copilot [--local]",
       "  tokenjuice install warp",
@@ -216,6 +218,7 @@ function printUsage(): void {
       "  tokenjuice uninstall roo",
       "  tokenjuice uninstall rovo",
       "  tokenjuice uninstall ruler",
+      "  tokenjuice uninstall tabnine",
       "  tokenjuice uninstall trae",
       "  tokenjuice uninstall vscode-copilot",
       "  tokenjuice uninstall warp",
@@ -226,7 +229,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -1390,6 +1393,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "tabnine") {
+    const result = await installTabnineInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Instructions", value: result.instructionsPath },
+      { label: "Beta", value: "instruction-based guidance; Tabnine CLI still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor tabnine" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("tabnine", "instructions", details));
+    return 0;
+  }
+
   if (target === "trae") {
     const result = await installTraeRule();
     if (args.format === "json") {
@@ -1516,7 +1539,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -2003,6 +2026,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "tabnine") {
+    const result = await uninstallTabnineInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed tabnine instructions: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
+    process.stdout.write("enable: tokenjuice install tabnine\n");
+    return 0;
+  }
+
   if (target === "trae") {
     const result = await uninstallTraeRule();
     if (args.format === "json") {
@@ -2094,7 +2130,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -3306,6 +3342,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     }
 
     process.stdout.write(`rule path: ${report.rulePath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "tabnine") {
+    const report = await doctorTabnineInstructions();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
     process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -39,6 +39,7 @@ import { doctorReplitInstructions } from "../replit/index.js";
 import { doctorRooInstructions } from "../roo/index.js";
 import { doctorRovoInstructions } from "../rovo/index.js";
 import { doctorRulerRule } from "../ruler/index.js";
+import { doctorTabnineInstructions } from "../tabnine/index.js";
 import { doctorTraeRule } from "../trae/index.js";
 import { doctorVscodeCopilotHook } from "../vscode-copilot/index.js";
 import { doctorWarpInstructions } from "../warp/index.js";
@@ -85,6 +86,7 @@ import type { QwenCodeDoctorReport, QwenCodeHookCommandOptions } from "../qwen-c
 import type { ReplitDoctorReport, ReplitInstructionsOptions } from "../replit/index.js";
 import type { RooDoctorReport } from "../roo/index.js";
 import type { RovoDoctorReport, RovoInstructionsOptions } from "../rovo/index.js";
+import type { TabnineDoctorReport, TabnineInstructionsOptions } from "../tabnine/index.js";
 import type { RulerDoctorReport, RulerRuleOptions } from "../ruler/index.js";
 import type { TraeDoctorReport, TraeRuleOptions } from "../trae/index.js";
 import type { VscodeCopilotDoctorReport } from "../vscode-copilot/index.js";
@@ -135,6 +137,7 @@ export type HookIntegrationDoctorReport = {
   roo: RooDoctorReport;
   rovo: RovoDoctorReport;
   ruler: RulerDoctorReport;
+  tabnine: TabnineDoctorReport;
   trae: TraeDoctorReport;
   "vscode-copilot": VscodeCopilotDoctorReport;
   warp: WarpDoctorReport;
@@ -148,7 +151,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TraeRuleOptions & WarpInstructionsOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -200,6 +203,7 @@ const hookDoctorIntegrationDoctors = {
   roo: () => doctorRooInstructions(),
   rovo: (options) => doctorRovoInstructions(undefined, getHookCommandOptions(options)),
   ruler: (options) => doctorRulerRule(undefined, getHookCommandOptions(options)),
+  tabnine: (options) => doctorTabnineInstructions(undefined, getHookCommandOptions(options)),
   trae: (options) => doctorTraeRule(undefined, getHookCommandOptions(options)),
   "vscode-copilot": (options) => doctorVscodeCopilotHook(undefined, getHookCommandOptions(options)),
   warp: (options) => doctorWarpInstructions(undefined, getHookCommandOptions(options)),

--- a/src/hosts/tabnine/index.ts
+++ b/src/hosts/tabnine/index.ts
@@ -1,0 +1,224 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type TabnineInstructionsOptions = {
+  projectDir?: string;
+};
+
+export type InstallTabnineInstructionsResult = {
+  instructionsPath: string;
+  backupPath?: string;
+};
+
+export type UninstallTabnineInstructionsResult = {
+  instructionsPath: string;
+  removed: boolean;
+};
+
+export type TabnineDoctorReport = {
+  instructionsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_TABNINE_FIX_COMMAND = "tokenjuice install tabnine";
+const TOKENJUICE_TABNINE_BEGIN = "<!-- tokenjuice:tabnine begin -->";
+const TOKENJUICE_TABNINE_END = "<!-- tokenjuice:tabnine end -->";
+const TOKENJUICE_TABNINE_ADVISORY = "Tabnine support is beta and instruction-based; it guides command usage through project TABNINE.md but does not intercept tool output.";
+
+function getExplicitProjectDir(options: TabnineInstructionsOptions = {}): string | undefined {
+  return options.projectDir || process.env.TABNINE_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: TabnineInstructionsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultInstructionsPath(options: TabnineInstructionsOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), "TABNINE.md");
+}
+
+const TOKENJUICE_TABNINE_BLOCK = [
+  TOKENJUICE_TABNINE_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through Tabnine CLI, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_TABNINE_END,
+].join("\n");
+
+const TOKENJUICE_TABNINE_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_TABNINE_BEGIN,
+  endMarker: TOKENJUICE_TABNINE_END,
+  block: TOKENJUICE_TABNINE_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_TABNINE_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_TABNINE_END, beginIndex + TOKENJUICE_TABNINE_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_TABNINE_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_TABNINE_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_TABNINE_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installTabnineInstructions(
+  instructionsPath?: string,
+  options: TabnineInstructionsOptions = {},
+): Promise<InstallTabnineInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_TABNINE_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely repair malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice install tabnine`,
+    );
+  }
+
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_TABNINE_BLOCK_CONFIG);
+  return {
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallTabnineInstructions(
+  instructionsPath?: string,
+  options: TabnineInstructionsOptions = {},
+): Promise<UninstallTabnineInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_TABNINE_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely uninstall malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall tabnine`,
+    );
+  }
+
+  const result = await uninstallMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_TABNINE_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
+}
+
+export async function doctorTabnineInstructions(
+  instructionsPath?: string,
+  options: TabnineInstructionsOptions = {},
+): Promise<TabnineDoctorReport> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_TABNINE_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      instructionsPath: resolvedInstructionsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Tabnine instructions are not installed"],
+        advisory: TOKENJUICE_TABNINE_ADVISORY,
+        fixCommand: TOKENJUICE_TABNINE_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Tabnine instructions",
+    repairCommand: TOKENJUICE_TABNINE_FIX_COMMAND,
+  });
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured Tabnine instructions have malformed tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured Tabnine instructions are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured Tabnine instructions are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured Tabnine instructions still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    instructionsPath: resolvedInstructionsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_TABNINE_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from TABNINE.md, then run tokenjuice install tabnine"
+        : TOKENJUICE_TABNINE_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { doctorReplitInstructions, installReplitInstructions, uninstallReplitIns
 export { doctorRooInstructions, installRooInstructions, uninstallRooInstructions } from "./hosts/roo/index.js";
 export { doctorRovoInstructions, installRovoInstructions, uninstallRovoInstructions } from "./hosts/rovo/index.js";
 export { doctorTraeRule, installTraeRule, uninstallTraeRule } from "./hosts/trae/index.js";
+export { doctorTabnineInstructions, installTabnineInstructions, uninstallTabnineInstructions } from "./hosts/tabnine/index.js";
 export {
   doctorVscodeCopilotHook,
   getVscodeCopilotInstructionsSnippet,
@@ -300,6 +301,12 @@ export type {
   RovoInstructionsOptions,
   UninstallRovoInstructionsResult,
 } from "./hosts/rovo/index.js";
+export type {
+  InstallTabnineInstructionsResult,
+  TabnineDoctorReport,
+  TabnineInstructionsOptions,
+  UninstallTabnineInstructionsResult,
+} from "./hosts/tabnine/index.js";
 export type {
   InstallRulerRuleResult,
   RulerDoctorReport,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/tabnine.test.ts
+++ b/test/hosts/tabnine.test.ts
@@ -1,0 +1,233 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorTabnineInstructions,
+  installTabnineInstructions,
+  uninstallTabnineInstructions,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "BUILDER_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_BUILD_PROJECT_DIR",
+  "GPTME_PROJECT_DIR",
+  "TABNINE_PROJECT_DIR",
+  "HOME",
+  "JULES_PROJECT_DIR",
+  "JUNIE_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "ROVO_DEV_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-tabnine-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("Tabnine instructions", () => {
+  it("installs a host-specific marker-delimited TABNINE.md instruction block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+
+    const result = await installTabnineInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(result.instructionsPath).toBe(instructionsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(instructions).toContain("<!-- tokenjuice:tabnine begin -->");
+    expect(instructions).toContain("tokenjuice terminal output compaction");
+    expect(instructions).toContain("When running terminal commands through Tabnine CLI");
+    expect(instructions).toContain("tokenjuice wrap -- <command>");
+    expect(instructions).toContain("tokenjuice wrap --raw -- <command>");
+    expect(instructions).not.toContain("wrap --full");
+  });
+
+  it("coexists with other tokenjuice TABNINE.md blocks", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "<!-- tokenjuice:custom begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through another Tabnine convention, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:custom end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installTabnineInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("<!-- tokenjuice:custom begin -->");
+    expect(instructions).toContain("When running terminal commands through another Tabnine convention");
+    expect(instructions).toContain("<!-- tokenjuice:tabnine begin -->");
+    expect(instructions).toContain("When running terminal commands through Tabnine CLI");
+  });
+
+  it("backs up existing project instructions before replacing its own block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+    await installTabnineInstructions(instructionsPath);
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const result = await installTabnineInstructions(instructionsPath);
+
+    expect(result.backupPath).toBe(`${instructionsPath}.bak`);
+    await expect(readFile(`${instructionsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    await expect(readFile(instructionsPath, "utf8")).resolves.toContain("<!-- tokenjuice:tabnine begin -->");
+  });
+
+  it("reports installed and uninstalled instruction health", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+
+    await installTabnineInstructions(instructionsPath);
+    const installed = await doctorTabnineInstructions(instructionsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("instruction-based");
+
+    const removed = await uninstallTabnineInstructions(instructionsPath);
+    const disabled = await doctorTabnineInstructions(instructionsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(instructionsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports broken instructions with unmatched Tabnine tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:tabnine begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorTabnineInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("reports broken instructions with nested Tabnine tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "TABNINE.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "<!-- tokenjuice:tabnine begin -->",
+        "<!-- tokenjuice:tabnine begin -->",
+        "## tokenjuice terminal output compaction",
+        "",
+        "- When running terminal commands through Tabnine CLI, prefer `tokenjuice wrap -- <command>`.",
+        "- Use `tokenjuice wrap --raw -- <command>` only when exact raw output bytes are required.",
+        "<!-- tokenjuice:tabnine end -->",
+        "<!-- tokenjuice:tabnine end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorTabnineInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Tabnine instructions have malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+    await expect(installTabnineInstructions(instructionsPath)).rejects.toThrow(
+      "cannot safely repair malformed tokenjuice markers",
+    );
+    await expect(uninstallTabnineInstructions(instructionsPath)).rejects.toThrow(
+      "cannot safely uninstall malformed tokenjuice markers",
+    );
+  });
+
+  it("uses TABNINE_PROJECT_DIR for the default TABNINE.md path", async () => {
+    const home = await createTempDir();
+    process.env.TABNINE_PROJECT_DIR = home;
+
+    const installed = await installTabnineInstructions();
+    const expectedInstructionsPath = join(home, "TABNINE.md");
+    const doctor = await doctorTabnineInstructions();
+
+    expect(installed.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("defaults to the git root TABNINE.md from nested directories", async () => {
+    const home = await createTempDir();
+    await mkdir(join(home, ".git"));
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installTabnineInstructions();
+    const root = await realpath(home);
+
+    expect(installed.instructionsPath).toBe(join(root, "TABNINE.md"));
+    await expect(readFile(join(root, "TABNINE.md"), "utf8")).resolves.toContain("Tabnine");
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await installTabnineInstructions(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.tabnine.instructionsPath).toBe(join(home, "TABNINE.md"));
+    expect(report.integrations.tabnine.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add a beta `tabnine` project context integration that manages a marker-delimited `TABNINE.md` block for Tabnine CLI terminal-output guidance
- resolve the default target from `TABNINE_PROJECT_DIR` or the nearest git/project root, and wire install, uninstall, doctor, aggregate doctor, exports, docs, changelog, and CLI host lists
- harden malformed-marker handling so direct and aggregate doctor report broken Tabnine blocks consistently before install/uninstall refuse unsafe rewrites

## Validation
- official Tabnine docs checked for `TABNINE.md` context and hook behavior; kept this guidance-only because Tabnine hooks do not document output replacement
- `pnpm exec vitest run test/hosts/tabnine.test.ts test/cli/doctor-output.test.ts` (2 files, 13 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- built CLI smoke: `--version`, `install tabnine`, inspect generated `TABNINE.md`, `doctor tabnine` ok, `uninstall tabnine`, `doctor tabnine` disabled from a nested git project
- `pnpm verify` (lint, circular dependency check, typecheck, 74 test files / 1152 tests)
- `git diff --check origin/main...HEAD && git diff --check`
- privacy scan over `git diff origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings)

## Review notes
- rebased onto current `origin/main`; this PR is now a single Tabnine commit instead of the old integration stack
- preserved current Trae, VS Code Copilot, Crush skill, and aggregate doctor behavior while resolving conflicts
- Tabnine CLI is not installed in the local environment, so live validation covered the tokenjuice-managed file lifecycle rather than a real Tabnine session
