### PR TITLE
test(docker-agent): assert legacy project override

### DIFF
--- a/test/hosts/docker-agent.test.ts
+++ b/test/hosts/docker-agent.test.ts
@@ -267,6 +267,7 @@ describe("Docker Agent prompt", () => {
 
     const installed = await installDockerAgentPrompt();
 
+    expect(installed.promptPath).toBe(join(home, ".docker-agent", "tokenjuice.md"));
     await expectSamePath(installed.promptPath, join(home, ".docker-agent", "tokenjuice.md"));
   });
 


### PR DESCRIPTION
## Summary

- add a direct assertion for the legacy `CAGENT_PROJECT_DIR` prompt path
- unblock the esbuild Dependabot update under oxlint 1.69

## Root cause

The upgraded `vitest/expect-expect` rule does not infer assertions hidden in the async path helper.

## Validation

- `pnpm exec vitest run test/hosts/docker-agent.test.ts`
- `pnpm dlx oxlint@1.69.0 --deny-warnings src test scripts`
- `pnpm verify`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "pnpm verify"`