### PR TITLE
fix(codex): fail open for oversized post-tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Let Codex hooks fail open without adding context when tool responses or hook input exceed safety limits.
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
 - Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites.

--- a/scripts/local-host-e2e.mjs
+++ b/scripts/local-host-e2e.mjs
@@ -198,10 +198,33 @@ async function runCodexE2E() {
     "expected authoritative Codex omissions to retain a factual recovery reference",
   );
 
+  // Exercise the packaged CLI at both fail-open thresholds: compaction itself
+  // is optional above 1 MiB, while stdin is drained above 16 MiB so Tokenjuice
+  // exits cleanly instead of failing on oversized hook input.
+  const oversizedResponse = await run(process.execPath, [distCliPath, "codex-post-tool-use"], {
+    env: { CODEX_HOME: codexHome },
+    input: postToolUsePayload("bin/rails test", "x".repeat(1024 * 1024 + 1)),
+  });
+  assert(oversizedResponse.code === 0, `expected oversized Codex hook exit 0, got ${oversizedResponse.code}`);
+  assert(oversizedResponse.stdout === "", "expected oversized Codex hook stdout to stay empty");
+  assert(oversizedResponse.stderr === "", `expected oversized Codex hook stderr to stay empty, got ${oversizedResponse.stderr}`);
+
+  const overInputLimit = await run(process.execPath, [distCliPath, "codex-post-tool-use"], {
+    env: { CODEX_HOME: codexHome },
+    input: postToolUsePayload("bin/rails test", "x".repeat(16 * 1024 * 1024)),
+  });
+  assert(overInputLimit.code === 0, `expected over-limit Codex hook exit 0, got ${overInputLimit.code}`);
+  assert(overInputLimit.stdout === "", "expected over-limit Codex hook stdout to stay empty");
+  assert(overInputLimit.stderr === "", `expected over-limit Codex hook stderr to stay empty, got ${overInputLimit.stderr}`);
+
   return {
     version: version.stdout.trim(),
     doctor: report.status,
-    exitCode: hook.code,
+    exitCodes: {
+      compacted: hook.code,
+      oversizedResponse: oversizedResponse.code,
+      overInputLimit: overInputLimit.code,
+    },
   };
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -53,7 +53,12 @@ import { doctorCodeRabbitConfig, installCodeRabbitConfig, uninstallCodeRabbitCon
 import { doctorCodeBuddyHook, installCodeBuddyHook, runCodeBuddyPreToolUseHook, uninstallCodeBuddyHook } from "../hosts/codebuddy/index.js";
 import { doctorCommandCodeHook, installCommandCodeHook, runCommandCodePostToolUseHook, uninstallCommandCodeHook } from "../hosts/command-code/index.js";
 import { doctorContinueRule, installContinueRule, uninstallContinueRule } from "../hosts/continue/index.js";
-import { doctorCodexHook, installCodexHook, runCodexPostToolUseHook, uninstallCodexHook } from "../hosts/codex/index.js";
+import {
+  doctorCodexHook,
+  installCodexHook,
+  runCodexPostToolUseHook,
+  uninstallCodexHook,
+} from "../hosts/codex/index.js";
 import { doctorCopilotAgentHook, installCopilotAgentHook, runCopilotAgentPostToolUseHook, uninstallCopilotAgentHook } from "../hosts/copilot-agent/index.js";
 import {
   doctorCopilotCliHook,
@@ -623,6 +628,28 @@ async function readStdin(maxBytes = DEFAULT_MAX_INPUT_BYTES): Promise<string> {
     chunks.push(buffer);
   }
   return Buffer.concat(chunks).toString("utf8");
+}
+
+async function readStdinForCodexHook(maxBytes = DEFAULT_MAX_INPUT_BYTES): Promise<string | undefined> {
+  if (inputStdin.isTTY) {
+    return "";
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let exceededLimit = false;
+  for await (const chunk of inputStdin) {
+    const buffer = Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (totalBytes > maxBytes) {
+      exceededLimit = true;
+      continue;
+    }
+    chunks.push(buffer);
+  }
+
+  // Drain stdin so Tokenjuice exits cleanly instead of failing on oversized hook input.
+  return exceededLimit ? undefined : Buffer.concat(chunks).toString("utf8");
 }
 
 async function readTextInput(file: string | undefined, maxBytes = DEFAULT_MAX_INPUT_BYTES): Promise<string> {
@@ -7393,10 +7420,16 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     case "stats":
       return await runStats(args);
     case "codex-post-tool-use":
-      return await runCodexPostToolUseHook(
-        await readStdin(args.maxInputBytes),
-        { noOmit: args.noOmit, allowOmit: args.allowOmit },
-      );
+      {
+        const hookInput = await readStdinForCodexHook(args.maxInputBytes);
+        if (hookInput === undefined) {
+          return 0;
+        }
+        return await runCodexPostToolUseHook(
+          hookInput,
+          { noOmit: args.noOmit, allowOmit: args.allowOmit },
+        );
+      }
     case "claude-code-pre-tool-use":
       return await runClaudeCodePreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "claude-code-post-tool-use":

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -46,6 +46,7 @@ type CodexPostToolUsePayload = {
 const GENERIC_FALLBACK_MIN_SAVED_CHARS = 120;
 const GENERIC_FALLBACK_MAX_RATIO = 0.75;
 const HOOK_REWRITE_MIN_SAVED_CHARS = 8;
+const CODEX_HOOK_MAX_COMPACTION_BYTES = 1 * 1024 * 1024;
 const CODEX_HOOK_LAST_LOG = "tokenjuice-hook.last.json";
 const CODEX_HOOK_HISTORY_LOG = "tokenjuice-hook.history.jsonl";
 const CODEX_HOOK_HISTORY_LIMIT = 200;
@@ -54,7 +55,7 @@ const CODEX_HOOK_HISTORY_LOCK_RETRY_MS = 25;
 const CODEX_HOOK_HISTORY_LOCK_RETRIES = 8;
 const LOW_NON_TOKENJUICE_TIMEOUT_SECONDS = 2;
 const RECOMMENDED_NON_TOKENJUICE_TIMEOUT_SECONDS = 6;
-const TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS = 10;
+const TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS = 30;
 
 export type InstallCodexHookResult = {
   hooksPath: string;
@@ -1010,19 +1011,23 @@ function shouldStoreFromEnv(): boolean {
 }
 
 async function writeHookDebug(record: Record<string, unknown>): Promise<void> {
-  const codexHome = getCodexHome();
-  const debugPath = join(codexHome, CODEX_HOOK_LAST_LOG);
-  const historyPath = join(codexHome, CODEX_HOOK_HISTORY_LOG);
-  const enrichedRecord = {
-    timestamp: new Date().toISOString(),
-    tokenjuiceVersion: packageJson.version,
-    hookCommandPath: process.argv[1],
-    ...record,
-  };
-  await mkdir(dirname(debugPath), { recursive: true });
-  await writeFile(debugPath, `${JSON.stringify(enrichedRecord, null, 2)}\n`, "utf8");
+  try {
+    const codexHome = getCodexHome();
+    const debugPath = join(codexHome, CODEX_HOOK_LAST_LOG);
+    const historyPath = join(codexHome, CODEX_HOOK_HISTORY_LOG);
+    const enrichedRecord = {
+      timestamp: new Date().toISOString(),
+      tokenjuiceVersion: packageJson.version,
+      hookCommandPath: process.argv[1],
+      ...record,
+    };
+    await mkdir(dirname(debugPath), { recursive: true });
+    await writeFile(debugPath, `${JSON.stringify(enrichedRecord, null, 2)}\n`, "utf8");
 
-  await writeHookHistoryEntry(historyPath, JSON.stringify(enrichedRecord));
+    await writeHookHistoryEntry(historyPath, JSON.stringify(enrichedRecord));
+  } catch {
+    // A diagnostic side effect must never turn an otherwise optional hook into a failed tool call.
+  }
 }
 
 function sanitizeHookHistoryLines(text: string): string[] {
@@ -1192,6 +1197,22 @@ export async function runCodexPostToolUseHook(
   const combinedText = stringifyToolResponse(payload.tool_response);
   if (!combinedText.trim()) {
     await writeHookDebug({ ...debug, skipped: "empty-tool-response" });
+    return 0;
+  }
+
+  const rawBytes = Buffer.byteLength(combinedText, "utf8");
+  if (rawBytes > CODEX_HOOK_MAX_COMPACTION_BYTES) {
+    const plainText = stripAnsi(combinedText);
+    const rawChars = countTextChars(plainText);
+    await writeHookDebug({
+      ...debug,
+      rawChars,
+      rawBytes,
+      reducedChars: rawChars,
+      savedChars: 0,
+      ratio: 1,
+      skipped: "response-too-large",
+    });
     return 0;
   }
 

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -182,7 +182,7 @@ describe("installCodexHook", () => {
     expect(parsed.hooks.PostToolUse[1]?.matcher).toBe("^Bash$");
     expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.command).toContain("codex-post-tool-use");
     expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.statusMessage).toBe("compacting bash output with tokenjuice");
-    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.timeout).toBe(10);
+    expect(parsed.hooks.PostToolUse[1]?.hooks[0]?.timeout).toBe(30);
   });
 
   it("prefers a stable tokenjuice launcher from PATH when installing the hook", async () => {
@@ -422,7 +422,7 @@ describe("doctorCodexHook", () => {
               type: "command",
               command: `${launcherPath} codex-post-tool-use ${staleFlag}`,
               statusMessage: "compacting bash output with tokenjuice",
-              timeout: 10,
+              timeout: 30,
             }],
           }],
         },
@@ -710,7 +710,7 @@ describe("doctorCodexHook", () => {
 
     expect(report.status).toBe("warn");
     expect(report.issues).toContain(
-      "configured Codex tokenjuice hook timeout is missing or stale; run tokenjuice install codex to add the 10s safety cap",
+      "configured Codex tokenjuice hook timeout is missing or stale; run tokenjuice install codex to add the 30s safety cap",
     );
   });
 
@@ -787,6 +787,125 @@ describe("doctorCodexHook", () => {
 });
 
 describe("runCodexPostToolUseHook", () => {
+  it("skips oversized Bash output without adding developer context", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "bin/rails test",
+      },
+      tool_response: "x".repeat(1024 * 1024 + 1),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rawBytes?: number;
+      rewrote?: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(debug.rawBytes).toBe(1024 * 1024 + 1);
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("response-too-large");
+  });
+
+  it("measures the response safety limit in UTF-8 bytes", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const atLimitPayload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "printf output",
+      },
+      tool_response: "\u00e9".repeat((1024 * 1024) / 2),
+    });
+    const atLimit = await captureStdio(() => runCodexPostToolUseHook(atLimitPayload));
+    const atLimitDebug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      skipped?: string;
+    };
+
+    expect(atLimit.code).toBe(0);
+    expect(atLimit.stderr).toBe("");
+    expect(atLimitDebug.skipped).not.toBe("response-too-large");
+
+    const overLimitPayload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "printf output",
+      },
+      tool_response: "\u00e9".repeat((1024 * 1024) / 2 + 1),
+    });
+    const overLimit = await captureStdio(() => runCodexPostToolUseHook(overLimitPayload));
+    const overLimitDebug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rawBytes?: number;
+      skipped?: string;
+    };
+
+    expect(overLimit.code).toBe(0);
+    expect(overLimit.stdout).toBe("");
+    expect(overLimit.stderr).toBe("");
+    expect(overLimitDebug.rawBytes).toBe(1024 * 1024 + 2);
+    expect(overLimitDebug.skipped).toBe("response-too-large");
+  });
+
+  it("counts ANSI escape bytes toward the response safety limit", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+    const ansiSequence = "\u001b[31m";
+    const toolResponse = ansiSequence.repeat(Math.floor((1024 * 1024) / Buffer.byteLength(ansiSequence)) + 1);
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "printf colored-output",
+      },
+      tool_response: toolResponse,
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rawBytes?: number;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(debug.rawBytes).toBe(Buffer.byteLength(toolResponse));
+    expect(debug.skipped).toBe("response-too-large");
+  });
+
+  it("does not fail the hook when its diagnostic directory is unavailable", async () => {
+    const home = await createTempDir();
+    const codexHomeFile = join(home, "codex-home-file");
+    await writeFile(codexHomeFile, "not a directory", "utf8");
+    process.env.CODEX_HOME = codexHomeFile;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git status --short",
+      },
+      tool_response: " M src/hosts/codex/index.ts\n",
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+  });
+
   it("returns post-tool feedback without a block decision when tokenjuice compacts output", async () => {
     const home = await createTempDir();
     process.env.CODEX_HOME = home;


### PR DESCRIPTION
## Problem

Oversized Codex PostToolUse payloads could make optional Tokenjuice processing fail or time out after the underlying command had already completed. Skip messages also entered Codex as developer context.

## Fix

- Raise the installed Tokenjuice Codex hook timeout from 10 to 30 seconds and migrate stale configurations through doctor/install.
- Skip compaction above 1 MiB measured as UTF-8 response bytes.
- Exit 0 with empty stdout/stderr for oversized responses and hook input, preserving the host-owned tool result without adding `systemMessage` or `additionalContext`.
- Drain hook stdin above 16 MiB so Tokenjuice exits cleanly instead of failing on oversized input.
- Keep debug/history writes fail-open.
- Preserve the landed omission policy and inert observation envelope for normal compaction.

## Coverage

- ASCII, multibyte UTF-8, and ANSI-heavy response boundaries.
- Empty-output fail-open behavior at both size limits.
- Unavailable diagnostic storage.
- 30-second install and doctor migration.
- Packaged Codex acceptance for normal compaction, oversized response, and oversized input.

## Verification

- Focused: 57 tests passed.
- `pnpm verify`: 132 files, 2,354 tests passed.
- `pnpm e2e:local`: Codex CLI 0.153.2, doctor healthy, all three hook paths exited 0.
- Branch autoreview against `4f8ed8b896ce5cad3e717e2c4a09ad5fdb66da7d`: clean.

Base: `4f8ed8b896ce5cad3e717e2c4a09ad5fdb66da7d`

Head: `4d201498ec9d1a31905fcdf9edd0b2369cd7fc93`
