### PR TITLE
feat(codebuff): add instruction integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a beta Amazon Q Developer CLI workspace-rule integration.
 - Add a beta IBM Bob Shell context-file integration.
 - Add a beta Builder Projects rule integration.
+- Add a beta Codebuff instruction integration.
 - Add a beta Devin for Terminal PreToolUse hook integration.
 - Add a beta Firebase Studio AI-rules integration.
 - Add a beta gptme instruction integration.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ beta integrations:
 | <img width="48px" src="docs/client-bob.svg" alt="IBM Bob" /> | [IBM Bob Shell](https://bob.ibm.com/docs/shell/configuration/configuring) | `tokenjuice install bob` | `AGENTS.md` |
 | <img width="48px" src="docs/client-builder.svg" alt="Builder" /> | [Builder](https://www.builder.io/c/docs/projects-configuration-files) | `tokenjuice install builder` | `.builder/rules/tokenjuice.mdc` |
 | <img width="48px" src="docs/client-cline.svg" alt="Cline" /> | [Cline](https://docs.cline.bot/features/hooks/hook-reference) | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` |
+| <img width="48px" src="docs/client-codebuff.svg" alt="Codebuff" /> | [Codebuff](https://www.codebuff.com/docs/help/quick-start) | `tokenjuice install codebuff` | `AGENTS.md` |
 | <img width="48px" src="docs/client-continue.png" alt="Continue" /> | [Continue](https://docs.continue.dev/) | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` |
 | <img width="48px" src="docs/client-crush.svg" alt="Crush" /> | [Crush](https://github.com/charmbracelet/crush) | `tokenjuice install crush` | `.crush/skills/tokenjuice/SKILL.md` |
 | <img width="48px" src="docs/client-devin.svg" alt="Devin" /> | [Devin for Terminal](https://cli.devin.ai/docs/extensibility/hooks/overview) | `tokenjuice install devin` | `.devin/hooks.v1.json` |
@@ -90,8 +91,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -113,9 +114,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify
@@ -178,6 +179,7 @@ direct payload:
 - [IBM Bob integration](docs/bob-integration.md)
 - [Builder integration](docs/builder-integration.md)
 - [GitHub Copilot coding agent integration](docs/copilot-agent-integration.md)
+- [Codebuff integration](docs/codebuff-integration.md)
 - [Crush integration](docs/crush-integration.md)
 - [Cursor integration](docs/cursor-integration.md)
 - [CodeBuddy integration](docs/codebuddy-integration.md)

--- a/docs/client-codebuff.svg
+++ b/docs/client-codebuff.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">Codebuff</title>
+  <desc id="desc">Codebuff client mark for tokenjuice docs.</desc>
+  <rect width="96" height="96" rx="18" fill="#111827"/>
+  <path d="M69 68c-6 5-13 7-22 7-17 0-29-12-29-27s12-27 29-27c9 0 16 3 21 8l-8 10c-3-3-8-5-13-5-8 0-15 6-15 14s7 14 15 14c5 0 10-2 14-5l8 11Z" fill="#F8FAFC"/>
+  <path d="M52 47h10c8 0 13 5 13 13s-5 13-13 13H52V47Zm8 7v12h2c3 0 5-2 5-6s-2-6-5-6h-2Z" fill="#38BDF8"/>
+</svg>

--- a/docs/codebuff-integration.md
+++ b/docs/codebuff-integration.md
@@ -1,0 +1,40 @@
+# Codebuff integration
+
+Codebuff support is beta.
+
+`tokenjuice install codebuff` inserts a marker-delimited instruction block into
+`AGENTS.md` at the current git/project root. Codebuff's `/init` flow sets up
+project-specific files, and Codebuff documents that it reads existing
+`AGENTS.md` and `CLAUDE.md` files.
+
+```bash
+tokenjuice install codebuff
+tokenjuice doctor codebuff
+tokenjuice uninstall codebuff
+```
+
+By default tokenjuice resolves the nearest git root and writes `AGENTS.md`.
+Set `CODEBUFF_PROJECT_DIR=/path/to/repo` to target a specific repository in
+scripts or tests.
+
+The installed block tells Codebuff to use:
+
+```bash
+tokenjuice wrap -- <command>
+```
+
+for noisy terminal commands, and to reserve:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+for commands where exact output bytes are required.
+
+This is guidance-only. Codebuff still owns command execution, permissions,
+and prompt loading; tokenjuice does not intercept or rewrite Codebuff tool output.
+
+`doctor codebuff` reports `ok` when the root `AGENTS.md` block exists, contains the
+`tokenjuice wrap` guidance, and does not advertise the older `--full` escape
+hatch. Malformed tokenjuice markers are reported as `broken` so project memory
+is not rewritten unsafely.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,6 +173,7 @@ install host wiring when tokenjuice can own it directly:
 tokenjuice install codex
 tokenjuice install claude-code
 tokenjuice install codebuddy
+tokenjuice install codebuff
 tokenjuice install amazon-q
 tokenjuice install antigravity
 tokenjuice install augment
@@ -210,6 +211,7 @@ tokenjuice doctor antigravity
 tokenjuice doctor augment
 tokenjuice doctor bob
 tokenjuice doctor builder
+tokenjuice doctor codebuff
 tokenjuice doctor crush
 tokenjuice doctor devin
 tokenjuice doctor firebase-studio
@@ -257,6 +259,7 @@ supported host hooks:
 | Builder | `tokenjuice install builder` | `.builder/rules/tokenjuice.mdc` | ✴️ Beta. Installs an always-applied Builder Projects rule file that tells Builder and Fusion to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Builder configuration files do not intercept tool output; see `docs/builder-integration.md` |
 | Claude Code | `tokenjuice install claude-code` | `~/.claude/settings.json` | Uses `PreToolUse` Bash input rewriting to route commands through `tokenjuice wrap` without bypassing Claude Code's own approval prompt; preserves unrelated hooks and migrates older Tokenjuice `PostToolUse` entries; `tokenjuice install claude-code --local` is available for repo-local verification |
 | Cline | `tokenjuice install cline` | `~/Documents/Cline/Hooks/tokenjuice-post-tool-use` | ✴️ Beta. Installs a global `PostToolUse` hook script for `execute_command`; enable it in Cline's Hooks tab after install; compacted context is injected through `contextModification`; `tokenjuice install cline --local` is available for repo-local verification; see `docs/cline-integration.md` |
+| Codebuff | `tokenjuice install codebuff` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited project instruction block into the current git/project root that tells Codebuff to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Codebuff instruction files do not intercept tool output; see `docs/codebuff-integration.md` |
 | CodeBuddy (Linux/macOS/WSL) | `tokenjuice install codebuddy` | `~/.codebuddy/settings.json` | Uses `PreToolUse` shell input rewriting (same pattern as Cursor) to route Bash commands through `tokenjuice wrap`; preserves unrelated hooks that share a matcher group with the tokenjuice entry; `tokenjuice install codebuddy --local` is available for repo-local verification; native Windows shell interception is intentionally blocked for now; see `docs/codebuddy-integration.md` |
 | Codex CLI | `tokenjuice install codex` | `~/.codex/hooks.json` | `tokenjuice install codex --local` is available for repo-local verification |
 | Continue | `tokenjuice install continue` | `.continue/rules/tokenjuice.md` | ✴️ Beta. Installs a workspace rule that tells Continue agents to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Continue rules do not intercept tool output; see `docs/continue-integration.md` |

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,6 +24,7 @@ import { doctorBobInstructions, installBobInstructions, uninstallBobInstructions
 import { doctorBuilderRule, installBuilderRule, uninstallBuilderRule } from "../hosts/builder/index.js";
 import { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "../hosts/claude-code/index.js";
 import { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "../hosts/cline/index.js";
+import { doctorCodebuffInstructions, installCodebuffInstructions, uninstallCodebuffInstructions } from "../hosts/codebuff/index.js";
 import { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook } from "../hosts/codebuddy/index.js";
 import { doctorContinueRule, installContinueRule, uninstallContinueRule } from "../hosts/continue/index.js";
 import { doctorCodexHook, installCodexHook, runCodexPostToolUseHook, uninstallCodexHook } from "../hosts/codex/index.js";
@@ -145,6 +146,7 @@ function printUsage(): void {
       "  tokenjuice install codex [--local]",
       "  tokenjuice install claude-code [--local]",
       "  tokenjuice install cline [--local]",
+      "  tokenjuice install codebuff",
       "  tokenjuice install codebuddy [--local]",
       "  tokenjuice install continue",
       "  tokenjuice install copilot-agent [--local]",
@@ -193,6 +195,7 @@ function printUsage(): void {
       "  tokenjuice uninstall builder",
       "  tokenjuice uninstall codex",
       "  tokenjuice uninstall cline",
+      "  tokenjuice uninstall codebuff",
       "  tokenjuice uninstall continue",
       "  tokenjuice uninstall copilot-agent",
       "  tokenjuice uninstall crush",
@@ -232,7 +235,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|junie|jules|kimi|kiro|kilo|mistral-vibe|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -784,6 +787,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
       { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
     ];
     process.stdout.write(formatInstallSuccess("cline", "hook", details));
+    return 0;
+  }
+
+  if (target === "codebuff") {
+    const result = await installCodebuffInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Instructions", value: result.instructionsPath },
+      { label: "Beta", value: "instruction-based guidance; Codebuff still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor codebuff" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("codebuff", "instructions", details));
     return 0;
   }
 
@@ -1562,7 +1585,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1703,6 +1726,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed cline hook: ${result.removed ? "yes" : "no"}\n`);
     process.stdout.write(`hook path: ${result.hookPath}\n`);
     process.stdout.write("enable: tokenjuice install cline\n");
+    return 0;
+  }
+
+  if (target === "codebuff") {
+    const result = await uninstallCodebuffInstructions();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed codebuff instructions: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`instructions path: ${result.instructionsPath}\n`);
+    process.stdout.write("enable: tokenjuice install codebuff\n");
     return 0;
   }
 
@@ -2166,7 +2202,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, cline, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, cline, codebuff, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -3710,6 +3746,32 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
       process.stdout.write("missing paths:\n");
       for (const path of report.missingPaths) {
         process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "codebuff") {
+    const report = await doctorCodebuffInstructions();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`instructions path: ${report.instructionsPath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
       }
     }
     if (report.advisories.length > 0) {

--- a/src/hosts/codebuff/index.ts
+++ b/src/hosts/codebuff/index.ts
@@ -1,0 +1,224 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type CodebuffInstructionsOptions = {
+  projectDir?: string;
+};
+
+export type InstallCodebuffInstructionsResult = {
+  instructionsPath: string;
+  backupPath?: string;
+};
+
+export type UninstallCodebuffInstructionsResult = {
+  instructionsPath: string;
+  removed: boolean;
+};
+
+export type CodebuffDoctorReport = {
+  instructionsPath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_CODEBUFF_FIX_COMMAND = "tokenjuice install codebuff";
+const TOKENJUICE_CODEBUFF_BEGIN = "<!-- tokenjuice:codebuff begin -->";
+const TOKENJUICE_CODEBUFF_END = "<!-- tokenjuice:codebuff end -->";
+const TOKENJUICE_CODEBUFF_ADVISORY = "Codebuff support is beta and instruction-based; it guides command usage through project AGENTS.md but does not intercept tool output.";
+
+function getExplicitProjectDir(options: CodebuffInstructionsOptions = {}): string | undefined {
+  return options.projectDir || process.env.CODEBUFF_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: CodebuffInstructionsOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultInstructionsPath(options: CodebuffInstructionsOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), "AGENTS.md");
+}
+
+const TOKENJUICE_CODEBUFF_BLOCK = [
+  TOKENJUICE_CODEBUFF_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through Codebuff, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_CODEBUFF_END,
+].join("\n");
+
+const TOKENJUICE_CODEBUFF_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_CODEBUFF_BEGIN,
+  endMarker: TOKENJUICE_CODEBUFF_END,
+  block: TOKENJUICE_CODEBUFF_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_CODEBUFF_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_CODEBUFF_END, beginIndex + TOKENJUICE_CODEBUFF_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_CODEBUFF_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_CODEBUFF_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_CODEBUFF_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installCodebuffInstructions(
+  instructionsPath?: string,
+  options: CodebuffInstructionsOptions = {},
+): Promise<InstallCodebuffInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_CODEBUFF_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely repair malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice install codebuff`,
+    );
+  }
+
+  const result = await installMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_CODEBUFF_BLOCK_CONFIG);
+  return {
+    instructionsPath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallCodebuffInstructions(
+  instructionsPath?: string,
+  options: CodebuffInstructionsOptions = {},
+): Promise<UninstallCodebuffInstructionsResult> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_CODEBUFF_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely uninstall malformed tokenjuice markers in ${resolvedInstructionsPath}; remove the dangling marker manually, then rerun tokenjuice uninstall codebuff`,
+    );
+  }
+
+  const result = await uninstallMarkerDelimitedBlock(resolvedInstructionsPath, TOKENJUICE_CODEBUFF_BLOCK_CONFIG);
+  return { instructionsPath: result.filePath, removed: result.removed };
+}
+
+export async function doctorCodebuffInstructions(
+  instructionsPath?: string,
+  options: CodebuffInstructionsOptions = {},
+): Promise<CodebuffDoctorReport> {
+  const resolvedInstructionsPath = instructionsPath ?? (await getDefaultInstructionsPath(options));
+  const existing = await readInstructionFile(resolvedInstructionsPath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_CODEBUFF_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      instructionsPath: resolvedInstructionsPath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice Codebuff instructions are not installed"],
+        advisory: TOKENJUICE_CODEBUFF_ADVISORY,
+        fixCommand: TOKENJUICE_CODEBUFF_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "Codebuff instructions",
+    repairCommand: TOKENJUICE_CODEBUFF_FIX_COMMAND,
+  });
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured Codebuff instructions have malformed tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured Codebuff instructions are missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured Codebuff instructions are missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured Codebuff instructions still suggest the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    instructionsPath: resolvedInstructionsPath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_CODEBUFF_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from AGENTS.md, then run tokenjuice install codebuff"
+        : TOKENJUICE_CODEBUFF_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -8,6 +8,7 @@ import { doctorBobInstructions } from "../bob/index.js";
 import { doctorBuilderRule } from "../builder/index.js";
 import { doctorClaudeCodeHook } from "../claude-code/index.js";
 import { doctorClineHook } from "../cline/index.js";
+import { doctorCodebuffInstructions } from "../codebuff/index.js";
 import { doctorCodeBuddyHook } from "../codebuddy/index.js";
 import { doctorContinueRule } from "../continue/index.js";
 import { doctorCodexHook } from "../codex/index.js";
@@ -57,6 +58,7 @@ import type { BobDoctorReport, BobInstructionsOptions } from "../bob/index.js";
 import type { BuilderDoctorReport, BuilderRuleOptions } from "../builder/index.js";
 import type { ClaudeCodeDoctorReport, ClaudeCodeHookCommandOptions } from "../claude-code/index.js";
 import type { ClineDoctorReport } from "../cline/index.js";
+import type { CodebuffDoctorReport, CodebuffInstructionsOptions } from "../codebuff/index.js";
 import type { CodeBuddyDoctorReport, CodeBuddyHookCommandOptions } from "../codebuddy/index.js";
 import type { ContinueDoctorReport } from "../continue/index.js";
 import type { CodexDoctorReport, CodexHookCommandOptions } from "../codex/index.js";
@@ -111,6 +113,7 @@ export type HookIntegrationDoctorReport = {
   "copilot-agent": CopilotAgentDoctorReport;
   "claude-code": ClaudeCodeDoctorReport;
   cline: ClineDoctorReport;
+  codebuff: CodebuffDoctorReport;
   codebuddy: CodeBuddyDoctorReport;
   continue: ContinueDoctorReport;
   crush: CrushDoctorReport;
@@ -154,7 +157,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BobInstructionsOptions & BuilderRuleOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BobInstructionsOptions & BuilderRuleOptions & CodebuffInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -177,6 +180,7 @@ const hookDoctorIntegrationDoctors = {
   codex: (options) => doctorCodexHook(undefined, options),
   "claude-code": (options) => doctorClaudeCodeHook(undefined, getHookCommandOptions(options)),
   cline: (options) => doctorClineHook(undefined, getHookCommandOptions(options)),
+  codebuff: (options) => doctorCodebuffInstructions(undefined, getHookCommandOptions(options)),
   codebuddy: (options) => doctorCodeBuddyHook(undefined, getHookCommandOptions(options)),
   continue: () => doctorContinueRule(),
   "copilot-agent": (options) => doctorCopilotAgentHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { doctorBobInstructions, installBobInstructions, uninstallBobInstructions
 export { doctorBuilderRule, installBuilderRule, uninstallBuilderRule } from "./hosts/builder/index.js";
 export { doctorClaudeCodeHook, installClaudeCodeHook, runClaudeCodePostToolUseHook, runClaudeCodePreToolUseHook } from "./hosts/claude-code/index.js";
 export { doctorClineHook, installClineHook, runClinePostToolUseHook, uninstallClineHook } from "./hosts/cline/index.js";
+export { doctorCodebuffInstructions, installCodebuffInstructions, uninstallCodebuffInstructions } from "./hosts/codebuff/index.js";
 export { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook } from "./hosts/codebuddy/index.js";
 export { doctorContinueRule, installContinueRule, uninstallContinueRule } from "./hosts/continue/index.js";
 export {
@@ -163,6 +164,12 @@ export type {
   InstallClineHookResult,
   UninstallClineHookResult,
 } from "./hosts/cline/index.js";
+export type {
+  CodebuffDoctorReport,
+  CodebuffInstructionsOptions,
+  InstallCodebuffInstructionsResult,
+  UninstallCodebuffInstructionsResult,
+} from "./hosts/codebuff/index.js";
 export type {
   ContinueDoctorReport,
   ContinueRuleOptions,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, junie, jules, kimi, kiro, kilo, mistral-vibe, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/codebuff.test.ts
+++ b/test/hosts/codebuff.test.ts
@@ -1,0 +1,229 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorInstalledHooks,
+  doctorCodebuffInstructions,
+  installCodebuffInstructions,
+  uninstallCodebuffInstructions,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "BUILDER_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GROK_BUILD_PROJECT_DIR",
+  "GPTME_PROJECT_DIR",
+  "CODEBUFF_PROJECT_DIR",
+  "HOME",
+  "JULES_PROJECT_DIR",
+  "JUNIE_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KILO_PROJECT_DIR",
+  "KIRO_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "REPLIT_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "ROVO_DEV_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "TABNINE_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+const originalCwd = process.cwd();
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-codebuff-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("Codebuff instructions", () => {
+  it("installs a host-specific marker-delimited AGENTS.md instruction block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    const result = await installCodebuffInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(result.instructionsPath).toBe(instructionsPath);
+    expect(result.backupPath).toBeUndefined();
+    expect(instructions).toContain("<!-- tokenjuice:codebuff begin -->");
+    expect(instructions).toContain("tokenjuice terminal output compaction");
+    expect(instructions).toContain("When running terminal commands through Codebuff");
+    expect(instructions).toContain("tokenjuice wrap -- <command>");
+    expect(instructions).toContain("tokenjuice wrap --raw -- <command>");
+    expect(instructions).not.toContain("wrap --full");
+  });
+
+  it("coexists with other tokenjuice AGENTS.md blocks", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "# project instructions",
+        "",
+        "<!-- tokenjuice:jules begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through Jules, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:jules end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installCodebuffInstructions(instructionsPath);
+    const instructions = await readFile(instructionsPath, "utf8");
+
+    expect(instructions).toContain("<!-- tokenjuice:jules begin -->");
+    expect(instructions).toContain("When running terminal commands through Jules");
+    expect(instructions).toContain("<!-- tokenjuice:codebuff begin -->");
+    expect(instructions).toContain("When running terminal commands through Codebuff");
+  });
+
+  it("backs up existing project instructions before replacing its own block", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await installCodebuffInstructions(instructionsPath);
+    await writeFile(instructionsPath, "# project instructions\n\n- keep this\n", "utf8");
+
+    const result = await installCodebuffInstructions(instructionsPath);
+
+    expect(result.backupPath).toBe(`${instructionsPath}.bak`);
+    await expect(readFile(`${instructionsPath}.bak`, "utf8")).resolves.toContain("keep this");
+    await expect(readFile(instructionsPath, "utf8")).resolves.toContain("<!-- tokenjuice:codebuff begin -->");
+  });
+
+  it("reports installed and uninstalled instruction health", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+
+    await installCodebuffInstructions(instructionsPath);
+    const installed = await doctorCodebuffInstructions(instructionsPath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("instruction-based");
+
+    const removed = await uninstallCodebuffInstructions(instructionsPath);
+    const disabled = await doctorCodebuffInstructions(instructionsPath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+    await expect(access(instructionsPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports broken instructions with unmatched Codebuff tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(instructionsPath, "<!-- tokenjuice:codebuff begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorCodebuffInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+  });
+
+  it("reports broken instructions with nested Codebuff tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const instructionsPath = join(home, "AGENTS.md");
+    await writeFile(
+      instructionsPath,
+      [
+        "<!-- tokenjuice:codebuff begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through Codebuff, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:codebuff begin -->",
+        "- Use `tokenjuice wrap --raw -- <command>` to preserve exact output.",
+        "<!-- tokenjuice:codebuff end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorCodebuffInstructions(instructionsPath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured Codebuff instructions have malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+    await expect(installCodebuffInstructions(instructionsPath)).rejects.toThrow("cannot safely repair malformed tokenjuice markers");
+    await expect(uninstallCodebuffInstructions(instructionsPath)).rejects.toThrow("cannot safely uninstall malformed tokenjuice markers");
+  });
+
+  it("uses CODEBUFF_PROJECT_DIR for the default AGENTS.md path", async () => {
+    const home = await createTempDir();
+    process.env.CODEBUFF_PROJECT_DIR = home;
+
+    const installed = await installCodebuffInstructions();
+    const expectedInstructionsPath = join(home, "AGENTS.md");
+    const doctor = await doctorCodebuffInstructions();
+
+    expect(installed.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.instructionsPath).toBe(expectedInstructionsPath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("defaults to the git root AGENTS.md from nested directories", async () => {
+    const home = await createTempDir();
+    await mkdir(join(home, ".git"));
+    const nestedDir = join(home, "packages", "app");
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installCodebuffInstructions();
+    const root = await realpath(home);
+
+    expect(installed.instructionsPath).toBe(join(root, "AGENTS.md"));
+    await expect(readFile(join(root, "AGENTS.md"), "utf8")).resolves.toContain("Codebuff");
+  });
+
+  it("is included in aggregate hook doctor output", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+    await installCodebuffInstructions(undefined, { projectDir: home });
+
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations.codebuff.instructionsPath).toBe(join(home, "AGENTS.md"));
+    expect(report.integrations.codebuff.status).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add a beta `codebuff` instruction integration that manages a marker-delimited Codebuff block in project-root `AGENTS.md`
- resolve the default target from `CODEBUFF_PROJECT_DIR` or the nearest git/project root, and wire install, uninstall, doctor, aggregate doctor, exports, docs, changelog, and CLI host lists
- harden malformed-marker handling so direct and aggregate doctor report broken Codebuff blocks consistently before install/uninstall refuse unsafe rewrites

## Validation
- official Codebuff docs checked for `/init`, existing `AGENTS.md`/`CLAUDE.md` loading, and command behavior; kept this guidance-only because Codebuff does not document a safe output-rewrite hook
- `pnpm exec vitest run test/hosts/codebuff.test.ts test/cli/doctor-output.test.ts` (2 files, 13 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- built CLI smoke: `--version`, `install codebuff`, inspect generated `AGENTS.md`, `doctor codebuff` ok, `uninstall codebuff`, `doctor codebuff` disabled from a nested git project
- `pnpm verify` (lint, circular dependency check, typecheck, 76 test files / 1170 tests)
- `git diff --check origin/main...HEAD && git diff --check`
- privacy scan over `git diff origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings)

## Review notes
- rebased onto current `origin/main`; this PR is now a single Codebuff commit instead of the old integration stack
- preserved current Bob, Tabnine, Trae, VS Code Copilot, Crush skill, and aggregate doctor behavior while resolving conflicts
- Codebuff CLI is not installed in the local environment, so live validation covered the tokenjuice-managed file lifecycle rather than a real Codebuff session
