### PR TITLE
fix(codex): pin Node runtime for npm launcher hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Let Codex hooks fail open without adding context when tool responses or hook input exceed safety limits.
+- Pin Codex JavaScript launchers to a verified Node runtime and report duplicate, missing, non-executable, runtime-skewed, and package-skewed hook commands.
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
 - Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites.

--- a/scripts/local-host-e2e.mjs
+++ b/scripts/local-host-e2e.mjs
@@ -123,6 +123,13 @@ async function runCodexE2E() {
   });
   const report = JSON.parse(doctor.stdout);
   assert(report.status === "ok", `expected Codex doctor status ok, got ${doctor.stdout}`);
+  assert(report.detectedCommands?.length === 1, `expected one Codex hook command, got ${doctor.stdout}`);
+  assert(report.detectedCommands[0]?.runtimePath === process.execPath, `expected pinned Codex Node runtime, got ${doctor.stdout}`);
+  assert(report.duplicateHookCount === 0, `expected no duplicate Codex hooks, got ${doctor.stdout}`);
+  assert(report.missingPaths?.length === 0, `expected no missing Codex hook paths, got ${doctor.stdout}`);
+  assert(report.nonExecutablePaths?.length === 0, `expected executable Codex hook paths, got ${doctor.stdout}`);
+  assert(report.runtimeMismatches?.length === 0, `expected current Codex Node runtime, got ${doctor.stdout}`);
+  assert(report.packageVersionMismatches?.length === 0, `expected current Codex package version, got ${doctor.stdout}`);
   const hookEnv = {
     CODEX_HOME: codexHome,
     // Keep the authoritative-vs-normalized assertions independent of a developer's shell env.

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -383,7 +383,17 @@ async function buildCodexHookCommand(options: CodexHookCommandOptions = {}): Pro
   if (!options.local) {
     const installedBinaryPath = await resolveInstalledTokenjuicePath();
     if (installedBinaryPath) {
-      command = `${shellQuote(installedBinaryPath)} codex-post-tool-use`;
+      let launcher = shellQuote(installedBinaryPath);
+      try {
+        if ((await realpath(installedBinaryPath)).endsWith(".js")) {
+          // Codex may execute hooks from a non-login environment with a different PATH.
+          // Pin the interpreter, but retain the launcher so package-manager upgrades stay atomic.
+          launcher = `${shellQuote(nodePath)} ${launcher}`;
+        }
+      } catch {
+        // Preserve package-manager wrappers when their final target cannot be inspected.
+      }
+      command = `${launcher} codex-post-tool-use`;
     }
   }
 

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -1,6 +1,5 @@
-import { constants as fsConstants } from "node:fs";
-import { access, appendFile, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
-import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
+import { appendFile, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
 
@@ -11,9 +10,15 @@ import { readNoOmissionFromEnv } from "../../core/env.js";
 import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
 import { countTextChars, sliceTextChars, stripAnsi } from "../../core/text.js";
-import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
+import { isNodeExecutablePath, parseShellWords } from "../shared/hook-command.js";
+import { buildTokenjuiceHookCommand } from "../shared/host-command.js";
+import { inspectTokenjuiceHookCommand } from "../shared/hook-command-doctor.js";
 
 import type { ToolExecutionInput } from "../../types.js";
+import type {
+  HookCommandPackageVersionMismatch,
+  HookCommandRuntimeMismatch,
+} from "../shared/hook-command-doctor.js";
 
 type CodexHookCommand = Record<string, unknown> & {
   type?: string;
@@ -118,6 +123,17 @@ function validateCodexOmissionPolicy(options: { noOmit?: boolean; allowOmit?: bo
   }
 }
 
+export type CodexHookCommandDiagnostic = {
+  location: string;
+  command: string;
+  checkedPaths: string[];
+  missingPaths: string[];
+  nonExecutablePaths: string[];
+  runtimePath?: string;
+  runtimeMismatch?: HookCommandRuntimeMismatch;
+  packageVersionMismatch?: HookCommandPackageVersionMismatch;
+};
+
 export type CodexDoctorReport = {
   hooksPath: string;
   status: "ok" | "warn" | "broken" | "disabled";
@@ -125,8 +141,13 @@ export type CodexDoctorReport = {
   fixCommand: string;
   expectedCommand: string;
   detectedCommand?: string;
+  detectedCommands: CodexHookCommandDiagnostic[];
+  duplicateHookCount: number;
   checkedPaths: string[];
   missingPaths: string[];
+  nonExecutablePaths: string[];
+  runtimeMismatches: Array<HookCommandRuntimeMismatch & { location: string }>;
+  packageVersionMismatches: Array<HookCommandPackageVersionMismatch & { location: string }>;
   featureFlag: CodexFeatureFlagStatus;
   runtimeConfig: CodexRuntimeConfigStatus;
 };
@@ -336,73 +357,11 @@ function parseCodexRuntimeConfig(source: string): Omit<CodexRuntimeConfigStatus,
   return values;
 }
 
-async function isExecutableFile(path: string): Promise<boolean> {
-  try {
-    await access(path, fsConstants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function resolveInstalledTokenjuicePath(): Promise<string | undefined> {
-  const pathValue = process.env.PATH;
-  if (!pathValue) {
-    return undefined;
-  }
-
-  const candidateNames = process.platform === "win32"
-    ? ["tokenjuice.exe", "tokenjuice.cmd", "tokenjuice.bat", "tokenjuice"]
-    : ["tokenjuice"];
-
-  for (const segment of pathValue.split(delimiter)) {
-    if (!segment) {
-      continue;
-    }
-
-    for (const candidateName of candidateNames) {
-      const candidatePath = join(segment, candidateName);
-      if (await isExecutableFile(candidatePath)) {
-        return candidatePath;
-      }
-    }
-  }
-
-  return undefined;
-}
-
 async function buildCodexHookCommand(options: CodexHookCommandOptions = {}): Promise<string> {
-  const rawBinaryPath = options.binaryPath ?? process.argv[1];
-  const binaryPath = rawBinaryPath && !isAbsolute(rawBinaryPath) ? resolve(rawBinaryPath) : rawBinaryPath;
-  const nodePath = options.nodePath ?? process.execPath;
-  if (!binaryPath) {
-    throw new Error("unable to resolve tokenjuice binary path for codex install");
-  }
-
-  let command: string | undefined;
-  if (!options.local) {
-    const installedBinaryPath = await resolveInstalledTokenjuicePath();
-    if (installedBinaryPath) {
-      let launcher = shellQuote(installedBinaryPath);
-      try {
-        if ((await realpath(installedBinaryPath)).endsWith(".js")) {
-          // Codex may execute hooks from a non-login environment with a different PATH.
-          // Pin the interpreter, but retain the launcher so package-manager upgrades stay atomic.
-          launcher = `${shellQuote(nodePath)} ${launcher}`;
-        }
-      } catch {
-        // Preserve package-manager wrappers when their final target cannot be inspected.
-      }
-      command = `${launcher} codex-post-tool-use`;
-    }
-  }
-
-  if (!command) {
-    command = binaryPath.endsWith(".js")
-      ? `${shellQuote(nodePath)} ${shellQuote(binaryPath)} codex-post-tool-use`
-      : `${shellQuote(binaryPath)} codex-post-tool-use`;
-  }
-
+  const command = await buildTokenjuiceHookCommand("codex-post-tool-use", "codex", {
+    ...options,
+    pinNodeForJavaScriptLauncher: true,
+  });
   return options.noOmit ? `${command} --no-omit` : command;
 }
 
@@ -411,15 +370,6 @@ function getCodexFixCommand(local = false, noOmit = false): string {
     local ? "tokenjuice install codex --local" : TOKENJUICE_CODEX_FIX_COMMAND,
     ...(noOmit ? ["--no-omit"] : []),
   ].join(" ");
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function newestMtimeMs(path: string): Promise<number | undefined> {
@@ -506,37 +456,36 @@ function createTokenjuiceCodexHook(command: string): CodexHookMatcherGroup {
   };
 }
 
+function isTokenjuiceCodexHookCommand(hook: CodexHookCommand): boolean {
+  const command = typeof hook.command === "string" ? hook.command : "";
+  return hook.statusMessage === TOKENJUICE_CODEX_STATUS
+    || command.includes("codex-post-tool-use")
+    || command.includes("post_tool_use_tokenjuice.py");
+}
+
 function isTokenjuiceCodexHook(group: CodexHookMatcherGroup): boolean {
-  return group.hooks.some((hook) => {
-    const command = typeof hook.command === "string" ? hook.command : "";
-    return hook.statusMessage === TOKENJUICE_CODEX_STATUS
-      || command.includes("codex-post-tool-use")
-      || command.includes("post_tool_use_tokenjuice.py");
-  });
+  return group.hooks.some((hook) => isTokenjuiceCodexHookCommand(hook));
 }
 
-function findTokenjuiceCodexHookCommand(config: CodexHooksConfig): string | undefined {
-  return findTokenjuiceCodexHook(config)?.command;
-}
-
-function findTokenjuiceCodexHook(config: CodexHooksConfig): CodexHookCommand | undefined {
-  for (const group of config.hooks.PostToolUse ?? []) {
-    if (!isTokenjuiceCodexHook(group)) {
-      continue;
-    }
-
-    const hook = group.hooks.find((hook) => {
-      const hookCommand = typeof hook.command === "string" ? hook.command : "";
-      return hook.statusMessage === TOKENJUICE_CODEX_STATUS
-        || hookCommand.includes("codex-post-tool-use")
-        || hookCommand.includes("post_tool_use_tokenjuice.py");
+function collectTokenjuiceCodexHookCommands(
+  config: CodexHooksConfig,
+): Array<{ location: string; hook: CodexHookCommand; command: string }> {
+  const commands: Array<{ location: string; hook: CodexHookCommand; command: string }> = [];
+  for (const [eventName, groups] of Object.entries(config.hooks)) {
+    groups.forEach((group, groupIndex) => {
+      group.hooks.forEach((hook, hookIndex) => {
+        if (!isTokenjuiceCodexHookCommand(hook) || typeof hook.command !== "string") {
+          return;
+        }
+        commands.push({
+          location: `${eventName}[${groupIndex}].hooks[${hookIndex}]`,
+          hook,
+          command: hook.command,
+        });
+      });
     });
-    if (hook) {
-      return hook;
-    }
   }
-
-  return undefined;
+  return commands;
 }
 
 function truncateHookCommand(command: string, maxLength = 80): string {
@@ -545,42 +494,6 @@ function truncateHookCommand(command: string, maxLength = 80): string {
     return trimmed;
   }
   return `${trimmed.slice(0, maxLength - 3)}...`;
-}
-
-function extractHomebrewCellarVersion(path: string): string | undefined {
-  const normalized = path.replace(/\\/gu, "/");
-  const match = normalized.match(/\/Cellar\/tokenjuice\/([^/]+)\//u);
-  return match?.[1];
-}
-
-async function detectResolvedHomebrewVersionMismatch(
-  commandPaths: string[],
-): Promise<{ launcherPath: string; resolvedPath: string; resolvedVersion: string } | undefined> {
-  for (const path of commandPaths) {
-    if (!path.endsWith("/tokenjuice") && !path.endsWith("\\tokenjuice") && !path.endsWith("\\tokenjuice.exe")) {
-      continue;
-    }
-
-    let resolvedPath: string;
-    try {
-      resolvedPath = await realpath(path);
-    } catch {
-      continue;
-    }
-
-    const resolvedVersion = extractHomebrewCellarVersion(resolvedPath);
-    if (!resolvedVersion || resolvedVersion === packageJson.version) {
-      continue;
-    }
-
-    return {
-      launcherPath: path,
-      resolvedPath,
-      resolvedVersion,
-    };
-  }
-
-  return undefined;
 }
 
 function collectLowTimeoutWarnings(config: CodexHooksConfig): string[] {
@@ -618,18 +531,16 @@ function collectLowTimeoutWarnings(config: CodexHooksConfig): string[] {
 }
 
 function collectTokenjuiceHookTimeoutWarnings(config: CodexHooksConfig, fixCommand: string): string[] {
-  const hook = findTokenjuiceCodexHook(config);
-  if (!hook) {
-    return [];
-  }
-
-  if (hook.timeout !== TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS) {
+  const staleCommands = collectTokenjuiceCodexHookCommands(config)
+    .filter(({ hook }) => hook.timeout !== TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS);
+  if (staleCommands.length === 1) {
     return [
       `configured Codex tokenjuice hook timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS}s safety cap`,
     ];
   }
-
-  return [];
+  return staleCommands.map(({ location }) =>
+    `configured Codex tokenjuice hook ${location} timeout is missing or stale; run ${fixCommand} to add the ${TOKENJUICE_CODEX_HOOK_TIMEOUT_SECONDS}s safety cap`
+  );
 }
 
 function sanitizeHooksConfig(raw: unknown): CodexHooksConfig {
@@ -916,10 +827,35 @@ export async function doctorCodexHook(
 ): Promise<CodexDoctorReport> {
   const noOmit = options.noOmit === true;
   const expectedCommand = await buildCodexHookCommand(options);
+  const expectedNodePath = options.nodePath ?? process.execPath;
   const installFixCommand = getCodexFixCommand(options.local, noOmit);
   let fixCommand = installFixCommand;
   const { config, exists } = await readHooksConfig(hooksPath);
-  const detectedCommand = findTokenjuiceCodexHookCommand(config);
+  const locatedCommands = collectTokenjuiceCodexHookCommands(config);
+  const detectedCommands = await Promise.all(
+    locatedCommands.map(async ({ location, command }): Promise<CodexHookCommandDiagnostic> => ({
+      location,
+      command,
+      ...(await inspectTokenjuiceHookCommand({
+        command,
+        expectedNodePath,
+        expectedPackageVersion: packageJson.version,
+      })),
+    })),
+  );
+  const detectedCommand = detectedCommands[0]?.command;
+  const duplicateHookCount = Math.max(0, detectedCommands.length - 1);
+  const checkedPaths = [...new Set(detectedCommands.flatMap((entry) => entry.checkedPaths))];
+  const missingPaths = [...new Set(detectedCommands.flatMap((entry) => entry.missingPaths))];
+  const nonExecutablePaths = [...new Set(detectedCommands.flatMap((entry) => entry.nonExecutablePaths))];
+  const runtimeMismatches = detectedCommands.flatMap((entry) =>
+    entry.runtimeMismatch ? [{ location: entry.location, ...entry.runtimeMismatch }] : []
+  );
+  const packageVersionMismatches = detectedCommands.flatMap((entry) =>
+    entry.packageVersionMismatch
+      ? [{ location: entry.location, ...entry.packageVersionMismatch }]
+      : []
+  );
   const featureFlag = await inspectCodexHooksFeatureFlag(options.featureFlagConfigPath);
   const runtimeConfig = await inspectCodexRuntimeConfig(options.featureFlagConfigPath);
 
@@ -930,8 +866,13 @@ export async function doctorCodexHook(
       issues: [],
       fixCommand,
       expectedCommand,
+      detectedCommands,
+      duplicateHookCount,
       checkedPaths: [],
       missingPaths: [],
+      nonExecutablePaths: [],
+      runtimeMismatches: [],
+      packageVersionMismatches: [],
       featureFlag,
       runtimeConfig,
     };
@@ -944,25 +885,27 @@ export async function doctorCodexHook(
       issues: [],
       fixCommand,
       expectedCommand,
+      detectedCommands,
+      duplicateHookCount,
       checkedPaths: [],
       missingPaths: [],
+      nonExecutablePaths: [],
+      runtimeMismatches: [],
+      packageVersionMismatches: [],
       featureFlag,
       runtimeConfig,
     };
   }
 
-  const checkedPaths = extractHookCommandPaths(detectedCommand);
-  const missingPaths: string[] = [];
-  for (const path of checkedPaths) {
-    if (!(await isExecutableFile(path)) && !(path.endsWith(".js") && await pathExists(path))) {
-      missingPaths.push(path);
-    }
-  }
-
   const issues: string[] = [];
-  const commandMismatch = detectedCommand !== expectedCommand;
+  const commandMismatch = detectedCommands.some((entry) => entry.command !== expectedCommand);
+  if (duplicateHookCount > 0) {
+    issues.push(
+      `configured Codex hooks contain ${detectedCommands.length} tokenjuice commands; expected exactly one managed hook`,
+    );
+  }
   if (commandMismatch) {
-    if (detectedCommand.includes("/Cellar/")) {
+    if (detectedCommands.some((entry) => entry.command.includes("/Cellar/"))) {
       issues.push("configured Codex hook is pinned to a versioned Homebrew Cellar path");
     } else {
       issues.push("configured Codex hook command does not match the current recommended command");
@@ -971,10 +914,17 @@ export async function doctorCodexHook(
   if (missingPaths.length > 0) {
     issues.push(`configured Codex hook points at missing path${missingPaths.length === 1 ? "" : "s"}`);
   }
-  const resolvedVersionMismatch = await detectResolvedHomebrewVersionMismatch(checkedPaths);
-  if (resolvedVersionMismatch) {
+  if (nonExecutablePaths.length > 0) {
+    issues.push(`configured Codex hook points at non-executable path${nonExecutablePaths.length === 1 ? "" : "s"}`);
+  }
+  for (const mismatch of runtimeMismatches) {
     issues.push(
-      `configured Codex hook launcher resolves to Homebrew tokenjuice ${resolvedVersionMismatch.resolvedVersion}, but this tokenjuice is ${packageJson.version}`,
+      `configured Codex hook ${mismatch.location} uses Node runtime ${mismatch.configuredPath}, but this tokenjuice uses ${mismatch.expectedPath}`,
+    );
+  }
+  for (const mismatch of packageVersionMismatches) {
+    issues.push(
+      `configured Codex hook launcher resolves to Homebrew tokenjuice ${mismatch.resolvedVersion}, but this tokenjuice is ${mismatch.expectedVersion}`,
     );
     fixCommand = commandMismatch
       ? `brew upgrade tokenjuice && ${installFixCommand}`
@@ -994,13 +944,22 @@ export async function doctorCodexHook(
 
   return {
     hooksPath,
-    status: missingPaths.length > 0 ? "broken" : issues.length > 0 ? "warn" : "ok",
+    status: missingPaths.length > 0 || nonExecutablePaths.length > 0
+      ? "broken"
+      : issues.length > 0
+        ? "warn"
+        : "ok",
     issues,
     fixCommand,
     expectedCommand,
     detectedCommand,
+    detectedCommands,
+    duplicateHookCount,
     checkedPaths,
     missingPaths,
+    nonExecutablePaths,
+    runtimeMismatches,
+    packageVersionMismatches,
     featureFlag,
     runtimeConfig,
   };

--- a/src/hosts/shared/hook-command-doctor.ts
+++ b/src/hosts/shared/hook-command-doctor.ts
@@ -1,4 +1,33 @@
-import { findMissingHookCommandPaths } from "./host-command.js";
+import { realpath } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+
+import {
+  findMissingHookCommandPaths,
+  isExecutableFile,
+  parseTokenjuiceHookCommand,
+  pathExists,
+} from "./host-command.js";
+
+export type HookCommandRuntimeMismatch = {
+  configuredPath: string;
+  expectedPath: string;
+};
+
+export type HookCommandPackageVersionMismatch = {
+  launcherPath: string;
+  resolvedPath: string;
+  resolvedVersion: string;
+  expectedVersion: string;
+};
+
+export type HookCommandInspection = {
+  checkedPaths: string[];
+  missingPaths: string[];
+  nonExecutablePaths: string[];
+  runtimePath?: string;
+  runtimeMismatch?: HookCommandRuntimeMismatch;
+  packageVersionMismatch?: HookCommandPackageVersionMismatch;
+};
 
 export type HookCommandDoctorStatus = "ok" | "broken" | "disabled";
 
@@ -12,6 +41,101 @@ export type HookCommandDoctorFields = {
   checkedPaths: string[];
   missingPaths: string[];
 };
+
+function extractHomebrewCellarVersion(path: string): string | undefined {
+  const normalized = path.replace(/\\/gu, "/");
+  return normalized.match(/\/Cellar\/tokenjuice\/([^/]+)\//u)?.[1];
+}
+
+async function pathsResolveToSameFile(left: string, right: string): Promise<boolean> {
+  if (left === right) {
+    return true;
+  }
+  try {
+    return await realpath(left) === await realpath(right);
+  } catch {
+    return false;
+  }
+}
+
+async function isNodeInvokedJavaScriptLauncher(
+  path: string,
+  runtimePath: string | undefined,
+  launcherPath: string | undefined,
+): Promise<boolean> {
+  if (!runtimePath || path !== launcherPath) {
+    return false;
+  }
+  try {
+    return (await realpath(path)).endsWith(".js");
+  } catch {
+    return false;
+  }
+}
+
+export async function inspectTokenjuiceHookCommand(options: {
+  command: string;
+  expectedNodePath?: string;
+  expectedPackageVersion?: string;
+  platform?: NodeJS.Platform;
+}): Promise<HookCommandInspection> {
+  const parsed = parseTokenjuiceHookCommand(options.command, options.platform);
+  const missingPaths = await findMissingHookCommandPaths(options.command, options.platform);
+  const nonExecutablePaths: string[] = [];
+
+  for (const path of parsed.checkedPaths) {
+    if (
+      missingPaths.includes(path)
+      || path.endsWith(".js")
+      || await isNodeInvokedJavaScriptLauncher(path, parsed.runtimePath, parsed.launcherPath)
+    ) {
+      continue;
+    }
+    if (!(await isExecutableFile(path))) {
+      nonExecutablePaths.push(path);
+    }
+  }
+
+  let runtimeMismatch: HookCommandRuntimeMismatch | undefined;
+  if (
+    parsed.runtimePath
+    && options.expectedNodePath
+    && isAbsolute(parsed.runtimePath)
+    && !(await pathsResolveToSameFile(parsed.runtimePath, options.expectedNodePath))
+  ) {
+    runtimeMismatch = {
+      configuredPath: parsed.runtimePath,
+      expectedPath: options.expectedNodePath,
+    };
+  }
+
+  let packageVersionMismatch: HookCommandPackageVersionMismatch | undefined;
+  if (parsed.launcherPath && options.expectedPackageVersion && await pathExists(parsed.launcherPath)) {
+    try {
+      const resolvedPath = await realpath(parsed.launcherPath);
+      const resolvedVersion = extractHomebrewCellarVersion(resolvedPath);
+      if (resolvedVersion && resolvedVersion !== options.expectedPackageVersion) {
+        packageVersionMismatch = {
+          launcherPath: parsed.launcherPath,
+          resolvedPath,
+          resolvedVersion,
+          expectedVersion: options.expectedPackageVersion,
+        };
+      }
+    } catch {
+      // Missing and unreadable paths are reported separately.
+    }
+  }
+
+  return {
+    checkedPaths: parsed.checkedPaths,
+    missingPaths,
+    nonExecutablePaths,
+    ...(parsed.runtimePath ? { runtimePath: parsed.runtimePath } : {}),
+    ...(runtimeMismatch ? { runtimeMismatch } : {}),
+    ...(packageVersionMismatch ? { packageVersionMismatch } : {}),
+  };
+}
 
 export async function buildHookCommandDoctorFields(options: {
   expectedCommand: string;

--- a/src/hosts/shared/hook-command.ts
+++ b/src/hosts/shared/hook-command.ts
@@ -159,7 +159,12 @@ export function extractHookCommandPaths(command: string, platform = process.plat
   }
 
   const second = argv[1];
-  if (first && second && isNodeExecutablePath(first) && second.endsWith(".js")) {
+  if (
+    first
+    && second
+    && isNodeExecutablePath(first)
+    && (second.endsWith(".js") || isTokenjuiceExecutablePath(second))
+  ) {
     paths.add(second);
   }
 

--- a/src/hosts/shared/host-command.ts
+++ b/src/hosts/shared/host-command.ts
@@ -1,17 +1,35 @@
 import { constants as fsConstants } from "node:fs";
-import { access } from "node:fs/promises";
+import { access, realpath, stat } from "node:fs/promises";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 
-import { extractHookCommandPaths, shellQuote } from "./hook-command.js";
+import {
+  extractHookCommandPaths,
+  isNodeExecutablePath,
+  isTokenjuiceExecutablePath,
+  parseShellWords,
+  shellQuote,
+} from "./hook-command.js";
 
 export type TokenjuiceHookCommandOptions = {
   local?: boolean;
   binaryPath?: string;
   nodePath?: string;
+  pinNodeForJavaScriptLauncher?: boolean;
+};
+
+export type ParsedTokenjuiceHookCommand = {
+  argv: string[];
+  checkedPaths: string[];
+  runtimePath?: string;
+  launcherPath?: string;
+  subcommand?: string;
 };
 
 export async function isExecutableFile(path: string): Promise<boolean> {
   try {
+    if (!(await stat(path)).isFile()) {
+      return false;
+    }
     await access(path, fsConstants.X_OK);
     return true;
   } catch {
@@ -71,14 +89,60 @@ export async function buildTokenjuiceHookCommand(
     launcher = installedBinaryPath ?? binaryPath;
   }
 
+  if (!options.local && options.pinNodeForJavaScriptLauncher) {
+    try {
+      if ((await realpath(launcher)).endsWith(".js")) {
+        return `${shellQuote(nodePath)} ${shellQuote(launcher)} ${subcommand}`;
+      }
+    } catch {
+      // Preserve package-manager launchers when their final target cannot be inspected.
+    }
+  }
+
   if (launcher.endsWith(".js")) {
     return `${shellQuote(nodePath)} ${shellQuote(launcher)} ${subcommand}`;
   }
   return `${shellQuote(launcher)} ${subcommand}`;
 }
 
-export async function findMissingHookCommandPaths(command: string): Promise<string[]> {
-  const paths = extractHookCommandPaths(command);
+export function parseTokenjuiceHookCommand(
+  command: string,
+  platform = process.platform,
+): ParsedTokenjuiceHookCommand {
+  const argv = parseShellWords(command, platform);
+  const first = argv[0];
+  const second = argv[1];
+
+  if (first && isNodeExecutablePath(first) && second) {
+    return {
+      argv,
+      checkedPaths: extractHookCommandPaths(command, platform),
+      runtimePath: first,
+      launcherPath: second,
+      ...(argv[2] ? { subcommand: argv[2] } : {}),
+    };
+  }
+
+  if (first && isTokenjuiceExecutablePath(first)) {
+    return {
+      argv,
+      checkedPaths: extractHookCommandPaths(command, platform),
+      launcherPath: first,
+      ...(second ? { subcommand: second } : {}),
+    };
+  }
+
+  return {
+    argv,
+    checkedPaths: extractHookCommandPaths(command, platform),
+  };
+}
+
+export async function findMissingHookCommandPaths(
+  command: string,
+  platform = process.platform,
+): Promise<string[]> {
+  const paths = extractHookCommandPaths(command, platform);
   const missing: string[] = [];
   for (const path of paths) {
     if (!(await pathExists(path))) {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -404,6 +404,19 @@ describe("doctorCodexHook", () => {
 
     expect(report.status).toBe("ok");
     expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(report.detectedCommands).toEqual([
+      {
+        location: "PostToolUse[0].hooks[0]",
+        command: `${launcherPath} codex-post-tool-use`,
+        checkedPaths: [launcherPath],
+        missingPaths: [],
+        nonExecutablePaths: [],
+      },
+    ]);
+    expect(report.duplicateHookCount).toBe(0);
+    expect(report.nonExecutablePaths).toEqual([]);
+    expect(report.runtimeMismatches).toEqual([]);
+    expect(report.packageVersionMismatches).toEqual([]);
     expect(report.issues).toEqual([]);
     expect(report.featureFlag.enabled).toBe(true);
   });
@@ -527,6 +540,11 @@ describe("doctorCodexHook", () => {
 
     expect(currentReport.status).toBe("ok");
     expect(currentReport.detectedCommand).toBe(`${nodePath} ${launcherPath} codex-post-tool-use`);
+    expect(currentReport.detectedCommands[0]).toMatchObject({
+      location: "PostToolUse[0].hooks[0]",
+      command: `${nodePath} ${launcherPath} codex-post-tool-use`,
+      runtimePath: nodePath,
+    });
     expect(currentReport.issues).toEqual([]);
 
     await rm(launcherPath);
@@ -565,6 +583,15 @@ describe("doctorCodexHook", () => {
     expect(report.issues).toContain(
       `configured Codex hook launcher resolves to Homebrew tokenjuice 0.0.1, but this tokenjuice is ${PACKAGE_VERSION}`,
     );
+    expect(report.packageVersionMismatches).toEqual([
+      {
+        location: "PostToolUse[0].hooks[0]",
+        launcherPath,
+        resolvedPath: await realpath(resolvedLauncherPath),
+        resolvedVersion: "0.0.1",
+        expectedVersion: PACKAGE_VERSION,
+      },
+    ]);
     expect(report.issues).not.toContain("configured Codex hook command does not match the current recommended command");
 
     const policyReport = await doctorCodexHook(hooksPath, {
@@ -580,6 +607,159 @@ describe("doctorCodexHook", () => {
     expect(policyReport.issues).toContain(
       "configured Codex hook command does not match the current recommended command",
     );
+  });
+
+  it("reports every managed command and duplicate Codex hooks", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const launcherPath = join(home, "tokenjuice");
+    const command = `${launcherPath} codex-post-tool-use`;
+
+    process.env.PATH = "";
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [
+                {
+                  type: "command",
+                  command,
+                  statusMessage: "compacting bash output with tokenjuice",
+                  timeout: 10,
+                },
+              ],
+            },
+            {
+              matcher: "^Bash$",
+              hooks: [
+                {
+                  type: "command",
+                  command,
+                  statusMessage: "compacting bash output with tokenjuice",
+                  timeout: 10,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, {
+      local: true,
+      binaryPath: launcherPath,
+    });
+
+    expect(report.status).toBe("warn");
+    expect(report.detectedCommands.map((entry) => entry.location)).toEqual([
+      "PostToolUse[0].hooks[0]",
+      "PostToolUse[1].hooks[0]",
+    ]);
+    expect(report.duplicateHookCount).toBe(1);
+    expect(report.issues).toContain(
+      "configured Codex hooks contain 2 tokenjuice commands; expected exactly one managed hook",
+    );
+  });
+
+  it("reports absolute Node runtime drift without executing the configured hook", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const configuredNodePath = join(home, "old", "bin", "node");
+    const expectedNodePath = join(home, "current", "bin", "node");
+    const launcherPath = join(home, "tokenjuice");
+    const command = `${configuredNodePath} ${launcherPath} codex-post-tool-use`;
+
+    process.env.PATH = "";
+    await mkdir(join(home, "old", "bin"), { recursive: true });
+    await mkdir(join(home, "current", "bin"), { recursive: true });
+    await writeFile(configuredNodePath, "#!/usr/bin/env bash\nexit 91\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(expectedNodePath, "#!/usr/bin/env bash\nexit 92\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 93\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [
+                {
+                  type: "command",
+                  command,
+                  statusMessage: "compacting bash output with tokenjuice",
+                  timeout: 10,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, {
+      local: true,
+      binaryPath: launcherPath,
+      nodePath: expectedNodePath,
+    });
+
+    expect(report.status).toBe("warn");
+    expect(report.runtimeMismatches).toEqual([
+      {
+        location: "PostToolUse[0].hooks[0]",
+        configuredPath: configuredNodePath,
+        expectedPath: expectedNodePath,
+      },
+    ]);
+    expect(report.issues).toContain(
+      `configured Codex hook PostToolUse[0].hooks[0] uses Node runtime ${configuredNodePath}, but this tokenjuice uses ${expectedNodePath}`,
+    );
+  });
+
+  it("reports present but non-executable hook paths as broken", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const launcherPath = join(home, "tokenjuice");
+    const command = `${launcherPath} codex-post-tool-use`;
+
+    process.env.PATH = "";
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o644 });
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [
+                {
+                  type: "command",
+                  command,
+                  statusMessage: "compacting bash output with tokenjuice",
+                  timeout: 10,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const report = await doctorCodexHook(hooksPath, {
+      local: true,
+      binaryPath: launcherPath,
+    });
+
+    expect(report.status).toBe("broken");
+    expect(report.missingPaths).toEqual([]);
+    expect(report.nonExecutablePaths).toEqual([launcherPath]);
+    expect(report.issues).toContain("configured Codex hook points at non-executable path");
   });
 
   it("treats absent hooks feature flag as enabled for current Codex", async () => {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -208,6 +208,34 @@ describe("installCodexHook", () => {
     expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(`${launcherPath} codex-post-tool-use`);
   });
 
+  it("pins the current Node runtime when the installed launcher resolves to JavaScript", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const wrongNodePath = join(binDir, "node");
+    const installedCliPath = join(home, "lib", "tokenjuice", "dist", "cli", "main.js");
+    const nodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(dirname(installedCliPath), { recursive: true });
+    await writeFile(wrongNodePath, "#!/usr/bin/env bash\nexit 99\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(installedCliPath, "#!/usr/bin/env node\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(nodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(installedCliPath, launcherPath);
+
+    const result = await installCodexHook(hooksPath, { nodePath });
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.command).toBe(`${nodePath} ${launcherPath} codex-post-tool-use`);
+    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(
+      `${nodePath} ${launcherPath} codex-post-tool-use`,
+    );
+  });
+
   it("does not persist the no-omit environment in the installed hook command", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");
@@ -447,6 +475,69 @@ describe("doctorCodexHook", () => {
     expect(explicitReport.expectedCommand).toBe(`${launcherPath} codex-post-tool-use --no-omit`);
     expect(explicitReport.fixCommand).toBe("tokenjuice install codex --no-omit");
     expect(explicitReport.issues).toEqual([]);
+  });
+
+  it("warns for an npm launcher-only hook and accepts the pinned Node command", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const installedCliPath = join(home, "lib", "tokenjuice", "dist", "cli", "main.js");
+    const nodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(dirname(installedCliPath), { recursive: true });
+    await writeFile(installedCliPath, "#!/usr/bin/env node\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(nodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(installedCliPath, launcherPath);
+    await writeFile(
+      hooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^Bash$",
+              hooks: [
+                {
+                  type: "command",
+                  command: `${launcherPath} codex-post-tool-use`,
+                  statusMessage: "compacting bash output with tokenjuice",
+                  timeout: 30,
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const staleReport = await doctorCodexHook(hooksPath, { nodePath });
+
+    expect(staleReport.status).toBe("warn");
+    expect(staleReport.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(staleReport.expectedCommand).toBe(`${nodePath} ${launcherPath} codex-post-tool-use`);
+    expect(staleReport.issues).toContain(
+      "configured Codex hook command does not match the current recommended command",
+    );
+
+    await installCodexHook(hooksPath, { nodePath });
+    const currentReport = await doctorCodexHook(hooksPath, { nodePath });
+
+    expect(currentReport.status).toBe("ok");
+    expect(currentReport.detectedCommand).toBe(`${nodePath} ${launcherPath} codex-post-tool-use`);
+    expect(currentReport.issues).toEqual([]);
+
+    await rm(launcherPath);
+    const missingLauncherReport = await doctorCodexHook(hooksPath, {
+      binaryPath: installedCliPath,
+      nodePath,
+    });
+
+    expect(missingLauncherReport.status).toBe("broken");
+    expect(missingLauncherReport.checkedPaths).toContain(launcherPath);
+    expect(missingLauncherReport.missingPaths).toContain(launcherPath);
   });
 
   it("warns when the stable launcher resolves to an older Homebrew tokenjuice version", async () => {

--- a/test/hosts/shared/hook-command-doctor.test.ts
+++ b/test/hosts/shared/hook-command-doctor.test.ts
@@ -1,0 +1,95 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { inspectTokenjuiceHookCommand } from "../../../src/hosts/shared/hook-command-doctor.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-hook-command-doctor-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("inspectTokenjuiceHookCommand", () => {
+  it("reports runtime and Homebrew package-version drift without executing the hook", async () => {
+    const home = await createTempDir();
+    const configuredNodePath = join(home, "old", "bin", "node");
+    const expectedNodePath = join(home, "current", "bin", "node");
+    const binDir = join(home, "opt", "homebrew", "bin");
+    const cellarDir = join(home, "opt", "homebrew", "Cellar", "tokenjuice", "0.7.0", "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const resolvedLauncherPath = join(cellarDir, "tokenjuice");
+
+    await mkdir(binDir, { recursive: true });
+    await mkdir(cellarDir, { recursive: true });
+    await mkdir(join(home, "old", "bin"), { recursive: true });
+    await mkdir(join(home, "current", "bin"), { recursive: true });
+    await writeFile(configuredNodePath, "#!/usr/bin/env bash\nexit 91\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(expectedNodePath, "#!/usr/bin/env bash\nexit 92\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(resolvedLauncherPath, "#!/usr/bin/env bash\nexit 93\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(resolvedLauncherPath, launcherPath);
+
+    const report = await inspectTokenjuiceHookCommand({
+      command: `${configuredNodePath} ${launcherPath} codex-post-tool-use`,
+      expectedNodePath,
+      expectedPackageVersion: "0.8.1",
+    });
+
+    expect(report.missingPaths).toEqual([]);
+    expect(report.nonExecutablePaths).toEqual([]);
+    expect(report.runtimeMismatch).toEqual({
+      configuredPath: configuredNodePath,
+      expectedPath: expectedNodePath,
+    });
+    expect(report.packageVersionMismatch).toEqual({
+      launcherPath,
+      resolvedPath: await realpath(resolvedLauncherPath),
+      resolvedVersion: "0.7.0",
+      expectedVersion: "0.8.1",
+    });
+  });
+
+  it("distinguishes missing paths from present non-executable launchers", async () => {
+    const home = await createTempDir();
+    const launcherPath = join(home, "tokenjuice");
+    const missingNodePath = join(home, "node");
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o644 });
+
+    const report = await inspectTokenjuiceHookCommand({
+      command: `${missingNodePath} ${launcherPath} codex-post-tool-use`,
+      expectedNodePath: missingNodePath,
+    });
+
+    expect(report.missingPaths).toEqual([missingNodePath]);
+    expect(report.nonExecutablePaths).toEqual([launcherPath]);
+  });
+
+  it("does not require execute permission for a Node-invoked JavaScript launcher", async () => {
+    const home = await createTempDir();
+    const nodePath = join(home, "bin", "node");
+    const launcherPath = join(home, "bin", "tokenjuice");
+    const scriptPath = join(home, "lib", "tokenjuice", "dist", "cli", "main.js");
+
+    await mkdir(join(home, "bin"), { recursive: true });
+    await mkdir(join(home, "lib", "tokenjuice", "dist", "cli"), { recursive: true });
+    await writeFile(nodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(scriptPath, "console.log('tokenjuice');\n", { encoding: "utf8", mode: 0o644 });
+    await symlink(scriptPath, launcherPath);
+
+    const report = await inspectTokenjuiceHookCommand({
+      command: `${nodePath} ${launcherPath} codex-post-tool-use`,
+      expectedNodePath: nodePath,
+    });
+
+    expect(report.missingPaths).toEqual([]);
+    expect(report.nonExecutablePaths).toEqual([]);
+  });
+});

--- a/test/hosts/shared/hook-command.test.ts
+++ b/test/hosts/shared/hook-command.test.ts
@@ -69,6 +69,17 @@ describe("parseShellWords", () => {
 });
 
 describe("extractHookCommandPaths", () => {
+  it("extracts both Node and a stable tokenjuice launcher from pinned commands", () => {
+    expect(
+      extractHookCommandPaths(
+        "/opt/node/bin/node /usr/local/bin/tokenjuice codex-post-tool-use --no-omit",
+      ),
+    ).toEqual([
+      "/opt/node/bin/node",
+      "/usr/local/bin/tokenjuice",
+    ]);
+  });
+
   it("extracts Windows launcher and script paths from quoted node commands", () => {
     const nodePath = String.raw`C:\Program Files\nodejs\node.exe`;
     const scriptPath = String.raw`C:\Users\andre\OneDrive\Documents\Github\tokenjuice\dist\cli\main.js`;

--- a/test/hosts/shared/host-command.test.ts
+++ b/test/hosts/shared/host-command.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildTokenjuiceHookCommand,
+  parseTokenjuiceHookCommand,
+} from "../../../src/hosts/shared/host-command.js";
+
+const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "tokenjuice-host-command-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("buildTokenjuiceHookCommand", () => {
+  it("pins Node for hosts that require a JavaScript launcher runtime", async () => {
+    const home = await createTempDir();
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const installedCliPath = join(home, "lib", "tokenjuice", "dist", "cli", "main.js");
+    const nodePath = join(home, "node");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await mkdir(dirname(installedCliPath), { recursive: true });
+    await writeFile(installedCliPath, "#!/usr/bin/env node\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(nodePath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await symlink(installedCliPath, launcherPath);
+
+    await expect(
+      buildTokenjuiceHookCommand("codex-post-tool-use", "codex", {
+        nodePath,
+        pinNodeForJavaScriptLauncher: true,
+      }),
+    ).resolves.toBe(`${nodePath} ${launcherPath} codex-post-tool-use`);
+  });
+});
+
+describe("parseTokenjuiceHookCommand", () => {
+  it("separates the runtime, stable launcher, and subcommand", () => {
+    expect(
+      parseTokenjuiceHookCommand(
+        "/opt/node/bin/node /usr/local/bin/tokenjuice codex-post-tool-use",
+      ),
+    ).toEqual({
+      argv: [
+        "/opt/node/bin/node",
+        "/usr/local/bin/tokenjuice",
+        "codex-post-tool-use",
+      ],
+      checkedPaths: [
+        "/opt/node/bin/node",
+        "/usr/local/bin/tokenjuice",
+      ],
+      runtimePath: "/opt/node/bin/node",
+      launcherPath: "/usr/local/bin/tokenjuice",
+      subcommand: "codex-post-tool-use",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Pin the current Node executable when an installed Tokenjuice launcher resolves to JavaScript, while retaining the stable package-manager launcher path.
- Centralize hook launcher construction and command parsing in shared host-command ownership.
- Extend the read-only Codex doctor JSON report to enumerate every Tokenjuice hook command and detect duplicates, missing paths, non-executable paths, absolute Node runtime drift, and Homebrew package-version skew.
- Preserve contributor authorship and the landed #211/#214 oversized-input and inert-feedback behavior.

## Why

Codex hooks may run from a non-login app-server environment with a minimal `PATH`. An npm launcher that relies on `#!/usr/bin/env node` can select an unintended or stale system Node runtime. Existing doctor output also inspected only the first matching hook, which hid duplicate and drifted installations.

Doctor remains read-only: it does not execute hooks or repair configuration.

## Rebase

- Base: `63823b3e31e40af752efe938419eff6de163dfd0`
- Head: `d94aaceebea01ba0eb3197a4322a7223c59f0ca6`
- Contributor commits and authorship preserved; all rebased commits are signed.

## Validation

- Focused Vitest suite: `6` files, `103` tests passed.
- `pnpm build`
- Built local hook install, JSON doctor, and configured PostToolUse command acceptance passed.
- `pnpm verify`: lint, circular dependency scan, typecheck, `134` test files and `2,365` tests passed.
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

The full Codex app-server schema acceptance is unavailable on this machine because its `codex` shim reports that the official standalone CLI is not installed.
