### PR TITLE
fix(mini-swe-agent): preserve incidental backups on uninstall

### DIFF
--- a/src/hosts/mini-swe-agent/index.ts
+++ b/src/hosts/mini-swe-agent/index.ts
@@ -218,12 +218,14 @@ export async function uninstallMiniSweAgentConfig(
   }
 
   const restoreBackupSuffix = readRestoreBackupSuffix(existing.text);
-  const backupPath = restoreBackupSuffix ? `${resolvedConfigPath}${restoreBackupSuffix}` : `${resolvedConfigPath}.bak`;
-  const backup = await readInstructionFile(backupPath);
-  if (backup.exists && !isTokenjuiceMiniSweAgentConfigText(backup.text)) {
-    await rm(resolvedConfigPath, { force: true });
-    await rename(backupPath, resolvedConfigPath);
-    return { configPath: resolvedConfigPath, removed: true };
+  if (restoreBackupSuffix) {
+    const backupPath = `${resolvedConfigPath}${restoreBackupSuffix}`;
+    const backup = await readInstructionFile(backupPath);
+    if (backup.exists && !isTokenjuiceMiniSweAgentConfigText(backup.text)) {
+      await rm(resolvedConfigPath, { force: true });
+      await rename(backupPath, resolvedConfigPath);
+      return { configPath: resolvedConfigPath, removed: true };
+    }
   }
 
   const result = await removeInstructionFile(resolvedConfigPath);

--- a/test/hosts/mini-swe-agent.test.ts
+++ b/test/hosts/mini-swe-agent.test.ts
@@ -176,6 +176,20 @@ describe("mini-SWE-agent config", () => {
     await expect(readFile(`${configPath}.bak`, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not restore incidental backups when uninstalling a fresh tokenjuice fragment", async () => {
+    const home = await createTempDir();
+    const configPath = join(home, ".mini-swe-agent", "tokenjuice.yaml");
+
+    await installMiniSweAgentConfig(configPath);
+    await writeFile(`${configPath}.bak`, "unrelated backup\n", "utf8");
+
+    const removed = await uninstallMiniSweAgentConfig(configPath);
+
+    expect(removed.removed).toBe(true);
+    await expect(access(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(`${configPath}.bak`, "utf8")).resolves.toBe("unrelated backup\n");
+  });
+
   it("reports installed and uninstalled config health", async () => {
     const home = await createTempDir();
     const configPath = join(home, ".mini-swe-agent", "tokenjuice.yaml");


### PR DESCRIPTION
## Summary
- Preserve incidental .mini-swe-agent/tokenjuice.yaml.bak files when uninstalling fresh tokenjuice fragments with no recorded restore suffix.
- Keep restoring only the exact backup suffix recorded during install-over-custom-config.
- Add regression coverage for the incidental backup case.

## Validation
- pnpm exec vitest run test/hosts/mini-swe-agent.test.ts test/hosts/shared/instruction-file.test.ts test/cli/doctor-output.test.ts
- pnpm typecheck && pnpm build && pnpm verify (97 files, 1520 tests)
- Built CLI smoke: fresh install/uninstall preserves incidental .bak; install over custom with existing .bak records/restores .bak.1 and preserves older .bak.
- git diff --check
- git diff --check origin/main...HEAD
- Privacy scan over origin/main...HEAD diff: no matches.

## Autoreview
- Command: .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review the mini-SWE-agent uninstall backup hardening fix. Focus on incidental backup preservation on fresh uninstall, recorded backup suffix restore behavior, non-tokenjuice config preservation, idempotence, and user-data preservation."
- Result: clean, no accepted/actionable findings reported.
- Accepted findings fixed: incidental .bak files are no longer restored without a recorded suffix.
- Rejected findings: none.