### PR TITLE
feat(bob): add instruction integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add a beta Amazon Q Developer CLI workspace-rule integration.
+- Add a beta IBM Bob Shell context-file integration.
 - Add a beta Builder Projects rule integration.
 - Add a beta Devin for Terminal PreToolUse hook integration.
 - Add a beta Firebase Studio AI-rules integration.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ beta integrations:
 | <img width="48px" src="docs/client-antigravity.svg" alt="Antigravity" /> | [Google Antigravity](https://antigravity.google/) | `tokenjuice install antigravity` | `.agents/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-augment.svg" alt="Augment" /> | [Augment](https://docs.augmentcode.com/cli/rules) | `tokenjuice install augment` | `.augment/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-avante.png" alt="Avante" /> | [Avante.nvim](https://github.com/yetone/avante.nvim) | `tokenjuice install avante` | `avante.md` |
+| <img width="48px" src="docs/client-bob.svg" alt="IBM Bob" /> | [IBM Bob Shell](https://bob.ibm.com/docs/shell/configuration/configuring) | `tokenjuice install bob` | `AGENTS.md` |
 | <img width="48px" src="docs/client-builder.svg" alt="Builder" /> | [Builder](https://www.builder.io/c/docs/projects-configuration-files) | `tokenjuice install builder` | `.builder/rules/tokenjuice.mdc` |
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
@@ -89,8 +90,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -112,9 +113,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -174,6 +175,7 @@ direct payload:
 - [Amazon Q integration](docs/amazon-q-integration.md)
 - [Antigravity integration](docs/antigravity-integration.md)
 - [Augment integration](docs/augment-integration.md)
+- [IBM Bob integration](docs/bob-integration.md)
 - [Builder integration](docs/builder-integration.md)
 - [GitHub Copilot coding agent integration](docs/copilot-agent-integration.md)
 - [Crush integration](docs/crush-integration.md)

--- a/docs/bob-integration.md
+++ b/docs/bob-integration.md
@@ -1,0 +1,41 @@
+# IBM Bob integration
+
+IBM Bob support is beta.
+
+`tokenjuice install bob` inserts a marker-delimited instruction block into
+`AGENTS.md` at the current git/project root. IBM Bob Shell loads `AGENTS.md`
+context files hierarchically, including global `~/.bob/AGENTS.md`, project-root
+and parent-directory `AGENTS.md`, and subdirectory `AGENTS.md` files for local
+component instructions.
+
+```bash
+tokenjuice install bob
+tokenjuice doctor bob
+tokenjuice uninstall bob
+```
+
+By default tokenjuice resolves the nearest git root and writes `AGENTS.md`.
+Set `BOB_PROJECT_DIR=/path/to/repo` to target a specific repository in
+scripts or tests.
+
+The installed block tells IBM Bob to use:
+
+```bash
+tokenjuice wrap -- <command>
+```
+
+for noisy terminal commands, and to reserve:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+for commands where exact output bytes are required.
+
+This is guidance-only. IBM Bob still owns command execution, permissions,
+and prompt loading; tokenjuice does not intercept or rewrite IBM Bob tool output.
+
+`doctor bob` reports `ok` when the root `AGENTS.md` block exists, contains the
+`tokenjuice wrap` guidance, and does not advertise the older `--full` escape
+hatch. Malformed tokenjuice markers are reported as `broken` so project memory
+is not rewritten unsafely.

--- a/docs/client-bob.svg
+++ b/docs/client-bob.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">IBM Bob</title>
+  <desc id="desc">IBM Bob client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#0F172A"/>
+  <path d="M27 21h24c12 0 20 7 20 18 0 6-3 11-8 14 7 3 11 9 11 17 0 13-9 21-23 21H27V21Zm14 12v15h9c5 0 8-3 8-8s-3-7-8-7h-9Zm0 26v20h11c6 0 9-4 9-10s-4-10-10-10H41Z" fill="#F8FAFC"/>
+  <path d="M18 10h60v7H18zM18 79h60v7H18z" fill="#0F62FE"/>
+</svg>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -176,6 +176,7 @@ tokenjuice install codebuddy
 tokenjuice install amazon-q
 tokenjuice install antigravity
 tokenjuice install augment
+tokenjuice install bob
 tokenjuice install builder
 tokenjuice install crush
 tokenjuice install cursor
@@ -207,6 +208,7 @@ tokenjuice doctor opencode
 tokenjuice doctor amazon-q
 tokenjuice doctor antigravity
 tokenjuice doctor augment
+tokenjuice doctor bob
 tokenjuice doctor builder
 tokenjuice doctor crush
 tokenjuice doctor devin
@@ -251,6 +253,7 @@ supported host hooks:
 | Antigravity | `tokenjuice install antigravity` | `.agents/rules/tokenjuice.md` | ✴️ Beta. Installs an always-on workspace rule that tells Google Antigravity to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Antigravity rules do not intercept tool output; see `docs/antigravity-integration.md` |
 | Augment | `tokenjuice install augment` | `.augment/rules/tokenjuice.md` | ✴️ Beta. Installs an `always_apply` workspace rule that tells Augment and Auggie to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Augment rules do not intercept tool output; see `docs/augment-integration.md` |
 | Avante.nvim | `tokenjuice install avante` | `avante.md` | ✴️ Beta. Inserts a marker-delimited instruction block that tells Avante to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Avante instructions do not intercept tool output; see `docs/avante-integration.md` |
+| IBM Bob Shell | `tokenjuice install bob` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited context block into the current git/project root that tells IBM Bob Shell to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Bob context files do not intercept tool output; see `docs/bob-integration.md` |
 | Builder | `tokenjuice install builder` | `.builder/rules/tokenjuice.mdc` | ✴️ Beta. Installs an always-applied Builder Projects rule file that tells Builder and Fusion to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Builder configuration files do not intercept tool output; see `docs/builder-integration.md` |
 | Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Uses `PreToolUse` Bash input rewriting to route commands through `tokenjuice wrap` without bypassing Claude Code's own approval prompt; preserves unrelated hooks and migrates older Tokenjuice `PostToolUse` entries; `tokenjuice install claude-code --local` is available for repo-local verification |
 | Cline | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` | ✴️ Beta. Installs a global `PostToolUse` hook script for `execute_command`; enable it in Cline's Hooks tab after install; compacted context is injected through `contextModification`; `tokenjuice install cline --local` is available for repo-local verification; see `docs/cline-integration.md` |

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -20,6 +20,7 @@ import { doctorAiderConvention, installAiderConvention, uninstallAiderConvention
 import { doctorAntigravityRule, installAntigravityRule, uninstallAntigravityRule } from "../hosts/antigravity/index.js";
 import { doctorAugmentRule, installAugmentRule, uninstallAugmentRule } from "../hosts/augment/index.js";
 import { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "../hosts/avante/index.js";
+import { doctorBobInstructions, installBobInstructions, uninstallBobInstructions } from "../hosts/bob/index.js";
 import { doctorBuilderRule, installBuilderRule, uninstallBuilderRule } from "../hosts/builder/index.js";
 import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "../hosts/claude-code/index.js";
 import { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "../hosts/cline/index.js";
@@ -139,6 +140,7 @@ function printUsage(): void {
       "  tokenjuice install antigravity",
       "  tokenjuice install augment",
       "  tokenjuice install avante",
+      "  tokenjuice install bob",
       "  tokenjuice install builder",
       "  tokenjuice install codex [--local]",
       "  tokenjuice install claude-code [--local]",
@@ -187,6 +189,7 @@ function printUsage(): void {
       "  tokenjuice uninstall antigravity",
       "  tokenjuice uninstall augment",
       "  tokenjuice uninstall avante",
+      "  tokenjuice uninstall bob",
       "  tokenjuice uninstall builder",
       "  tokenjuice uninstall codex",
       "  tokenjuice uninstall cline",
@@ -229,7 +232,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -674,6 +677,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
       details.push({ label: "Backup", value: result.backupPath });
     }
     process.stdout.write(formatInstallSuccess("avante", "instructions", details));
+    return 0;
+  }
+
+  if (target === "bob") {
+    const result = await installBobInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Instructions", value: result.instructionsPath },
+      { label: "Beta", value: "instruction-based guidance; IBM Bob still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor bob" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("bob", "instructions", details));
     return 0;
   }
 
@@ -1539,7 +1562,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1625,6 +1648,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed avante instructions: ${result.removed ? "yes" : "no"}\n`);
     process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
     process.stdout.write("enable: tokenjuice install avante\n");
+    return 0;
+  }
+
+  if (target === "bob") {
+    const result = await uninstallBobInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed bob instructions: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
+    process.stdout.write("enable: tokenjuice install bob\n");
     return 0;
   }
 
@@ -2130,7 +2166,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -2448,6 +2484,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
 
   if (args.positionals[0] === "avante") {
     const report = await doctorAvanteInstructions();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "bob") {
+    const report = await doctorBobInstructions();
 
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/src/hosts/bob/index.ts
+++ b/src/hosts/bob/index.ts
@@ -1,0 +1,224 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type BobInstructionsOptions = {
+  projectDir?: string;
+};
+
+export type InstallBobInstructionsResult = {
+  instructionsPath: string;
+  backupPath?: string;
+};
+
+export type UninstallBobInstructionsResult = {
+  instructionsPath: string;
+  removed: boolean;
+};
+
+export type BobDoctorReport = {
+  instructionsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_BOB_FIX_COMMAND = "tokenjuice install bob";
+const TOKENJUICE_BOB_BEGIN = "<!-- tokenjuice:bob begin -->";
+const TOKENJUICE_BOB_END = "<!-- tokenjuice:bob end -->";
+const TOKENJUICE_BOB_ADVISORY = "IBM Bob support is beta and instruction-based; it guides command usage through project AGENTS.md but does not intercept tool output.";
+
+function getExplicitProjectDir(options: BobInstructionsOptions = {}): string | undefined {
+  return options.projectDir || process.env.BOB_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: BobInstructionsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultInstructionsPath(options: BobInstructionsOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), "AGENTS.md");
+}
+
+const TOKENJUICE_BOB_BLOCK = [
+  TOKENJUICE_BOB_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through IBM Bob, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_BOB_END,
+].join("\n");
+
+const TOKENJUICE_BOB_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_BOB_BEGIN,
+  endMarker: TOKENJUICE_BOB_END,
+  block: TOKENJUICE_BOB_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_BOB_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_BOB_END, beginIndex + TOKENJUICE_BOB_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_BOB_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_BOB_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_BOB_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installBobInstructions(
+  instructionsPath?: string,
+  options: BobInstructionsOptions = {},
+): Promise<InstallBobInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_BOB_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely repair malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice install bob`,
+    );
+  }
+
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_BOB_BLOCK_CONFIG);
+  return {
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallBobInstructions(
+  instructionsPath?: string,
+  options: BobInstructionsOptions = {},
+): Promise<UninstallBobInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_BOB_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely uninstall malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall bob`,
+    );
+  }
+
+  const result = await uninstallMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_BOB_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
+}
+
+export async function doctorBobInstructions(
+  instructionsPath?: string,
+  options: BobInstructionsOptions = {},
+): Promise<BobDoctorReport> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_BOB_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      instructionsPath: resolvedInstructionsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice IBM Bob instructions are not installed"],
+        advisory: TOKENJUICE_BOB_ADVISORY,
+        fixCommand: TOKENJUICE_BOB_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "IBM Bob instructions",
+    repairCommand: TOKENJUICE_BOB_FIX_COMMAND,
+  });
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured IBM Bob instructions have malformed tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured IBM Bob instructions are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured IBM Bob instructions are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured IBM Bob instructions still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    instructionsPath: resolvedInstructionsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_BOB_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from AGENTS.md, then run tokenjuice install bob"
+        : TOKENJUICE_BOB_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -4,6 +4,7 @@ import { doctorAmpInstructions } from "../amp/index.js";
 import { doctorAntigravityRule } from "../antigravity/index.js";
 import { doctorAugmentRule } from "../augment/index.js";
 import { doctorAvanteInstructions } from "../avante/index.js";
+import { doctorBobInstructions } from "../bob/index.js";
 import { doctorBuilderRule } from "../builder/index.js";
 import { doctorClaudeCodeHook } from "../claude-code/index.js";
 import { doctorClineHook } from "../cline/index.js";
@@ -52,6 +53,7 @@ import type { AmpDoctorReport, AmpInstructionsOptions } from "../amp/index.js";
 import type { AntigravityDoctorReport, AntigravityRuleOptions } from "../antigravity/index.js";
 import type { AugmentDoctorReport, AugmentRuleOptions } from "../augment/index.js";
 import type { AvanteDoctorReport } from "../avante/index.js";
+import type { BobDoctorReport, BobInstructionsOptions } from "../bob/index.js";
 import type { BuilderDoctorReport, BuilderRuleOptions } from "../builder/index.js";
 import type { ClaudeCodeDoctorReport, ClaudeCodeHookCommandOptions } from "../claude-code/index.js";
 import type { ClineDoctorReport } from "../cline/index.js";
@@ -103,6 +105,7 @@ export type HookIntegrationDoctorReport = {
   antigravity: AntigravityDoctorReport;
   augment: AugmentDoctorReport;
   avante: AvanteDoctorReport;
+  bob: BobDoctorReport;
   builder: BuilderDoctorReport;
   codex: CodexDoctorReport;
   "copilot-agent": CopilotAgentDoctorReport;
@@ -151,7 +154,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BobInstructionsOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -169,6 +172,7 @@ const hookDoctorIntegrationDoctors = {
   antigravity: (options) => doctorAntigravityRule(undefined, getHookCommandOptions(options)),
   augment: (options) => doctorAugmentRule(undefined, getHookCommandOptions(options)),
   avante: () => doctorAvanteInstructions(),
+  bob: (options) => doctorBobInstructions(undefined, getHookCommandOptions(options)),
   builder: (options) => doctorBuilderRule(undefined, getHookCommandOptions(options)),
   codex: (options) => doctorCodexHook(undefined, options),
   "claude-code": (options) => doctorClaudeCodeHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { doctorAntigravityRule, installAntigravityRule, uninstallAntigravityRule
 export { doctorAugmentRule, installAugmentRule, uninstallAugmentRule } from "./hosts/augment/index.js";
 export { doctorAvanteInstructions, installAvanteInstructions, uninstallAvanteInstructions } from "./hosts/avante/index.js";
 export { doctorAiderConvention, installAiderConvention, uninstallAiderConvention } from "./hosts/aider/index.js";
+export { doctorBobInstructions, installBobInstructions, uninstallBobInstructions } from "./hosts/bob/index.js";
 export { doctorBuilderRule, installBuilderRule, uninstallBuilderRule } from "./hosts/builder/index.js";
 export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "./hosts/claude-code/index.js";
 export { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "./hosts/cline/index.js";
@@ -143,6 +144,12 @@ export type {
   InstallAvanteInstructionsResult,
   UninstallAvanteInstructionsResult,
 } from "./hosts/avante/index.js";
+export type {
+  BobDoctorReport,
+  BobInstructionsOptions,
+  InstallBobInstructionsResult,
+  UninstallBobInstructionsResult,
+} from "./hosts/bob/index.js";
 export type {
   BuilderDoctorReport,
   BuilderRuleOptions,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/bob.test.ts
+++ b/test/hosts/bob.test.ts
@@ -1,0 +1,233 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorBobInstructions,
+  installBobInstructions,
+  uninstallBobInstructions,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "BUILDER_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_BUILD_PROJECT_DIR",
+  "GPTME_PROJECT_DIR",
+  "BOB_PROJECT_DIR",
+  "HOME",
+  "JULES_PROJECT_DIR",
+  "JUNIE_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "REPLIT_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "ROVO_DEV_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "TABNINE_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-bob-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("IBM Bob instructions", () => {
+  it("installs a host-specific marker-delimited AGENTS.md instruction block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    const result = await installBobInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(result.instructionsPath).toBe(instructionsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(instructions).toContain("<!-- tokenjuice:bob begin -->");
+    expect(instructions).toContain("tokenjuice terminal output compaction");
+    expect(instructions).toContain("When running terminal commands through IBM Bob");
+    expect(instructions).toContain("tokenjuice wrap -- <command>");
+    expect(instructions).toContain("tokenjuice wrap --raw -- <command>");
+    expect(instructions).not.toContain("wrap --full");
+  });
+
+  it("coexists with other tokenjuice AGENTS.md blocks", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "<!-- tokenjuice:jules begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through Jules, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:jules end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installBobInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("<!-- tokenjuice:jules begin -->");
+    expect(instructions).toContain("When running terminal commands through Jules");
+    expect(instructions).toContain("<!-- tokenjuice:bob begin -->");
+    expect(instructions).toContain("When running terminal commands through IBM Bob");
+  });
+
+  it("backs up existing project instructions before replacing its own block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await installBobInstructions(instructionsPath);
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const result = await installBobInstructions(instructionsPath);
+
+    expect(result.backupPath).toBe(`${instructionsPath}.bak`);
+    await expect(readFile(`${instructionsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    await expect(readFile(instructionsPath, "utf8")).resolves.toContain("<!-- tokenjuice:bob begin -->");
+  });
+
+  it("reports installed and uninstalled instruction health", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    await installBobInstructions(instructionsPath);
+    const installed = await doctorBobInstructions(instructionsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("instruction-based");
+
+    const removed = await uninstallBobInstructions(instructionsPath);
+    const disabled = await doctorBobInstructions(instructionsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(instructionsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports broken instructions with unmatched IBM Bob tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:bob begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorBobInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("reports broken instructions with nested IBM Bob tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "<!-- tokenjuice:bob begin -->",
+        "<!-- tokenjuice:bob begin -->",
+        "## tokenjuice terminal output compaction",
+        "",
+        "- When running terminal commands through IBM Bob, prefer `tokenjuice wrap -- <command>`.",
+        "- Use `tokenjuice wrap --raw -- <command>` only when exact raw output bytes are required.",
+        "<!-- tokenjuice:bob end -->",
+        "<!-- tokenjuice:bob end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorBobInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured IBM Bob instructions have malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+    await expect(installBobInstructions(instructionsPath)).rejects.toThrow("cannot safely repair malformed tokenjuice markers");
+    await expect(uninstallBobInstructions(instructionsPath)).rejects.toThrow(
+      "cannot safely uninstall malformed tokenjuice markers",
+    );
+  });
+
+  it("uses BOB_PROJECT_DIR for the default AGENTS.md path", async () => {
+    const home = await createTempDir();
+    process.env.BOB_PROJECT_DIR = home;
+
+    const installed = await installBobInstructions();
+    const expectedInstructionsPath = join(home, "AGENTS.md");
+    const doctor = await doctorBobInstructions();
+
+    expect(installed.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("defaults to the git root AGENTS.md from nested directories", async () => {
+    const home = await createTempDir();
+    await mkdir(join(home, ".git"));
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installBobInstructions();
+    const root = await realpath(home);
+
+    expect(installed.instructionsPath).toBe(join(root, "AGENTS.md"));
+    await expect(readFile(join(root, "AGENTS.md"), "utf8")).resolves.toContain("IBM Bob");
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await installBobInstructions(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.bob.instructionsPath).toBe(join(home, "AGENTS.md"));
+    expect(report.integrations.bob.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add a beta `bob` instruction integration that manages a marker-delimited IBM Bob block in project-root `AGENTS.md`
- resolve the default target from `BOB_PROJECT_DIR` or the nearest git/project root, and wire install, uninstall, doctor, aggregate doctor, exports, docs, changelog, and CLI host lists
- harden malformed-marker handling so direct and aggregate doctor report broken Bob blocks consistently before install/uninstall refuse unsafe rewrites

## Validation
- official IBM Bob Shell docs checked for `AGENTS.md` hierarchical context and configuration behavior; kept this guidance-only because Bob does not document a safe output-rewrite hook
- `pnpm exec vitest run test/hosts/bob.test.ts test/cli/doctor-output.test.ts` (2 files, 13 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- built CLI smoke: `--version`, `install bob`, inspect generated `AGENTS.md`, `doctor bob` ok, `uninstall bob`, `doctor bob` disabled from a nested git project
- `pnpm verify` (lint, circular dependency check, typecheck, 75 test files / 1161 tests)
- `git diff --check origin/main...HEAD && git diff --check`
- privacy scan over `git diff origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings)

## Review notes
- rebased onto current `origin/main`; this PR is now a single Bob commit instead of the old integration stack
- preserved current Tabnine, Trae, VS Code Copilot, Crush skill, and aggregate doctor behavior while resolving conflicts
- IBM Bob CLI is not installed in the local environment, so live validation covered the tokenjuice-managed file lifecycle rather than a real Bob session
