### PR TITLE
feat(gitlab-duo): add custom rules integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a beta Codebuff instruction integration.
 - Add a beta Devin for Terminal PreToolUse hook integration.
 - Add a beta Firebase Studio AI-rules integration.
+- Add a beta GitLab Duo custom-rules integration.
 - Add a beta gptme instruction integration.
 - Add a beta JetBrains AI Assistant project-rule integration.
 - Add a beta Jules instruction integration.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ beta integrations:
 | <img width="48px" src="docs/client-devin.svg" alt="Devin" /> | [Devin for Terminal](https://cli.devin.ai/docs/extensibility/hooks/overview) | `tokenjuice install devin` | `.devin/hooks.v1.json` |
 | <img width="48px" src="docs/client-firebase-studio.svg" alt="Firebase Studio" /> | [Firebase Studio](https://firebase.google.com/docs/studio/set-up-gemini) | `tokenjuice install firebase-studio` | `.idx/airules.md` |
 | <img width="48px" src="docs/client-gemini.png" alt="Gemini" /> | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` |
+| <img width="48px" src="docs/client-gitlab-duo.svg" alt="GitLab Duo" /> | [GitLab Duo Agent Platform](https://docs.gitlab.com/user/duo_agent_platform/customize/custom_rules/) | `tokenjuice install gitlab-duo` | `.gitlab/duo/chat-rules.md` |
 | <img width="48px" src="docs/client-goose.svg" alt="Goose" /> | [Goose](https://goose-docs.ai/) | `tokenjuice install goose` | `.goosehints` |
 | <img width="48px" src="docs/client-grok-build.svg" alt="Grok Build" /> | [Grok Build](https://docs.x.ai/build/overview) | `tokenjuice install grok-build` | `AGENTS.md` |
 | <img width="48px" src="docs/client-grok-cli.svg" alt="Grok CLI" /> | [Grok CLI](https://github.com/superagent-ai/grok-cli) | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` |
@@ -94,8 +95,8 @@ then:
 ```bash
 tokenjuice --help
 tokenjuice --version
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
 ```
 
 OpenClaw support is bundled on the OpenClaw side. Do not run
@@ -117,9 +118,9 @@ tokenjuice reduce-json [file]
 tokenjuice wrap -- <command> [args...]
 tokenjuice wrap --raw -- <command> [args...]
 tokenjuice wrap --store -- <command> [args...]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
-tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder] --local
-tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
+tokenjuice install [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder] --local
+tokenjuice uninstall [aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|cline|codebuff|continue|copilot-agent|crush|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|copilot-cli|zed|zencoder]
 tokenjuice ls
 tokenjuice cat <artifact-id>
 tokenjuice verify

--- a/docs/client-gitlab-duo.svg
+++ b/docs/client-gitlab-duo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="GitLab Duo">
+  <rect width="64" height="64" rx="12" fill="#171321"/>
+  <path d="M32 50 13 36l4-22 9 17h12l9-17 4 22-19 14Z" fill="#fc6d26"/>
+  <path d="M26 31 17 14l15 36 15-36-9 17H26Z" fill="#fca326"/>
+  <path d="M13 36h38L32 50 13 36Z" fill="#e24329"/>
+</svg>

--- a/docs/gitlab-duo-integration.md
+++ b/docs/gitlab-duo-integration.md
@@ -1,0 +1,41 @@
+# GitLab Duo integration
+
+GitLab Duo support is beta.
+
+`tokenjuice install gitlab-duo` inserts a marker-delimited custom-rules block
+into `.gitlab/duo/chat-rules.md`. GitLab documents this file as the project
+custom-rules path for GitLab Duo Agent Platform.
+
+```bash
+tokenjuice install gitlab-duo
+tokenjuice doctor gitlab-duo
+tokenjuice uninstall gitlab-duo
+```
+
+By default tokenjuice resolves the nearest git root and writes the rule there.
+Set `GITLAB_DUO_PROJECT_DIR=/path/to/repo` to target a specific repository in
+scripts or tests.
+
+The installed rule tells GitLab Duo agents to use:
+
+```bash
+tokenjuice wrap -- <command>
+```
+
+for terminal commands likely to produce long output, and to use:
+
+```bash
+tokenjuice wrap --raw -- <command>
+```
+
+only when raw output is genuinely required.
+
+Existing `.gitlab/duo/chat-rules.md` content is backed up before install and
+preserved outside the managed tokenjuice block. Uninstall removes only the
+tokenjuice block.
+
+GitLab Duo also supports `AGENTS.md`, but tokenjuice uses the host-specific
+custom-rules file to avoid mutating a shared cross-tool instruction file.
+
+`doctor gitlab-duo` reports `ok` when the managed block is present and contains
+the expected wrap guidance.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -183,6 +183,7 @@ tokenjuice install crush
 tokenjuice install cursor
 tokenjuice install devin
 tokenjuice install firebase-studio
+tokenjuice install gitlab-duo
 tokenjuice install grok-build
 tokenjuice install grok-cli
 tokenjuice install gptme
@@ -218,6 +219,7 @@ tokenjuice doctor codebuff
 tokenjuice doctor crush
 tokenjuice doctor devin
 tokenjuice doctor firebase-studio
+tokenjuice doctor gitlab-duo
 tokenjuice doctor grok-build
 tokenjuice doctor grok-cli
 tokenjuice doctor gptme
@@ -275,6 +277,7 @@ supported host hooks:
 | Droid (Factory CLI) | `tokenjuice install droid` | `~/.factory/settings.json` | Uses a `PostToolUse` hook for the `Execute` tool to compact shell output before Droid sees it; preserves unrelated settings keys; `tokenjuice install droid --local` is available for repo-local verification |
 | Firebase Studio | `tokenjuice install firebase-studio` | `.idx/airules.md` | ✴️ Beta. Inserts a marker-delimited AI rules block that tells Gemini in Firebase chat to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Firebase Studio rules do not intercept command output; see `docs/firebase-studio-integration.md` |
 | Gemini CLI | `tokenjuice install gemini-cli` | `~/.gemini/settings.json` | ✴️ Beta. Uses an `AfterTool` hook for `run_shell_command` to compact shell output before Gemini CLI sees it; `tokenjuice install gemini-cli --local` is available for repo-local verification; see `docs/gemini-cli-integration.md` |
+| GitLab Duo Agent Platform | `tokenjuice install gitlab-duo` | `.gitlab/duo/chat-rules.md` | ✴️ Beta. Inserts a marker-delimited custom-rules block that tells GitLab Duo to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because GitLab Duo custom rules do not intercept command output; see `docs/gitlab-duo-integration.md` |
 | Goose | `tokenjuice install goose` | `.goosehints` | ✴️ Beta. Inserts a marker-delimited hints block that tells Goose to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Goose hints do not intercept tool output; restart the Goose session after install; see `docs/goose-integration.md` |
 | Grok Build | `tokenjuice install grok-build` | `AGENTS.md` | ✴️ Beta. Inserts a marker-delimited instruction block into the current git/project root that tells Grok Build to use `tokenjuice wrap` for noisy terminal commands and `tokenjuice wrap --raw -- <command>` only when raw bytes are needed; guidance-only, because Grok Build instructions do not intercept command output; see `docs/grok-build-integration.md` |
 | Grok CLI | `tokenjuice install grok-cli` | `~/.grok/user-settings.json` | ✴️ Beta. Uses a user-level `PostToolUse` hook for the `bash` tool; compacted context is injected alongside the original output; `tokenjuice install grok-cli --local` is available for repo-local verification; see `docs/grok-cli-integration.md` |

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -42,6 +42,7 @@ import { doctorDevinHook, installDevinHook, runDevinPreToolUseHook, uninstallDev
 import { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "../hosts/droid/index.js";
 import { doctorFirebaseStudioRule, installFirebaseStudioRule, uninstallFirebaseStudioRule } from "../hosts/firebase-studio/index.js";
 import { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "../hosts/gemini-cli/index.js";
+import { doctorGitLabDuoRule, installGitLabDuoRule, uninstallGitLabDuoRule } from "../hosts/gitlab-duo/index.js";
 import { doctorGooseHints, installGooseHints, uninstallGooseHints } from "../hosts/goose/index.js";
 import { doctorGrokBuildInstructions, installGrokBuildInstructions, uninstallGrokBuildInstructions } from "../hosts/grok-build/index.js";
 import { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "../hosts/grok-cli/index.js";
@@ -159,6 +160,7 @@ function printUsage(): void {
       "  tokenjuice install droid [--local]",
       "  tokenjuice install firebase-studio",
       "  tokenjuice install gemini-cli [--local]",
+      "  tokenjuice install gitlab-duo",
       "  tokenjuice install goose",
       "  tokenjuice install grok-build",
       "  tokenjuice install grok-cli [--local]",
@@ -209,6 +211,7 @@ function printUsage(): void {
       "  tokenjuice uninstall droid",
       "  tokenjuice uninstall firebase-studio",
       "  tokenjuice uninstall gemini-cli",
+      "  tokenjuice uninstall gitlab-duo",
       "  tokenjuice uninstall goose",
       "  tokenjuice uninstall grok-build",
       "  tokenjuice uninstall grok-cli",
@@ -244,7 +247,7 @@ function printUsage(): void {
       "  tokenjuice cat <artifact-id>",
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
-      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|zencoder|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor [file|hooks|aider|amazon-q|amp|antigravity|augment|avante|bob|builder|codex|claude-code|cline|codebuff|codebuddy|continue|copilot-agent|crush|cursor|devin|droid|firebase-studio|gemini-cli|gitlab-duo|goose|grok-build|grok-cli|gptme|jetbrains-ai|junie|jules|kimi|kiro|kilo|mistral-vibe|mux|openhands|open-interpreter|openwebui|pi|opencode|plandex|qoder|qwen-code|replit|roo|rovo|ruler|tabnine|trae|vscode-copilot|warp|windsurf|zed|zencoder|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -979,6 +982,26 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
+  if (target === "gitlab-duo") {
+    const result = await installGitLabDuoRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    const details = [
+      { label: "Rule", value: result.rulePath },
+      { label: "Beta", value: "custom-rules guidance; GitLab Duo still owns command execution" },
+      { label: "Verify", value: "tokenjuice doctor gitlab-duo" },
+      { label: "Escape hatch", value: "tokenjuice wrap --raw -- <command>" },
+    ];
+    if (result.backupPath) {
+      details.push({ label: "Backup", value: result.backupPath });
+    }
+    process.stdout.write(formatInstallSuccess("gitlab-duo", "rule", details));
+    return 0;
+  }
+
   if (target === "grok-cli") {
     const result = await installGrokCliHook(undefined, { local: args.local });
     if (args.format === "json") {
@@ -1655,7 +1678,7 @@ async function runInstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed, zencoder");
+  throw new Error("install currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, gitlab-duo, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed, zencoder");
 }
 
 async function runUninstall(args: ParsedArgs): Promise<number> {
@@ -1877,6 +1900,19 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     process.stdout.write(`removed gemini-cli entries: ${result.removed}\n`);
     process.stdout.write(`settings path: ${result.settingsPath}\n`);
     process.stdout.write("enable: tokenjuice install gemini-cli\n");
+    return 0;
+  }
+
+  if (target === "gitlab-duo") {
+    const result = await uninstallGitLabDuoRule();
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+
+    process.stdout.write(`removed gitlab-duo rule: ${result.removed ? "yes" : "no"}\n`);
+    process.stdout.write(`rule path: ${result.rulePath}\n`);
+    process.stdout.write("enable: tokenjuice install gitlab-duo\n");
     return 0;
   }
 
@@ -2311,7 +2347,7 @@ async function runUninstall(args: ParsedArgs): Promise<number> {
     return 0;
   }
 
-  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, cline, codebuff, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed, zencoder");
+  throw new Error("uninstall currently supports: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, cline, codebuff, continue, copilot-agent, crush, devin, droid, firebase-studio, gemini-cli, gitlab-duo, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, opencode, plandex, qoder, replit, qwen-code, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, copilot-cli, zed, zencoder");
 }
 
 async function runList(args: ParsedArgs): Promise<number> {
@@ -3104,6 +3140,38 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
     if (report.detectedCommand) {
       process.stdout.write(`configured command: ${report.detectedCommand}\n`);
     }
+    if (report.issues.length > 0) {
+      process.stdout.write("issues:\n");
+      for (const issue of report.issues) {
+        process.stdout.write(`- ${issue}\n`);
+      }
+    }
+    if (report.missingPaths.length > 0) {
+      process.stdout.write("missing paths:\n");
+      for (const path of report.missingPaths) {
+        process.stdout.write(`- ${path}\n`);
+      }
+    }
+    if (report.advisories.length > 0) {
+      process.stdout.write("advisories:\n");
+      for (const advisory of report.advisories) {
+        process.stdout.write(`- ${advisory}\n`);
+      }
+    }
+    process.stdout.write(`repair: ${report.fixCommand}\n`);
+    return report.status === "broken" ? 1 : 0;
+  }
+
+  if (args.positionals[0] === "gitlab-duo") {
+    const report = await doctorGitLabDuoRule();
+
+    if (args.format === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      return report.status === "broken" ? 1 : 0;
+    }
+
+    process.stdout.write(`rule path: ${report.rulePath}\n`);
+    process.stdout.write(`health: ${report.status}\n`);
     if (report.issues.length > 0) {
       process.stdout.write("issues:\n");
       for (const issue of report.issues) {

--- a/src/hosts/gitlab-duo/index.ts
+++ b/src/hosts/gitlab-duo/index.ts
@@ -1,0 +1,225 @@
+import { stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  collectMarkerDelimitedBlockIssues,
+  inspectMarkerDelimitedBlock,
+  installMarkerDelimitedBlock,
+  uninstallMarkerDelimitedBlock,
+} from "../shared/marker-instructions.js";
+import {
+  buildTokenjuiceGuidanceBullets,
+  TOKENJUICE_FULL_COMMAND,
+  TOKENJUICE_RAW_COMMAND,
+  TOKENJUICE_WRAP_COMMAND,
+} from "../shared/instruction-guidance.js";
+import {
+  buildInstructionDoctorReportFields,
+  instructionDoctorStatusFromIssues,
+} from "../shared/instruction-doctor.js";
+import { collectGuidanceIssues, readInstructionFile } from "../shared/instruction-file.js";
+
+export type GitLabDuoRuleOptions = {
+  projectDir?: string;
+};
+
+export type InstallGitLabDuoRuleResult = {
+  rulePath: string;
+  backupPath?: string;
+};
+
+export type UninstallGitLabDuoRuleResult = {
+  rulePath: string;
+  removed: boolean;
+};
+
+export type GitLabDuoDoctorReport = {
+  rulePath: string;
+  status: "ok" | "warn" | "broken" | "disabled";
+  issues: string[];
+  advisories: string[];
+  fixCommand: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+};
+
+const TOKENJUICE_GITLAB_DUO_FIX_COMMAND = "tokenjuice install gitlab-duo";
+const TOKENJUICE_GITLAB_DUO_BEGIN = "<!-- tokenjuice:gitlab-duo begin -->";
+const TOKENJUICE_GITLAB_DUO_END = "<!-- tokenjuice:gitlab-duo end -->";
+const TOKENJUICE_GITLAB_DUO_ADVISORY =
+  "GitLab Duo support is beta and custom-rules based; Duo still owns command execution.";
+
+function getExplicitProjectDir(options: GitLabDuoRuleOptions = {}): string | undefined {
+  return options.projectDir || process.env.GITLAB_DUO_PROJECT_DIR;
+}
+
+async function hasGitMetadata(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findGitRoot(startDir: string): Promise<string | undefined> {
+  let current = resolve(startDir);
+  while (true) {
+    if (await hasGitMetadata(current)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+async function resolveProjectDir(options: GitLabDuoRuleOptions = {}): Promise<string> {
+  const explicitProjectDir = getExplicitProjectDir(options);
+  if (explicitProjectDir) {
+    return resolve(explicitProjectDir);
+  }
+
+  return (await findGitRoot(process.cwd())) ?? process.cwd();
+}
+
+async function getDefaultRulePath(options: GitLabDuoRuleOptions = {}): Promise<string> {
+  return join(await resolveProjectDir(options), ".gitlab", "duo", "chat-rules.md");
+}
+
+const TOKENJUICE_GITLAB_DUO_BLOCK = [
+  TOKENJUICE_GITLAB_DUO_BEGIN,
+  "## tokenjuice terminal output compaction",
+  "",
+  ...buildTokenjuiceGuidanceBullets({
+    wrapBullet: "- When running terminal commands through GitLab Duo Agent Platform, prefer `tokenjuice wrap -- <command>` for commands likely to produce long output.",
+  }),
+  TOKENJUICE_GITLAB_DUO_END,
+].join("\n");
+
+const TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG = {
+  beginMarker: TOKENJUICE_GITLAB_DUO_BEGIN,
+  endMarker: TOKENJUICE_GITLAB_DUO_END,
+  block: TOKENJUICE_GITLAB_DUO_BLOCK,
+};
+
+function getTokenjuiceBlockText(text: string): string {
+  const beginIndex = text.indexOf(TOKENJUICE_GITLAB_DUO_BEGIN);
+  if (beginIndex === -1) {
+    return "";
+  }
+  const endIndex = text.indexOf(TOKENJUICE_GITLAB_DUO_END, beginIndex + TOKENJUICE_GITLAB_DUO_BEGIN.length);
+  if (endIndex === -1) {
+    return text.slice(beginIndex);
+  }
+  return text.slice(beginIndex, endIndex + TOKENJUICE_GITLAB_DUO_END.length);
+}
+
+function countMarker(text: string, marker: string): number {
+  return text.split(marker).length - 1;
+}
+
+function hasMalformedMarkerStructure(text: string, completeBlockCount: number): boolean {
+  const beginCount = countMarker(text, TOKENJUICE_GITLAB_DUO_BEGIN);
+  const endCount = countMarker(text, TOKENJUICE_GITLAB_DUO_END);
+  return beginCount !== endCount || beginCount !== completeBlockCount || endCount !== completeBlockCount;
+}
+
+export async function installGitLabDuoRule(
+  rulePath?: string,
+  options: GitLabDuoRuleOptions = {},
+): Promise<InstallGitLabDuoRuleResult> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely repair malformed tokenjuice markers in ${resolvedRulePath}; remove the dangling marker manually, then rerun tokenjuice install gitlab-duo`,
+    );
+  }
+
+  const result = await installMarkerDelimitedBlock(resolvedRulePath, TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG);
+  return {
+    rulePath: result.filePath,
+    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
+  };
+}
+
+export async function uninstallGitLabDuoRule(
+  rulePath?: string,
+  options: GitLabDuoRuleOptions = {},
+): Promise<UninstallGitLabDuoRuleResult> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG);
+  if (existing.exists && hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount)) {
+    throw new Error(
+      `cannot safely uninstall malformed tokenjuice markers in ${resolvedRulePath}; remove the dangling marker manually, then rerun tokenjuice uninstall gitlab-duo`,
+    );
+  }
+
+  const result = await uninstallMarkerDelimitedBlock(resolvedRulePath, TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG);
+  return { rulePath: result.filePath, removed: result.removed };
+}
+
+export async function doctorGitLabDuoRule(
+  rulePath?: string,
+  options: GitLabDuoRuleOptions = {},
+): Promise<GitLabDuoDoctorReport> {
+  const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
+  const existing = await readInstructionFile(resolvedRulePath);
+  const markerState = inspectMarkerDelimitedBlock(existing.text, TOKENJUICE_GITLAB_DUO_BLOCK_CONFIG);
+  if (!existing.exists || (!markerState.hasBegin && !markerState.hasEnd)) {
+    return {
+      rulePath: resolvedRulePath,
+      ...buildInstructionDoctorReportFields({
+        status: "disabled",
+        issues: ["tokenjuice GitLab Duo rule is not installed"],
+        advisory: TOKENJUICE_GITLAB_DUO_ADVISORY,
+        fixCommand: TOKENJUICE_GITLAB_DUO_FIX_COMMAND,
+      }),
+    };
+  }
+
+  const markerIssues = collectMarkerDelimitedBlockIssues(markerState, {
+    configuredLabel: "GitLab Duo rule",
+    repairCommand: TOKENJUICE_GITLAB_DUO_FIX_COMMAND,
+  });
+  const hasMalformedMarkers = hasMalformedMarkerStructure(existing.text, markerState.completeBlockCount);
+  const issues = [
+    ...markerIssues,
+    ...(hasMalformedMarkers ? ["configured GitLab Duo rule has malformed tokenjuice markers"] : []),
+    ...collectGuidanceIssues(getTokenjuiceBlockText(existing.text), {
+      required: [
+        {
+          requiredText: TOKENJUICE_WRAP_COMMAND,
+          missingIssue: "configured GitLab Duo rule is missing tokenjuice wrap guidance",
+        },
+        {
+          requiredText: TOKENJUICE_RAW_COMMAND,
+          missingIssue: "configured GitLab Duo rule is missing the raw escape hatch",
+        },
+      ],
+      forbidden: [
+        {
+          forbiddenText: TOKENJUICE_FULL_COMMAND,
+          presentIssue: "configured GitLab Duo rule still suggests the full escape hatch",
+        },
+      ],
+    }),
+  ];
+
+  return {
+    rulePath: resolvedRulePath,
+    ...buildInstructionDoctorReportFields({
+      status: instructionDoctorStatusFromIssues(issues),
+      issues,
+      advisory: TOKENJUICE_GITLAB_DUO_ADVISORY,
+      fixCommand: hasMalformedMarkers
+        ? "remove unmatched tokenjuice markers from .gitlab/duo/chat-rules.md, then run tokenjuice install gitlab-duo"
+        : TOKENJUICE_GITLAB_DUO_FIX_COMMAND,
+    }),
+  };
+}

--- a/src/hosts/shared/hook-doctor.ts
+++ b/src/hosts/shared/hook-doctor.ts
@@ -20,6 +20,7 @@ import { doctorDevinHook } from "../devin/index.js";
 import { doctorDroidHook } from "../droid/index.js";
 import { doctorFirebaseStudioRule } from "../firebase-studio/index.js";
 import { doctorGeminiCliHook } from "../gemini-cli/index.js";
+import { doctorGitLabDuoRule } from "../gitlab-duo/index.js";
 import { doctorGooseHints } from "../goose/index.js";
 import { doctorGrokBuildInstructions } from "../grok-build/index.js";
 import { doctorGrokCliHook } from "../grok-cli/index.js";
@@ -73,6 +74,7 @@ import type { DevinDoctorReport, DevinHookCommandOptions } from "../devin/index.
 import type { DroidDoctorReport, DroidHookCommandOptions } from "../droid/index.js";
 import type { FirebaseStudioDoctorReport, FirebaseStudioRuleOptions } from "../firebase-studio/index.js";
 import type { GeminiCliDoctorReport } from "../gemini-cli/index.js";
+import type { GitLabDuoDoctorReport, GitLabDuoRuleOptions } from "../gitlab-duo/index.js";
 import type { GooseDoctorReport, GooseHintsOptions } from "../goose/index.js";
 import type { GrokBuildDoctorReport, GrokBuildInstructionsOptions } from "../grok-build/index.js";
 import type { GrokCliDoctorReport, GrokCliHookCommandOptions } from "../grok-cli/index.js";
@@ -128,6 +130,7 @@ export type HookIntegrationDoctorReport = {
   droid: DroidDoctorReport;
   "firebase-studio": FirebaseStudioDoctorReport;
   "gemini-cli": GeminiCliDoctorReport;
+  "gitlab-duo": GitLabDuoDoctorReport;
   goose: GooseDoctorReport;
   "grok-build": GrokBuildDoctorReport;
   "grok-cli": GrokCliDoctorReport;
@@ -166,7 +169,7 @@ export type HookDoctorReport = {
   integrations: HookIntegrationDoctorReport;
 };
 
-export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BobInstructionsOptions & BuilderRuleOptions & CodebuffInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JetBrainsAiRuleOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & MuxHookCommandOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions & ZencoderRuleOptions;
+export type HookDoctorCommandOptions = AmazonQRuleOptions & AmpInstructionsOptions & AntigravityRuleOptions & AugmentRuleOptions & BobInstructionsOptions & BuilderRuleOptions & CodebuffInstructionsOptions & CodexHookCommandOptions & ClaudeCodeHookCommandOptions & CodeBuddyHookCommandOptions & CopilotAgentHookCommandOptions & CrushSkillOptions & DevinHookCommandOptions & DroidHookCommandOptions & FirebaseStudioRuleOptions & GitLabDuoRuleOptions & GooseHintsOptions & GrokBuildInstructionsOptions & GrokCliHookCommandOptions & GptmeInstructionsOptions & JetBrainsAiRuleOptions & JulesInstructionsOptions & KimiHookCommandOptions & MistralVibeInstructionsOptions & MuxHookCommandOptions & OpenInterpreterInstructionsOptions & OpenWebUIToolOptions & PlandexConventionOptions & QoderInstructionsOptions & QwenCodeHookCommandOptions & ReplitInstructionsOptions & RovoInstructionsOptions & RulerRuleOptions & TabnineInstructionsOptions & TraeRuleOptions & WarpInstructionsOptions & ZencoderRuleOptions;
 export type HookIntegrationDoctorEntry = [
   keyof HookIntegrationDoctorReport,
   HookIntegrationDoctorReport[keyof HookIntegrationDoctorReport],
@@ -199,6 +202,7 @@ const hookDoctorIntegrationDoctors = {
   droid: (options) => doctorDroidHook(undefined, getHookCommandOptions(options)),
   "firebase-studio": (options) => doctorFirebaseStudioRule(undefined, getHookCommandOptions(options)),
   "gemini-cli": (options) => doctorGeminiCliHook(undefined, getHookCommandOptions(options)),
+  "gitlab-duo": (options) => doctorGitLabDuoRule(undefined, getHookCommandOptions(options)),
   goose: (options) => doctorGooseHints(undefined, { ...getHookCommandOptions(options), scanProjectTree: false }),
   "grok-build": (options) => doctorGrokBuildInstructions(undefined, getHookCommandOptions(options)),
   "grok-cli": (options) => doctorGrokCliHook(undefined, getHookCommandOptions(options)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export { doctorDevinHook, installDevinHook, runDevinPreToolUseHook, uninstallDev
 export { doctorDroidHook, installDroidHook, runDroidPostToolUseHook, uninstallDroidHook } from "./hosts/droid/index.js";
 export { doctorFirebaseStudioRule, installFirebaseStudioRule, uninstallFirebaseStudioRule } from "./hosts/firebase-studio/index.js";
 export { doctorGeminiCliHook, installGeminiCliHook, runGeminiCliAfterToolHook, uninstallGeminiCliHook } from "./hosts/gemini-cli/index.js";
+export { doctorGitLabDuoRule, installGitLabDuoRule, uninstallGitLabDuoRule } from "./hosts/gitlab-duo/index.js";
 export { doctorGooseHints, installGooseHints, uninstallGooseHints } from "./hosts/goose/index.js";
 export { doctorGrokBuildInstructions, installGrokBuildInstructions, uninstallGrokBuildInstructions } from "./hosts/grok-build/index.js";
 export { doctorGrokCliHook, installGrokCliHook, runGrokCliPostToolUseHook, uninstallGrokCliHook } from "./hosts/grok-cli/index.js";
@@ -204,6 +205,12 @@ export type {
   InstallGeminiCliHookResult,
   UninstallGeminiCliHookResult,
 } from "./hosts/gemini-cli/index.js";
+export type {
+  GitLabDuoDoctorReport,
+  GitLabDuoRuleOptions,
+  InstallGitLabDuoRuleResult,
+  UninstallGitLabDuoRuleResult,
+} from "./hosts/gitlab-duo/index.js";
 export type {
   GooseDoctorReport,
   GooseHintsOptions,

--- a/test/cli/doctor-output.test.ts
+++ b/test/cli/doctor-output.test.ts
@@ -46,7 +46,7 @@ describe("formatHookDoctorReport", () => {
       "- configured command: tokenjuice claude-code-pre-tool-use --wrap-launcher tokenjuice",
       "- repair: tokenjuice install claude-code",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, zencoder, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, gitlab-duo, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, zencoder, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));
@@ -71,7 +71,7 @@ describe("formatHookDoctorReport", () => {
       "hook health: disabled",
       "no tokenjuice hooks installed",
       "",
-      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, zencoder, copilot-cli",
+      "available integrations: aider, amazon-q, amp, antigravity, augment, avante, bob, builder, codex, claude-code, cline, codebuff, codebuddy, continue, copilot-agent, crush, cursor, devin, droid, firebase-studio, gemini-cli, gitlab-duo, goose, grok-build, grok-cli, gptme, jetbrains-ai, junie, jules, kimi, kiro, kilo, mistral-vibe, mux, openhands, open-interpreter, openwebui, pi, plandex, qoder, qwen-code, replit, roo, rovo, ruler, tabnine, trae, vscode-copilot, warp, windsurf, zed, zencoder, copilot-cli",
       "enable another integration: tokenjuice install <host>",
       "",
     ].join("\n"));

--- a/test/hosts/gitlab-duo.test.ts
+++ b/test/hosts/gitlab-duo.test.ts
@@ -1,0 +1,299 @@
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  doctorGitLabDuoRule,
+  doctorInstalledHooks,
+  installGitLabDuoRule,
+  uninstallGitLabDuoRule,
+} from "../../src/index.js";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+const envKeys = [
+  "AIDER_PROJECT_DIR",
+  "AMAZON_Q_PROJECT_DIR",
+  "AMP_PROJECT_DIR",
+  "ANTIGRAVITY_PROJECT_DIR",
+  "AUGMENT_PROJECT_DIR",
+  "AVANTE_PROJECT_DIR",
+  "BOB_PROJECT_DIR",
+  "BUILDER_PROJECT_DIR",
+  "CLINE_HOOKS_DIR",
+  "CLAUDE_CONFIG_DIR",
+  "CODEBUDDY_CONFIG_DIR",
+  "CODEBUFF_PROJECT_DIR",
+  "CODEX_HOME",
+  "CONTINUE_PROJECT_DIR",
+  "COPILOT_AGENT_PROJECT_DIR",
+  "COPILOT_HOME",
+  "CURSOR_HOME",
+  "FACTORY_HOME",
+  "GEMINI_HOME",
+  "GITLAB_DUO_PROJECT_DIR",
+  "GROK_BUILD_PROJECT_DIR",
+  "GPTME_PROJECT_DIR",
+  "HOME",
+  "JETBRAINS_AI_PROJECT_DIR",
+  "JULES_PROJECT_DIR",
+  "JUNIE_PROJECT_DIR",
+  "KILO_PROJECT_DIR",
+  "KIMI_HOME",
+  "KIMI_SHARE_DIR",
+  "KIRO_PROJECT_DIR",
+  "MISTRAL_VIBE_PROJECT_DIR",
+  "MUX_PROJECT_DIR",
+  "OPENCODE_CONFIG_DIR",
+  "OPENHANDS_PROJECT_DIR",
+  "OPENWEBUI_PROJECT_DIR",
+  "OPEN_INTERPRETER_PROJECT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "PLANDEX_PROJECT_DIR",
+  "QODER_PROJECT_DIR",
+  "QWEN_PROJECT_DIR",
+  "REPLIT_PROJECT_DIR",
+  "ROO_PROJECT_DIR",
+  "ROVO_DEV_PROJECT_DIR",
+  "RULER_PROJECT_DIR",
+  "TABNINE_PROJECT_DIR",
+  "TRAE_PROJECT_DIR",
+  "WINDSURF_PROJECT_DIR",
+  "ZED_PROJECT_DIR",
+  "ZENCODER_PROJECT_DIR",
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-gitlab-duo-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("GitLab Duo custom rules", () => {
+  function countTokenjuiceBlocks(text: string): number {
+    return text.match(/<!-- tokenjuice:gitlab-duo begin -->/gu)?.length ?? 0;
+  }
+
+  it("installs a marker-delimited chat rules block", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+
+    const result = await installGitLabDuoRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.rulePath).toBe(rulePath);
+    expect(result.backupPath).toBeUndefined();
+    expect(rule).toContain("<!-- tokenjuice:gitlab-duo begin -->");
+    expect(rule).toContain("tokenjuice terminal output compaction");
+    expect(rule).toContain("tokenjuice wrap -- <command>");
+    expect(rule).toContain("tokenjuice wrap --raw -- <command>");
+    expect(rule).not.toContain("wrap --full");
+  });
+
+  it("preserves existing chat rules and backs them up", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await installGitLabDuoRule(rulePath);
+    await writeFile(rulePath, "# Duo rules\n\n- keep this\n", "utf8");
+
+    const result = await installGitLabDuoRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.backupPath).toBe(`${rulePath}.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("keep this");
+    expect(rule).toContain("- keep this");
+    expect(rule).toContain("<!-- tokenjuice:gitlab-duo begin -->");
+  });
+
+  it("does not overwrite an existing user backup when preserving chat rules", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await mkdir(join(home, ".gitlab", "duo"), { recursive: true });
+    await writeFile(rulePath, "# Duo rules\n\n- keep this\n", "utf8");
+    await writeFile(`${rulePath}.bak`, "# user backup\n", "utf8");
+
+    const result = await installGitLabDuoRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.backupPath).toBe(`${rulePath}.bak.1`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("user backup");
+    await expect(readFile(`${rulePath}.bak.1`, "utf8")).resolves.toContain("keep this");
+    expect(rule).toContain("<!-- tokenjuice:gitlab-duo begin -->");
+    expect(rule).toContain("- keep this");
+  });
+
+  it("reinstalls current tokenjuice blocks idempotently", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+
+    await installGitLabDuoRule(rulePath);
+    const result = await installGitLabDuoRule(rulePath);
+
+    expect(result.backupPath).toBeUndefined();
+    await expect(access(`${rulePath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("replaces stale tokenjuice rules without duplicating the block", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await mkdir(join(home, ".gitlab", "duo"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "# Duo rules",
+        "",
+        "- keep this",
+        "",
+        "<!-- tokenjuice:gitlab-duo begin -->",
+        "stale tokenjuice block",
+        "<!-- tokenjuice:gitlab-duo end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await installGitLabDuoRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(rule).toContain("- keep this");
+    expect(rule).not.toContain("stale tokenjuice block");
+    expect(countTokenjuiceBlocks(rule)).toBe(1);
+  });
+
+  it("reports installed and uninstalled rule health", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+
+    await installGitLabDuoRule(rulePath);
+    const installed = await doctorGitLabDuoRule(rulePath);
+
+    expect(installed.status).toBe("ok");
+    expect(installed.advisories[0]).toContain("custom-rules based");
+
+    const removed = await uninstallGitLabDuoRule(rulePath);
+    const disabled = await doctorGitLabDuoRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    expect(disabled.status).toBe("disabled");
+  });
+
+  it("reports broken rules with unmatched tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await mkdir(join(home, ".gitlab", "duo"), { recursive: true });
+    await writeFile(rulePath, "<!-- tokenjuice:gitlab-duo begin -->\nmissing end marker\n", "utf8");
+
+    const doctor = await doctorGitLabDuoRule(rulePath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues[0]).toContain("without an end marker");
+  });
+
+  it("reports broken rules with nested GitLab Duo tokenjuice markers", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await mkdir(join(home, ".gitlab", "duo"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "<!-- tokenjuice:gitlab-duo begin -->",
+        "## tokenjuice terminal output compaction",
+        "- When running terminal commands through GitLab Duo Agent Platform, prefer `tokenjuice wrap -- <command>`.",
+        "<!-- tokenjuice:gitlab-duo begin -->",
+        "- Use `tokenjuice wrap --raw -- <command>` to preserve exact output.",
+        "<!-- tokenjuice:gitlab-duo end -->",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const doctor = await doctorGitLabDuoRule(rulePath);
+
+    expect(doctor.status).toBe("broken");
+    expect(doctor.issues).toContain("configured GitLab Duo rule has malformed tokenjuice markers");
+    expect(doctor.fixCommand).toContain("remove unmatched tokenjuice markers");
+    await expect(installGitLabDuoRule(rulePath)).rejects.toThrow("cannot safely repair malformed tokenjuice markers");
+    await expect(uninstallGitLabDuoRule(rulePath)).rejects.toThrow("cannot safely uninstall malformed tokenjuice markers");
+  });
+
+  it("leaves unrelated chat rules untouched when uninstall finds no tokenjuice block", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    await mkdir(join(home, ".gitlab", "duo"), { recursive: true });
+    await writeFile(rulePath, "# Duo rules\n\n- keep this\n", "utf8");
+
+    const removed = await uninstallGitLabDuoRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(removed.removed).toBe(false);
+    expect(rule).toBe("# Duo rules\n\n- keep this\n");
+  });
+
+  it("uses GITLAB_DUO_PROJECT_DIR for the default rule file", async () => {
+    const home = await createTempDir();
+    process.env.GITLAB_DUO_PROJECT_DIR = home;
+
+    const installed = await installGitLabDuoRule();
+    const expectedRulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+    const doctor = await doctorGitLabDuoRule();
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(doctor.rulePath).toBe(expectedRulePath);
+    expect(doctor.status).toBe("ok");
+  });
+
+  it("uses the nearest git root for the default rule file", async () => {
+    const repo = await createTempDir();
+    const nestedDir = join(repo, "src", "nested");
+    await mkdir(join(repo, ".git"), { recursive: true });
+    await mkdir(nestedDir, { recursive: true });
+    process.chdir(nestedDir);
+
+    const installed = await installGitLabDuoRule();
+    const expectedRulePath = join(await realpath(repo), ".gitlab", "duo", "chat-rules.md");
+    const doctor = await doctorGitLabDuoRule();
+
+    expect(installed.rulePath).toBe(expectedRulePath);
+    expect(doctor.rulePath).toBe(expectedRulePath);
+    expect(doctor.status).toBe("ok");
+    await expect(access(join(nestedDir, ".gitlab", "duo", "chat-rules.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports gitlab-duo in aggregate hook doctor", async () => {
+    const home = await createTempDir();
+    for (const key of envKeys) {
+      process.env[key] = home;
+    }
+
+    await installGitLabDuoRule(undefined, { projectDir: home });
+    const report = await doctorInstalledHooks({ projectDir: home });
+
+    expect(report.integrations["gitlab-duo"].rulePath).toBe(join(home, ".gitlab", "duo", "chat-rules.md"));
+    expect(report.integrations["gitlab-duo"].status).toBe("ok");
+  });
+
+  it("removes the default rule file when only tokenjuice content remains", async () => {
+    const home = await createTempDir();
+    process.env.GITLAB_DUO_PROJECT_DIR = home;
+    const rulePath = join(home, ".gitlab", "duo", "chat-rules.md");
+
+    await installGitLabDuoRule();
+    await uninstallGitLabDuoRule(rulePath);
+
+    await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary
- add GitLab Duo custom rules support for `.gitlab/duo/chat-rules.md`
- wire install/doctor/uninstall into the CLI, aggregate doctor, docs, and exports
- preserve user files with no-clobber backup suffixing and idempotent marker-block reinstall behavior

## Validation
- `pnpm exec vitest run test/hosts/gitlab-duo.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify`
- built CLI smoke: GitLab Duo no-clobber install, idempotent reinstall, doctor, uninstall preservation
- `git diff --check origin/main...HEAD`
- privacy scan over `git diff origin/main...HEAD` for personal paths, private IPs, and email-like values

## Autoreview
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review the GitLab Duo custom rules integration after rebasing onto the shared instruction-backup fix. Focus on .gitlab/duo/chat-rules.md install/doctor/uninstall behavior, marker-delimited block parsing and malformed marker safety, GITLAB_DUO_PROJECT_DIR/default git root resolution, no-clobber backup suffix behavior and idempotent reinstall via shared marker helper, aggregate doctor option forwarding and host list consistency, docs accuracy, tests, and regressions to existing instruction/rule hosts. Reject speculative broad rewrites; report concrete bugs only."`
- result: `autoreview clean: no accepted/actionable findings reported`
- accepted/rejected findings: none on final run