### PR TITLE
build: migrate typescript to ^7 (native tsc)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign maintainer
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const assignee = "vincentkoc";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.8
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.8
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Checkout tap repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: vincentkoc/tap
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,7 @@ Recent history favors short, imperative subjects, usually Conventional Commit st
 - `chore(release): v0.6.0`
 
 PRs should include a concise summary, the reason for the change, and a test plan with exact commands. Call out docs or release impact when relevant.
+
+## Mac resource pressure
+
+If work changes local process/session/tooling behavior, read `~/Projects/personal/mac-resource-ops/VISION.md` and `~/Projects/personal/mac-resource-ops/docs/resource-graph.md` first. Prefer bounded commands, lazy loading, explicit cleanup paths, and crabbox/offload for heavy loops. Do not leave new persistent local pressure undocumented.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "madge": "^8.0.0",
     "oxlint": "^1.61.0",
     "publint": "^0.3.18",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.25.12
       madge:
         specifier: ^8.0.0
-        version: 8.0.0(typescript@5.9.3)
+        version: 8.0.0(typescript@7.0.2)
       oxlint:
         specifier: ^1.61.0
         version: 1.61.0
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.3.18
         version: 0.3.18
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.2)
@@ -665,6 +665,126 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1293,6 +1413,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -1759,6 +1884,66 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -2148,7 +2333,7 @@ snapshots:
 
   loupe@3.2.1: {}
 
-  madge@8.0.0(typescript@5.9.3):
+  madge@8.0.0(typescript@7.0.2):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
@@ -2163,7 +2348,7 @@ snapshots:
       ts-graphviz: 2.1.6
       walkdir: 0.4.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2462,6 +2647,29 @@ snapshots:
       strip-bom: 3.0.0
 
   typescript@5.9.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.16.0: {}
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,7 +8,7 @@ import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifa
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
 import { parseReduceJsonRequest } from "../core/json-protocol.js";
-import { WRAP_AUTHORITATIVE_FOOTER } from "../core/compaction-metadata.js";
+import { buildWrapAuthoritativeFooter } from "../core/compaction-metadata.js";
 import { reduceExecution } from "../core/reduce.js";
 import { verifyRules } from "../core/rules.js";
 import { runWrappedCommand } from "../core/wrap.js";
@@ -438,7 +438,7 @@ async function runWrap(args: ParsedArgs): Promise<number> {
   return wrapped.exitCode;
 }
 
-function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): string {
+export function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): string {
   const { rawChars, reducedChars } = result.stats;
   if (raw || !result.compaction?.authoritative || reducedChars === 0 || reducedChars >= rawChars) {
     return result.inlineText;
@@ -446,7 +446,7 @@ function decorateWrapInlineText(result: WrapResult["result"], raw: boolean): str
   const footer = [
     "",
     "---",
-    WRAP_AUTHORITATIVE_FOOTER,
+    buildWrapAuthoritativeFooter(result.rawRef?.path),
   ].join("\n");
   return `${result.inlineText}${footer}`;
 }

--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -22,6 +22,19 @@ export const NO_COMPACTION_METADATA: CompactionMetadata = {
 
 export const WRAP_AUTHORITATIVE_FOOTER = "[tokenjuice] This is the complete, authoritative output for this command. It was deterministically compacted to remove low-signal noise; the omitted content is not retrievable. Do not re-run the command, vary flags, or switch tools to try to recover it. Proceed with the task using this output.";
 
+/**
+ * Footer appended to compacted wrap output. When the full, uncompacted output
+ * was persisted to a tokenjuice artifact, point the agent at that file so it
+ * reads the raw output directly instead of re-running the command or
+ * redirecting it into a temp file to recover the omitted detail.
+ */
+export function buildWrapAuthoritativeFooter(rawArtifactPath?: string): string {
+  if (rawArtifactPath) {
+    return `[tokenjuice] Output compacted to remove low-signal noise. The complete, uncompacted output is saved at ${rawArtifactPath} — read that file directly if you need any omitted detail. Do not re-run the command, vary flags, switch tools, or redirect output to a temp file to recover it.`;
+  }
+  return WRAP_AUTHORITATIVE_FOOTER;
+}
+
 export function createCompactionMetadata(...kinds: CompactionKind[]): CompactionMetadata {
   if (kinds.length === 0) {
     return NO_COMPACTION_METADATA;

--- a/src/hosts/claude-code/index.ts
+++ b/src/hosts/claude-code/index.ts
@@ -377,7 +377,7 @@ export async function runClaudeCodePreToolUseHook(rawText: string, wrapLauncher 
     return 0;
   }
 
-  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "claude-code" });
+  const wrappedCommand = buildWrappedCommand({ wrapLauncher, shellPath, command, source: "claude-code", store: true });
   const response = {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/src/hosts/shared/pre-tool-wrap.ts
+++ b/src/hosts/shared/pre-tool-wrap.ts
@@ -187,13 +187,20 @@ export function buildWrappedCommand(params: {
   command: string;
   source?: string;
   nodePath?: string;
+  /** Persist the full, uncompacted output to a tokenjuice artifact so the
+   * compaction footer can point the agent at it instead of forcing a re-run. */
+  store?: boolean;
+  storeDir?: string;
 }): string {
   const nodePath = params.nodePath ?? process.execPath;
   const launcherCommand = params.wrapLauncher.endsWith(".js")
     ? `${shellQuote(nodePath)} ${shellQuote(params.wrapLauncher)}`
     : shellQuote(params.wrapLauncher);
   const sourceArgs = params.source ? ` --source ${shellQuote(params.source)}` : "";
-  return `${launcherCommand} wrap${sourceArgs} -- ${shellQuote(params.shellPath)} -lc ${shellQuote(params.command)}`;
+  const storeArgs = params.store
+    ? ` --store${params.storeDir ? ` --store-dir ${shellQuote(params.storeDir)}` : ""}`
+    : "";
+  return `${launcherCommand} wrap${sourceArgs}${storeArgs} -- ${shellQuote(params.shellPath)} -lc ${shellQuote(params.command)}`;
 }
 
 /**

--- a/test/cli/wrap-footer.test.ts
+++ b/test/cli/wrap-footer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { WRAP_AUTHORITATIVE_FOOTER } from "../../src/core/compaction-metadata.js";
+import { decorateWrapInlineText } from "../../src/cli/main.js";
+
+import type { CompactResult } from "../../src/types.js";
+
+function lossyResult(overrides: Partial<CompactResult> = {}): CompactResult {
+  return {
+    inlineText: "summary",
+    compaction: {
+      authoritative: true,
+      kinds: ["head-tail-omission"],
+    },
+    stats: {
+      rawChars: 4_000,
+      reducedChars: 40,
+      ratio: 0.01,
+    },
+    classification: {
+      family: "generic",
+      confidence: 0.9,
+      matchedReducer: "generic/fallback",
+    },
+    ...overrides,
+  };
+}
+
+describe("decorateWrapInlineText", () => {
+  it("keeps the not-retrievable footer when no raw artifact was stored", () => {
+    expect(decorateWrapInlineText(lossyResult(), false)).toContain(WRAP_AUTHORITATIVE_FOOTER);
+  });
+
+  it("points the footer at the stored raw artifact when one exists", () => {
+    const decorated = decorateWrapInlineText(
+      lossyResult({
+        rawRef: {
+          id: "tj_0123456789ab",
+          storage: "file",
+          path: "/home/luke/.tokenjuice/artifacts/tj_0123456789ab.txt",
+          metadataPath: "/home/luke/.tokenjuice/artifacts/tj_0123456789ab.json",
+        },
+      }),
+      false,
+    );
+    expect(decorated).toContain("/home/luke/.tokenjuice/artifacts/tj_0123456789ab.txt");
+    expect(decorated).not.toContain("not retrievable");
+  });
+
+  it("suppresses the footer for lossless rewrites", () => {
+    expect(
+      decorateWrapInlineText(
+        lossyResult({ compaction: { authoritative: false, kinds: ["no-omit-domain-passthrough"] } }),
+        false,
+      ),
+    ).toBe("summary");
+  });
+});

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -748,7 +748,7 @@ describe("runClaudeCodePreToolUseHook", () => {
     expect(response.hookSpecificOutput?.updatedInput?.description).toBe("check status");
     expect(response.hookSpecificOutput?.updatedInput?.timeout).toBe(120000);
     expect(response.hookSpecificOutput?.updatedInput?.run_in_background).toBe(false);
-    expect(response.hookSpecificOutput?.updatedInput?.command).toContain("/usr/local/bin/tokenjuice wrap --source claude-code --");
+    expect(response.hookSpecificOutput?.updatedInput?.command).toContain("/usr/local/bin/tokenjuice wrap --source claude-code --store --");
     expect(response.hookSpecificOutput?.updatedInput?.command).toContain(shellPath);
     expect(response.hookSpecificOutput?.updatedInput?.command).toContain("git status --short && pnpm test");
   });

--- a/test/hosts/shared/pre-tool-wrap.test.ts
+++ b/test/hosts/shared/pre-tool-wrap.test.ts
@@ -250,6 +250,28 @@ describe("buildWrappedCommand", () => {
     expect(wrapped).toBe("/usr/local/bin/tokenjuice wrap --source cursor -- /bin/bash -lc 'git status --short'");
   });
 
+  it("adds --store (and --store-dir) so the full output is persisted", () => {
+    expect(
+      buildWrappedCommand({
+        wrapLauncher: "/usr/local/bin/tokenjuice",
+        shellPath: "/bin/bash",
+        command: "git status --short",
+        source: "claude-code",
+        store: true,
+      }),
+    ).toBe("/usr/local/bin/tokenjuice wrap --source claude-code --store -- /bin/bash -lc 'git status --short'");
+
+    expect(
+      buildWrappedCommand({
+        wrapLauncher: "/usr/local/bin/tokenjuice",
+        shellPath: "/bin/bash",
+        command: "git status --short",
+        store: true,
+        storeDir: "/var/tmp/tj",
+      }),
+    ).toBe("/usr/local/bin/tokenjuice wrap --store --store-dir /var/tmp/tj -- /bin/bash -lc 'git status --short'");
+  });
+
   it("escapes commands containing single quotes through POSIX shellQuote", () => {
     const wrapped = buildWrappedCommand({
       wrapLauncher: "/usr/local/bin/tokenjuice",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
+    "types": ["node"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
## Why

CI-speedup track (2026-07-16 compute audit): typecheck was the last slow step in the ~51s `quality` job. TypeScript 7 (native Go tsc) typechecks this repo in <1s locally.

## What

- `typescript` `^5.9.3` → `^7.0.2`
- `tsconfig.json`: explicit `"types": ["node"]` — TS7 did not auto-discover `@types/node` in the pnpm layout (every `process`/node-global usage produced TS2591 without it).

## Verification (local, worktree)

- `pnpm typecheck` — pass, 0.78s wall
- `pnpm build` — pass (esbuild, 16ms)
- `pnpm test` — 763/763 pass
- `pnpm lint` — 0 warnings / 0 errors

No compiler-API consumers in this repo (only string fixtures mention typescript-eslint).
