### PR TITLE
fix(hosts): preserve instruction backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixes
 
+- Preserve existing instruction-file `.bak` backups instead of overwriting them during install.
 - Preserve existing JetBrains AI Assistant `.bak` rule backups when installing over a custom rule.
 - Normalize stored artifact sources for Copilot, Droid, and VS Code Copilot hook adapters.
 

--- a/src/hosts/shared/instruction-file.ts
+++ b/src/hosts/shared/instruction-file.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 export type InstructionFileSnapshot = {
@@ -42,15 +42,36 @@ export async function readInstructionFile(filePath: string): Promise<Instruction
   }
 }
 
+async function instructionBackupPathExists(filePath: string): Promise<boolean> {
+  try {
+    await lstat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function chooseInstructionBackupPath(filePath: string): Promise<string> {
+  for (let index = 0; ; index += 1) {
+    const candidate = index === 0 ? `${filePath}.bak` : `${filePath}.bak.${index}`;
+    if (!(await instructionBackupPathExists(candidate))) {
+      return candidate;
+    }
+  }
+}
+
 export async function writeInstructionFile(filePath: string, text: string): Promise<WriteInstructionFileResult> {
   const existing = await readInstructionFile(filePath);
+  await mkdir(dirname(filePath), { recursive: true });
   let backupPath: string | undefined;
   if (existing.exists) {
-    backupPath = `${filePath}.bak`;
-    await writeFile(backupPath, existing.text, "utf8");
+    backupPath = await chooseInstructionBackupPath(filePath);
+    await writeFile(backupPath, existing.text, { encoding: "utf8", flag: "wx" });
   }
 
-  await mkdir(dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.tmp`;
   await writeFile(tempPath, text, "utf8");
   await rename(tempPath, filePath);

--- a/src/hosts/shared/marker-instructions.ts
+++ b/src/hosts/shared/marker-instructions.ts
@@ -82,7 +82,12 @@ export function upsertMarkerDelimitedBlock(text: string, config: MarkerDelimited
 
 export async function installMarkerDelimitedBlock(filePath: string, config: MarkerDelimitedBlockConfig): Promise<InstallMarkerDelimitedBlockResult> {
   const existing = await readInstructionFile(filePath);
-  const result = await writeInstructionFile(filePath, upsertMarkerDelimitedBlock(existing.text, config));
+  const nextText = upsertMarkerDelimitedBlock(existing.text, config);
+  if (existing.exists && existing.text === nextText) {
+    return { filePath };
+  }
+
+  const result = await writeInstructionFile(filePath, nextText);
   return {
     filePath: result.filePath,
     ...(result.backupPath ? { backupPath: result.backupPath } : {}),

--- a/test/hosts/shared/instruction-file.test.ts
+++ b/test/hosts/shared/instruction-file.test.ts
@@ -1,6 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { collectGuidanceIssues } from "../../../src/hosts/shared/instruction-file.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectGuidanceIssues, writeInstructionFile } from "../../../src/hosts/shared/instruction-file.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-instruction-file-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
 
 describe("collectGuidanceIssues", () => {
   it("reports missing required guidance and present forbidden guidance in order", () => {
@@ -16,5 +32,46 @@ describe("collectGuidanceIssues", () => {
     });
 
     expect(issues).toEqual(["missing raw", "has full"]);
+  });
+
+  it("uses suffixed backups instead of overwriting an existing backup", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "RULES.md");
+    await writeFile(filePath, "custom guidance\n", "utf8");
+
+    const first = await writeInstructionFile(filePath, "generated guidance\n");
+    const second = await writeInstructionFile(filePath, "updated generated guidance\n");
+
+    expect(first.backupPath).toBe(`${filePath}.bak`);
+    expect(second.backupPath).toBe(`${filePath}.bak.1`);
+    await expect(readFile(`${filePath}.bak`, "utf8")).resolves.toBe("custom guidance\n");
+    await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("generated guidance\n");
+  });
+
+  it("skips existing backup symlinks when choosing a backup path", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "RULES.md");
+    const targetPath = join(dir, "outside-backup");
+    await writeFile(filePath, "custom guidance\n", "utf8");
+    await writeFile(targetPath, "outside\n", "utf8");
+    await symlink(targetPath, `${filePath}.bak`);
+
+    const result = await writeInstructionFile(filePath, "generated guidance\n");
+
+    expect(result.backupPath).toBe(`${filePath}.bak.1`);
+    await expect(readFile(targetPath, "utf8")).resolves.toBe("outside\n");
+    await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("custom guidance\n");
+  });
+
+  it("skips dangling backup symlinks when choosing a backup path", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "RULES.md");
+    await writeFile(filePath, "custom guidance\n", "utf8");
+    await symlink(join(dir, "missing-backup-target"), `${filePath}.bak`);
+
+    const result = await writeInstructionFile(filePath, "generated guidance\n");
+
+    expect(result.backupPath).toBe(`${filePath}.bak.1`);
+    await expect(readFile(`${filePath}.bak.1`, "utf8")).resolves.toBe("custom guidance\n");
   });
 });

--- a/test/hosts/shared/marker-instructions.test.ts
+++ b/test/hosts/shared/marker-instructions.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   collectMarkerDelimitedBlockIssues,
+  installMarkerDelimitedBlock,
   inspectMarkerDelimitedBlock,
 } from "../../../src/hosts/shared/marker-instructions.js";
 
@@ -10,6 +15,18 @@ const config = {
   endMarker: "<!-- tokenjuice:end -->",
   block: "<!-- tokenjuice:begin -->\nbody\n<!-- tokenjuice:end -->",
 };
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-marker-instructions-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
 
 describe("marker instruction helpers", () => {
   it("reports unmatched and duplicate marker blocks", () => {
@@ -24,5 +41,17 @@ describe("marker instruction helpers", () => {
       configuredLabel: "Zed rules",
       repairCommand: "tokenjuice install zed",
     })).toEqual(["configured Zed rules have multiple tokenjuice blocks; run tokenjuice install zed to repair"]);
+  });
+
+  it("does not create backups when reinstalling an unchanged marker block", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "RULES.md");
+
+    await installMarkerDelimitedBlock(filePath, config);
+    const result = await installMarkerDelimitedBlock(filePath, config);
+
+    expect(result.backupPath).toBeUndefined();
+    await expect(readFile(filePath, "utf8")).resolves.toBe(`${config.block}\n`);
+    await expect(readFile(`${filePath}.bak`, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 });


### PR DESCRIPTION
## Summary
- Preserves existing instruction-file backups by choosing suffixed `.bak.N` paths instead of overwriting `.bak`.
- Treats existing and dangling backup symlinks as occupied paths, so installs choose a safe new backup path.
- Makes marker-delimited block reinstalls idempotent when the managed block is already current.

## Validation
- `pnpm exec vitest run test/hosts/shared/instruction-file.test.ts test/hosts/shared/marker-instructions.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify`
- Built CLI/runtime smoke: shared instruction backups no-clobber and marker reinstall idempotence
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review the shared instruction-file backup preservation fix. Focus on writeInstructionFile backup suffix selection, lstat handling for existing and dangling symlink backups, no clobbering of existing .bak files, marker-delimited block reinstall idempotence, effects on Aider/Continue/Avante/Junie/Zed and new GitLab Duo-style marker integrations, docs/changelog accuracy, tests, and regressions to existing instruction hosts. Reject speculative broad rewrites; report concrete bugs only."`

Autoreview result: `autoreview clean: no accepted/actionable findings reported`.
