### PR TITLE
fix(jetbrains-ai): preserve existing rule backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixes
 
+- Preserve existing JetBrains AI Assistant `.bak` rule backups when installing over a custom rule.
 - Normalize stored artifact sources for Copilot, Droid, and VS Code Copilot hook adapters.
 
 ## 0.7.1 - 2026-05-17

--- a/docs/jetbrains-ai-integration.md
+++ b/docs/jetbrains-ai-integration.md
@@ -19,7 +19,8 @@ repository in scripts or tests.
 
 If the target rule file already exists, tokenjuice backs it up before replacing
 it. `tokenjuice uninstall jetbrains-ai` only removes tokenjuice-managed rule
-files; when a pre-tokenjuice backup exists, uninstall restores that backup.
+files; when a pre-tokenjuice backup exists, uninstall restores the backup
+recorded in the tokenjuice rule. Existing user `.bak` files are left untouched.
 
 The installed rule tells JetBrains AI Assistant to use:
 

--- a/src/hosts/jetbrains-ai/index.ts
+++ b/src/hosts/jetbrains-ai/index.ts
@@ -7,7 +7,7 @@ import {
   TOKENJUICE_RAW_COMMAND,
   TOKENJUICE_WRAP_COMMAND,
 } from "../shared/instruction-guidance.js";
-import { collectGuidanceIssues, readInstructionFile, removeInstructionFile, writeInstructionFile } from "../shared/instruction-file.js";
+import { collectGuidanceIssues, readInstructionFile, removeInstructionFile } from "../shared/instruction-file.js";
 import {
   buildInstructionDoctorReportFields,
   instructionDoctorStatusFromIssues,
@@ -39,7 +39,8 @@ export type JetBrainsAiDoctorReport = {
 
 const TOKENJUICE_JETBRAINS_AI_FIX_COMMAND = "tokenjuice install jetbrains-ai";
 const TOKENJUICE_JETBRAINS_AI_OWNERSHIP_MARKER = "<!-- tokenjuice:jetbrains-ai-rule -->";
-const TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER = "<!-- tokenjuice:jetbrains-ai-restore-backup -->";
+const TOKENJUICE_JETBRAINS_AI_LEGACY_RESTORE_BACKUP_MARKER = "<!-- tokenjuice:jetbrains-ai-restore-backup -->";
+const TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER_PREFIX = "<!-- tokenjuice:jetbrains-ai-restore-backup=";
 const TOKENJUICE_JETBRAINS_AI_RULE_MARKER = "tokenjuice terminal output compaction";
 const TOKENJUICE_JETBRAINS_AI_ADVISORY = "JetBrains AI Assistant support is beta and rule-based; it guides chat behavior but does not intercept tool output.";
 const TOKENJUICE_JETBRAINS_AI_REINSTALL_BACKUP_SUFFIX = ".tokenjuice.bak";
@@ -84,10 +85,10 @@ async function getDefaultRulePath(options: JetBrainsAiRuleOptions = {}): Promise
   return join(await resolveProjectDir(options), ".aiassistant", "rules", "tokenjuice.md");
 }
 
-function buildJetBrainsAiRule({ restoreBackup = false }: { restoreBackup?: boolean } = {}): string {
+function buildJetBrainsAiRule({ restoreBackupSuffix }: { restoreBackupSuffix?: string | undefined } = {}): string {
   return [
     TOKENJUICE_JETBRAINS_AI_OWNERSHIP_MARKER,
-    ...(restoreBackup ? [TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER] : []),
+    ...(restoreBackupSuffix ? [`${TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER_PREFIX}${restoreBackupSuffix} -->`] : []),
     "",
     `# ${TOKENJUICE_JETBRAINS_AI_RULE_MARKER}`,
     "",
@@ -102,13 +103,46 @@ function isTokenjuiceJetBrainsAiRuleText(text: string): boolean {
   return text.includes(TOKENJUICE_JETBRAINS_AI_OWNERSHIP_MARKER);
 }
 
+function readRestoreBackupSuffix(text: string): string | undefined {
+  if (text.includes(TOKENJUICE_JETBRAINS_AI_LEGACY_RESTORE_BACKUP_MARKER)) {
+    return ".bak";
+  }
+
+  const match = text.match(/<!-- tokenjuice:jetbrains-ai-restore-backup=([^ ]+) -->/u);
+  const suffix = match?.[1];
+  if (!suffix || !suffix.startsWith(".") || suffix.includes("/") || suffix.includes("\\")) {
+    return undefined;
+  }
+  return suffix;
+}
+
+async function chooseBackupSuffix(rulePath: string): Promise<string> {
+  const primaryBackup = await readInstructionFile(`${rulePath}.bak`);
+  if (!primaryBackup.exists) {
+    return ".bak";
+  }
+
+  const secondaryBackup = await readInstructionFile(`${rulePath}${TOKENJUICE_JETBRAINS_AI_REINSTALL_BACKUP_SUFFIX}`);
+  if (!secondaryBackup.exists) {
+    return TOKENJUICE_JETBRAINS_AI_REINSTALL_BACKUP_SUFFIX;
+  }
+
+  for (let index = 1; ; index += 1) {
+    const suffix = `.tokenjuice-${index}.bak`;
+    const candidate = await readInstructionFile(`${rulePath}${suffix}`);
+    if (!candidate.exists) {
+      return suffix;
+    }
+  }
+}
+
 async function writeJetBrainsAiRuleWithoutBackup(
   rulePath: string,
-  { restoreBackup = false }: { restoreBackup?: boolean } = {},
+  { restoreBackupSuffix }: { restoreBackupSuffix?: string | undefined } = {},
 ): Promise<void> {
   await mkdir(dirname(rulePath), { recursive: true });
   const tempPath = `${rulePath}.tmp`;
-  await writeFile(tempPath, buildJetBrainsAiRule({ restoreBackup }), "utf8");
+  await writeFile(tempPath, buildJetBrainsAiRule({ restoreBackupSuffix }), "utf8");
   await rename(tempPath, rulePath);
 }
 
@@ -119,27 +153,28 @@ export async function installJetBrainsAiRule(
   const resolvedRulePath = rulePath ?? (await getDefaultRulePath(options));
   const existing = await readInstructionFile(resolvedRulePath);
   if (existing.exists && isTokenjuiceJetBrainsAiRuleText(existing.text)) {
-    const preserveRestore = existing.text.includes(TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER);
-    const expectedRule = buildJetBrainsAiRule({ restoreBackup: preserveRestore });
+    const restoreBackupSuffix = readRestoreBackupSuffix(existing.text);
+    const expectedRule = buildJetBrainsAiRule({ restoreBackupSuffix });
     if (existing.text === expectedRule) {
       return { rulePath: resolvedRulePath };
     }
 
-    const primaryBackupPath = `${resolvedRulePath}.bak`;
-    const primaryBackup = await readInstructionFile(primaryBackupPath);
-    const backupPath = primaryBackup.exists && !isTokenjuiceJetBrainsAiRuleText(primaryBackup.text)
-      ? `${resolvedRulePath}${TOKENJUICE_JETBRAINS_AI_REINSTALL_BACKUP_SUFFIX}`
-      : primaryBackupPath;
+    const backupPath = `${resolvedRulePath}${await chooseBackupSuffix(resolvedRulePath)}`;
     await writeFile(backupPath, existing.text, "utf8");
-    await writeJetBrainsAiRuleWithoutBackup(resolvedRulePath, { restoreBackup: preserveRestore });
+    await writeJetBrainsAiRuleWithoutBackup(resolvedRulePath, { restoreBackupSuffix });
     return { rulePath: resolvedRulePath, backupPath };
   }
 
-  const result = await writeInstructionFile(resolvedRulePath, buildJetBrainsAiRule({ restoreBackup: existing.exists }));
-  return {
-    rulePath: result.filePath,
-    ...(result.backupPath ? { backupPath: result.backupPath } : {}),
-  };
+  if (existing.exists) {
+    const backupSuffix = await chooseBackupSuffix(resolvedRulePath);
+    const backupPath = `${resolvedRulePath}${backupSuffix}`;
+    await writeFile(backupPath, existing.text, "utf8");
+    await writeJetBrainsAiRuleWithoutBackup(resolvedRulePath, { restoreBackupSuffix: backupSuffix });
+    return { rulePath: resolvedRulePath, backupPath };
+  }
+
+  await writeJetBrainsAiRuleWithoutBackup(resolvedRulePath);
+  return { rulePath: resolvedRulePath };
 }
 
 export async function uninstallJetBrainsAiRule(
@@ -154,11 +189,12 @@ export async function uninstallJetBrainsAiRule(
     );
   }
 
-  const backupPath = `${resolvedRulePath}.bak`;
-  const backup = await readInstructionFile(backupPath);
+  const restoreBackupSuffix = readRestoreBackupSuffix(existing.text);
+  const backupPath = restoreBackupSuffix ? `${resolvedRulePath}${restoreBackupSuffix}` : "";
+  const backup = restoreBackupSuffix ? await readInstructionFile(backupPath) : { exists: false, text: "" };
   if (
     existing.exists
-    && existing.text.includes(TOKENJUICE_JETBRAINS_AI_RESTORE_BACKUP_MARKER)
+    && restoreBackupSuffix
     && backup.exists
     && !isTokenjuiceJetBrainsAiRuleText(backup.text)
   ) {

--- a/test/hosts/jetbrains-ai.test.ts
+++ b/test/hosts/jetbrains-ai.test.ts
@@ -93,7 +93,7 @@ describe("JetBrains AI Assistant rules", () => {
     expect(result.rulePath).toBe(rulePath);
     expect(result.backupPath).toBeUndefined();
     expect(rule).toContain("<!-- tokenjuice:jetbrains-ai-rule -->");
-    expect(rule).not.toContain("<!-- tokenjuice:jetbrains-ai-restore-backup -->");
+    expect(rule).not.toContain("<!-- tokenjuice:jetbrains-ai-restore-backup=");
     expect(rule).toContain("tokenjuice terminal output compaction");
     expect(rule).toContain("JetBrains AI Assistant chat");
     expect(rule).toContain("tokenjuice wrap -- <command>");
@@ -112,7 +112,7 @@ describe("JetBrains AI Assistant rules", () => {
 
     expect(result.backupPath).toBe(`${rulePath}.bak`);
     await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("keep this");
-    expect(rule).toContain("<!-- tokenjuice:jetbrains-ai-restore-backup -->");
+    expect(rule).toContain("<!-- tokenjuice:jetbrains-ai-restore-backup=.bak -->");
     expect(rule).toContain("tokenjuice terminal output compaction");
     expect(rule).not.toContain("keep this");
   });
@@ -185,12 +185,37 @@ describe("JetBrains AI Assistant rules", () => {
     await mkdir(join(home, ".aiassistant", "rules"), { recursive: true });
     await writeFile(rulePath, "# custom local rule\n", "utf8");
     await installJetBrainsAiRule(rulePath);
-    await expect(readFile(rulePath, "utf8")).resolves.toContain("<!-- tokenjuice:jetbrains-ai-restore-backup -->");
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("<!-- tokenjuice:jetbrains-ai-restore-backup=.bak -->");
 
     const removed = await uninstallJetBrainsAiRule(rulePath);
 
     expect(removed.removed).toBe(true);
     await expect(readFile(rulePath, "utf8")).resolves.toContain("custom local rule");
+  });
+
+  it("restores legacy pre-tokenjuice backups on uninstall", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".aiassistant", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".aiassistant", "rules"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "<!-- tokenjuice:jetbrains-ai-rule -->",
+        "<!-- tokenjuice:jetbrains-ai-restore-backup -->",
+        "",
+        "# tokenjuice terminal output compaction",
+        "",
+        "- When running terminal commands from JetBrains AI Assistant chat, prefer `tokenjuice wrap -- <command>`.",
+        "- Use `tokenjuice wrap --raw -- <command>` when exact output is required.",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(`${rulePath}.bak`, "# legacy custom rule\n", "utf8");
+
+    const removed = await uninstallJetBrainsAiRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("legacy custom rule");
   });
 
   it("does not restore a stale backup tokenjuice did not create", async () => {
@@ -205,6 +230,57 @@ describe("JetBrains AI Assistant rules", () => {
     expect(removed.removed).toBe(true);
     await expect(access(rulePath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("stale local rule");
+  });
+
+  it("does not overwrite an existing user backup when preserving a rule file", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".aiassistant", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".aiassistant", "rules"), { recursive: true });
+    await writeFile(rulePath, "# custom local rule\n", "utf8");
+    await writeFile(`${rulePath}.bak`, "# user backup\n", "utf8");
+
+    const result = await installJetBrainsAiRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.backupPath).toBe(`${rulePath}.tokenjuice.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("user backup");
+    await expect(readFile(`${rulePath}.tokenjuice.bak`, "utf8")).resolves.toContain("custom local rule");
+    expect(rule).toContain("<!-- tokenjuice:jetbrains-ai-restore-backup=.tokenjuice.bak -->");
+
+    const removed = await uninstallJetBrainsAiRule(rulePath);
+
+    expect(removed.removed).toBe(true);
+    await expect(readFile(rulePath, "utf8")).resolves.toContain("custom local rule");
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("user backup");
+    await expect(access(`${rulePath}.tokenjuice.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("upgrades legacy restore markers without clobbering their backups", async () => {
+    const home = await createTempDir();
+    const rulePath = join(home, ".aiassistant", "rules", "tokenjuice.md");
+    await mkdir(join(home, ".aiassistant", "rules"), { recursive: true });
+    await writeFile(
+      rulePath,
+      [
+        "<!-- tokenjuice:jetbrains-ai-rule -->",
+        "<!-- tokenjuice:jetbrains-ai-restore-backup -->",
+        "",
+        "# tokenjuice terminal output compaction",
+        "",
+        "- old generated guidance",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(`${rulePath}.bak`, "# legacy custom rule\n", "utf8");
+
+    const result = await installJetBrainsAiRule(rulePath);
+    const rule = await readFile(rulePath, "utf8");
+
+    expect(result.backupPath).toBe(`${rulePath}.tokenjuice.bak`);
+    await expect(readFile(`${rulePath}.bak`, "utf8")).resolves.toContain("legacy custom rule");
+    await expect(readFile(`${rulePath}.tokenjuice.bak`, "utf8")).resolves.toContain("old generated guidance");
+    expect(rule).toContain("<!-- tokenjuice:jetbrains-ai-restore-backup=.bak -->");
+    expect(rule).not.toContain("<!-- tokenjuice:jetbrains-ai-restore-backup -->");
   });
 
   it("uses JETBRAINS_AI_PROJECT_DIR for the default rule file", async () => {


### PR DESCRIPTION
## Summary
- Preserves existing JetBrains AI Assistant `.bak` files when installing over a custom `.aiassistant/rules/tokenjuice.md`.
- Records the backup suffix inside the tokenjuice-managed rule and restores that exact backup on uninstall.
- Keeps backward compatibility for legacy unsuffixed restore markers by mapping them to `.bak`.

## Validation
- `pnpm exec vitest run test/hosts/jetbrains-ai.test.ts test/cli/doctor-output.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify`
- Built CLI smoke: existing `.bak` no-clobber, recorded backup restore, legacy marker restore
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review the JetBrains AI Assistant backup preservation fix after adding legacy marker compatibility. Focus on .aiassistant/rules/tokenjuice.md install/doctor/uninstall behavior, legacy unsuffixed restore marker mapping to .bak, restore marker suffix parsing, preserving pre-existing user .bak files, stale backup non-restore semantics, reinstall behavior, docs/changelog accuracy, and regressions versus the Zencoder no-clobber pattern. Reject speculative broad rewrites; report concrete bugs only."`

Autoreview accepted finding fixed: legacy unsuffixed restore markers now restore from `.bak`. Final autoreview result: `autoreview clean: no accepted/actionable findings reported`.
