### PR TITLE
fix(hosts): preserve instruction backups

### DIFF
--- a/src/hosts/shared/instruction-file.ts
+++ b/src/hosts/shared/instruction-file.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 export type InstructionFileSnapshot = {
   text: string;
@@ -43,23 +42,47 @@ export async function readInstructionFile(filePath: string): Promise<Instruction
   }
 }
 
-async function instructionBackupPathExists(filePath: string): Promise<boolean> {
+async function writeInstructionFileAtomically(filePath: string, text: string): Promise<void> {
+  const tempDir = await mkdtemp(join(dirname(filePath), ".tokenjuice-"));
+  const tempPath = join(tempDir, "write");
   try {
-    await lstat(filePath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw error;
+    await writeFile(tempPath, text, { encoding: "utf8", flag: "wx" });
+    await rename(tempPath, filePath);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
   }
 }
 
-async function chooseInstructionBackupPath(filePath: string): Promise<string> {
-  for (let index = 0; ; index += 1) {
-    const candidate = index === 0 ? `${filePath}.bak` : `${filePath}.bak.${index}`;
-    if (!(await instructionBackupPathExists(candidate))) {
-      return candidate;
+async function resolveBackupPath(filePath: string): Promise<string> {
+  let suffix = 0;
+  while (true) {
+    const candidate = suffix === 0 ? `${filePath}.bak` : `${filePath}.bak.${suffix}`;
+    try {
+      const stats = await lstat(candidate);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`cannot write instruction backup ${candidate}; tokenjuice will not write through instruction symlinks`);
+      }
+      suffix += 1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return candidate;
+      }
+      throw error;
+    }
+  }
+}
+
+async function writeInstructionBackup(filePath: string, text: string): Promise<string> {
+  while (true) {
+    const backupPath = await resolveBackupPath(filePath);
+    try {
+      await writeFile(backupPath, text, { encoding: "utf8", flag: "wx" });
+      return backupPath;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        continue;
+      }
+      throw error;
     }
   }
 }
@@ -69,18 +92,10 @@ export async function writeInstructionFile(filePath: string, text: string): Prom
   await mkdir(dirname(filePath), { recursive: true });
   let backupPath: string | undefined;
   if (existing.exists) {
-    backupPath = await chooseInstructionBackupPath(filePath);
-    await writeFile(backupPath, existing.text, { encoding: "utf8", flag: "wx" });
+    backupPath = await writeInstructionBackup(filePath, existing.text);
   }
 
-  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-  await writeFile(tempPath, text, { encoding: "utf8", flag: "wx" });
-  try {
-    await rename(tempPath, filePath);
-  } catch (error) {
-    await rm(tempPath, { force: true });
-    throw error;
-  }
+  await writeInstructionFileAtomically(filePath, text);
   return {
     filePath,
     ...(backupPath ? { backupPath } : {}),

--- a/test/hosts/shared/instruction-file.test.ts
+++ b/test/hosts/shared/instruction-file.test.ts
@@ -48,7 +48,7 @@ describe("collectGuidanceIssues", () => {
     await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("generated guidance\n");
   });
 
-  it("skips existing backup symlinks when choosing a backup path", async () => {
+  it("rejects existing backup symlinks when choosing a backup path", async () => {
     const dir = await createTempDir();
     const filePath = join(dir, "RULES.md");
     const targetPath = join(dir, "outside-backup");
@@ -56,23 +56,18 @@ describe("collectGuidanceIssues", () => {
     await writeFile(targetPath, "outside\n", "utf8");
     await symlink(targetPath, `${filePath}.bak`);
 
-    const result = await writeInstructionFile(filePath, "generated guidance\n");
+    await expect(writeInstructionFile(filePath, "generated guidance\n")).rejects.toThrow(/instruction backup/);
 
-    expect(result.backupPath).toBe(`${filePath}.bak.1`);
     await expect(readFile(targetPath, "utf8")).resolves.toBe("outside\n");
-    await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("custom guidance\n");
   });
 
-  it("skips dangling backup symlinks when choosing a backup path", async () => {
+  it("rejects dangling backup symlinks when choosing a backup path", async () => {
     const dir = await createTempDir();
     const filePath = join(dir, "RULES.md");
     await writeFile(filePath, "custom guidance\n", "utf8");
     await symlink(join(dir, "missing-backup-target"), `${filePath}.bak`);
 
-    const result = await writeInstructionFile(filePath, "generated guidance\n");
-
-    expect(result.backupPath).toBe(`${filePath}.bak.1`);
-    await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("custom guidance\n");
+    await expect(writeInstructionFile(filePath, "generated guidance\n")).rejects.toThrow(/instruction backup/);
   });
 
   it("matches forbidden command placeholders against concrete commands", () => {
@@ -84,5 +79,16 @@ describe("collectGuidanceIssues", () => {
     });
 
     expect(issues).toEqual(["has full"]);
+  });
+
+  it("rejects symlinked backup candidates while looking for a free suffix", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "SKILL.md");
+    const outsidePath = join(dir, "outside.md");
+    await writeFile(filePath, "custom guidance\n", "utf8");
+    await writeFile(`${filePath}.bak`, "first backup\n", "utf8");
+    await symlink(outsidePath, `${filePath}.bak.1`);
+
+    await expect(writeInstructionFile(filePath, "generated guidance\n")).rejects.toThrow(/instruction backup/);
   });
 });


### PR DESCRIPTION
## Summary
- preserve existing instruction backups with suffixed `.bak.N` files instead of overwriting `.bak`
- reject symlinked backup candidates while searching for a free backup suffix
- keep replacement writes atomic while creating backup files with exclusive `wx` writes so newly-created backup suffixes are not clobbered
- add shared writer regressions for repeated writes, existing/dangling backup symlinks, and suffix-chain symlink safety

## Validation
- `pnpm exec vitest run test/hosts/shared/instruction-file.test.ts test/hosts/tabby.test.ts test/hosts/ai-memory-protocol.test.ts` (3 files / 61 tests)
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm exec oxlint --deny-warnings src/hosts/shared/instruction-file.ts test/hosts/shared/instruction-file.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify` (115 files / 1905 tests)
- compiled `dist` smoke for shared writer: `.bak`, `.bak.1`, and symlinked suffix rejection
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review #183 after rebasing onto current main ..."`
- final autoreview result: `autoreview clean: no accepted/actionable findings reported`
- accepted autoreview finding fixed before final pass: backup creation now uses exclusive writes/retry so a newly-created suffix cannot be clobbered by `rename`
- `git diff --check`
- changed-file privacy scan
