### PR TITLE
fix(codex): avoid raw hints for non-authoritative rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
+- Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites.
 - Keep raw and full command output available when optional telemetry storage is unavailable.
 - Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output.
 - Render successful generic error and warning counters as neutral mentions.

--- a/scripts/local-host-e2e.mjs
+++ b/scripts/local-host-e2e.mjs
@@ -20,14 +20,11 @@ function assert(condition, message) {
   }
 }
 
-function compactableOutput(prefix, count) {
-  return Array.from({ length: count }, (_, index) => `${prefix}/example-${index + 1}.json`).join("\n");
-}
-
-function postToolUsePayload(command, toolResponse) {
+function postToolUsePayload(command, toolResponse, exitCode = 0) {
   return `${JSON.stringify({
     hook_event_name: "PostToolUse",
     tool_name: "Bash",
+    exit_code: exitCode,
     tool_input: { command },
     tool_response: toolResponse,
   })}\n`;
@@ -126,13 +123,28 @@ async function runCodexE2E() {
   });
   const report = JSON.parse(doctor.stdout);
   assert(report.status === "ok", `expected Codex doctor status ok, got ${doctor.stdout}`);
+  const hookEnv = {
+    CODEX_HOME: codexHome,
+    // Keep the authoritative-vs-normalized assertions independent of a developer's shell env.
+    TOKENJUICE_NO_OMISSION: "",
+  };
 
   const payload = postToolUsePayload(
-    "find src/rules -maxdepth 2 -type f | head -n 40",
-    compactableOutput("src/rules", 40),
+    "git status",
+    [
+      "On branch pr-65478-security-fix",
+      "Your branch and 'origin/pr-65478-security-fix' have diverged,",
+      "and have 8 and 642 different commits each, respectively.",
+      "",
+      "Changes not staged for commit:",
+      "\tmodified:   src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts",
+      "\tmodified:   src/agents/pi-embedded-runner/run/attempt.test.ts",
+      "",
+      "no changes added to commit",
+    ].join("\n"),
   );
   const hook = await run(process.execPath, [distCliPath, "codex-post-tool-use"], {
-    env: { CODEX_HOME: codexHome },
+    env: hookEnv,
     input: payload,
   });
 
@@ -141,10 +153,50 @@ async function runCodexE2E() {
   const additionalContext = output.hookSpecificOutput?.additionalContext;
   assert(output.hookSpecificOutput?.hookEventName === "PostToolUse", "expected Codex PostToolUse output");
   assert(typeof additionalContext === "string", "expected Codex additionalContext");
-  assert(additionalContext.includes("40 matches"), "expected Codex hook output to contain compacted match count");
-  assert(additionalContext.includes("src/rules/example-1.json"), "expected Codex hook output to include compacted paths");
-  assert(additionalContext.includes("tokenjuice wrap --raw -- <command>"), "expected Codex hook output to include raw rerun hint");
+  const observationPrefix = "<tokenjuice_compacted_tool_observation>\n";
+  const observationSuffix = "\n</tokenjuice_compacted_tool_observation>";
+  assert(additionalContext.startsWith(observationPrefix), "expected delimited Codex observation");
+  assert(additionalContext.endsWith(observationSuffix), "expected closed Codex observation");
+  const observation = JSON.parse(additionalContext.slice(observationPrefix.length, -observationSuffix.length));
+  assert(observation.source === "codex-post-tool-use", "expected factual Codex observation source");
+  assert(observation.exitCode === 0, "expected factual Codex observation exit code");
+  assert(observation.authority === "non-authoritative-rewrite", "expected non-authoritative rewrite label");
+  assert(observation.compactedOutput.includes("Changes not staged:"), "expected Codex hook output to retain status context");
+  assert(
+    observation.compactedOutput.includes("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts"),
+    "expected Codex hook output to include compacted status paths",
+  );
+  assert(!observation.compactedOutput.includes("and have 8 and 642"), "expected Codex hook output to omit noisy branch details");
+  assert(
+    observation.recoveryReference === undefined,
+    "expected non-authoritative Codex rewrites to omit recovery references",
+  );
   assert(!hook.stdout.includes("\"decision\""), "Codex hook feedback must not emit JSON decision:block output");
+
+  const authoritativeHook = await run(process.execPath, [distCliPath, "codex-post-tool-use"], {
+    env: hookEnv,
+    input: postToolUsePayload(
+      "git log --oneline",
+      Array.from(
+        { length: 40 },
+        (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`,
+      ).join("\n"),
+    ),
+  });
+  const authoritativeOutput = JSON.parse(authoritativeHook.stdout);
+  const authoritativeContext = authoritativeOutput.hookSpecificOutput?.additionalContext;
+  assert(typeof authoritativeContext === "string", "expected authoritative Codex context");
+  const authoritativeObservation = JSON.parse(
+    authoritativeContext.slice(observationPrefix.length, -observationSuffix.length),
+  );
+  assert(
+    authoritativeObservation.authority === "authoritative-omission",
+    "expected authoritative Codex omission label",
+  );
+  assert(
+    authoritativeObservation.recoveryReference === "tokenjuice wrap --raw -- <command>",
+    "expected authoritative Codex omissions to retain a factual recovery reference",
+  );
 
   return {
     version: version.stdout.trim(),

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -6,12 +6,12 @@ import packageJson from "../../../package.json" with { type: "json" };
 
 import { stripLeadingCdPrefix } from "../../core/command.js";
 import { tryStoreArtifactMetadata } from "../../core/artifacts.js";
+import type { CompactionMetadata } from "../../core/compaction-metadata.js";
 import { readNoOmissionFromEnv } from "../../core/env.js";
 import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
-import { countTextChars, stripAnsi } from "../../core/text.js";
+import { countTextChars, sliceTextChars, stripAnsi } from "../../core/text.js";
 import { extractHookCommandPaths, isNodeExecutablePath, parseShellWords, shellQuote } from "../shared/hook-command.js";
-import { buildCompactionHint } from "../shared/hook-output.js";
 
 import type { ToolExecutionInput } from "../../types.js";
 
@@ -745,17 +745,75 @@ function commandRequestsTokenjuiceRawBypass(command: string): boolean {
   return optionArgs.includes("--raw") || optionArgs.includes("--full");
 }
 
-function buildCodexFeedback(inlineText: string, rawRefId?: string): string {
-  return `${inlineText}\n\n${buildCompactionHint(rawRefId)}`;
+function buildCodexFeedback(
+  inlineText: string,
+  rawRefId?: string,
+  compaction?: CompactionMetadata,
+  exitCode?: number,
+  maxChars = 1200,
+  noOmit = false,
+): { text: string; truncated: boolean } | undefined {
+  const recoveryReference = rawRefId
+    ? `tokenjuice cat ${rawRefId}`
+    : "tokenjuice wrap --raw -- <command>";
+  const serialize = (compactedOutput: string, authoritative: boolean): string => [
+    "<tokenjuice_compacted_tool_observation>",
+    JSON.stringify({
+      source: "codex-post-tool-use",
+      exitCode: exitCode ?? null,
+      authority: authoritative ? "authoritative-omission" : "non-authoritative-rewrite",
+      compactedOutput,
+      ...(authoritative ? { recoveryReference } : {}),
+    }, null, 2),
+    "</tokenjuice_compacted_tool_observation>",
+  ].join("\n");
+
+  const feedback = serialize(inlineText, compaction?.authoritative === true);
+  if (countTextChars(feedback) <= maxChars) {
+    return { text: feedback, truncated: false };
+  }
+  if (noOmit) {
+    return undefined;
+  }
+
+  const truncationMarker = "\n... compacted observation truncated ...";
+  let low = 0;
+  let high = countTextChars(inlineText);
+  let best: string | undefined;
+  while (low <= high) {
+    const midpoint = Math.floor((low + high) / 2);
+    const candidate = serialize(`${sliceTextChars(inlineText, 0, midpoint)}${truncationMarker}`, true);
+    if (countTextChars(candidate) <= maxChars) {
+      best = candidate;
+      low = midpoint + 1;
+    } else {
+      high = midpoint - 1;
+    }
+  }
+
+  return best ? { text: best, truncated: true } : undefined;
 }
 
-function buildCodexReplacementOutput(inlineText: string, rawRefId?: string): Record<string, unknown> {
-  const feedback = buildCodexFeedback(inlineText, rawRefId);
+function buildCodexReplacementOutput(
+  inlineText: string,
+  rawRefId?: string,
+  compaction?: CompactionMetadata,
+  exitCode?: number,
+  maxChars?: number,
+  noOmit?: boolean,
+): { payload: Record<string, unknown>; truncated: boolean } | undefined {
+  const feedback = buildCodexFeedback(inlineText, rawRefId, compaction, exitCode, maxChars, noOmit);
+  if (!feedback) {
+    return undefined;
+  }
   return {
-    hookSpecificOutput: {
-      hookEventName: "PostToolUse",
-      additionalContext: feedback,
+    payload: {
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: feedback.text,
+      },
     },
+    truncated: feedback.truncated,
   };
 }
 
@@ -1205,6 +1263,7 @@ export async function runCodexPostToolUseHook(
       debug.savedChars = savedChars;
       debug.ratio = result.stats.ratio;
       debug.matchedReducer = result.classification.matchedReducer;
+      debug.compaction = result.compaction;
     }
 
     if (outcome.action === "keep") {
@@ -1212,8 +1271,25 @@ export async function runCodexPostToolUseHook(
       return 0;
     }
 
-    process.stdout.write(`${JSON.stringify(buildCodexReplacementOutput(outcome.result.inlineText, outcome.result.rawRef?.id))}\n`);
-    await writeHookDebug({ ...debug, rewrote: true });
+    const replacement = buildCodexReplacementOutput(
+      outcome.result.inlineText,
+      outcome.result.rawRef?.id,
+      outcome.result.compaction,
+      exitCode,
+      maxInlineChars,
+      noOmit,
+    );
+    if (!replacement) {
+      await writeHookDebug({ ...debug, skipped: "observation-inline-limit" });
+      return 0;
+    }
+
+    process.stdout.write(`${JSON.stringify(replacement.payload)}\n`);
+    await writeHookDebug({
+      ...debug,
+      rewrote: true,
+      feedbackTruncated: replacement.truncated,
+    });
     return 0;
   } catch (error) {
     await writeHookDebug({

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { countTextChars } from "../../src/core/text.js";
 import { doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
 
 const tempDirs: string[] = [];
@@ -12,9 +13,12 @@ const PACKAGE_VERSION = JSON.parse(readFileSync(new URL("../../package.json", im
 const originalHome = process.env.HOME;
 const originalPath = process.env.PATH;
 const originalNoOmission = process.env.TOKENJUICE_NO_OMISSION;
+const originalCodexMaxInlineChars = process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS;
 
 beforeEach(() => {
+  // These assertions describe the default reducer policy, not a caller's opt-out environment.
   delete process.env.TOKENJUICE_NO_OMISSION;
+  delete process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS;
 });
 
 afterEach(async () => {
@@ -25,6 +29,11 @@ afterEach(async () => {
     delete process.env.TOKENJUICE_NO_OMISSION;
   } else {
     process.env.TOKENJUICE_NO_OMISSION = originalNoOmission;
+  }
+  if (originalCodexMaxInlineChars === undefined) {
+    delete process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS;
+  } else {
+    process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS = originalCodexMaxInlineChars;
   }
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
@@ -85,6 +94,26 @@ function parseCodexReplacementOutput(stdout: string): {
       hookEventName?: string;
       additionalContext?: string;
     };
+  };
+}
+
+function parseCodexObservation(additionalContext: string | undefined): {
+  source: string;
+  exitCode: number | null;
+  authority: string;
+  compactedOutput: string;
+  recoveryReference?: string;
+} {
+  const begin = "<tokenjuice_compacted_tool_observation>\n";
+  const end = "\n</tokenjuice_compacted_tool_observation>";
+  expect(additionalContext?.startsWith(begin)).toBe(true);
+  expect(additionalContext?.endsWith(end)).toBe(true);
+  return JSON.parse(additionalContext!.slice(begin.length, -end.length)) as {
+    source: string;
+    exitCode: number | null;
+    authority: string;
+    compactedOutput: string;
+    recoveryReference?: string;
   };
 }
 
@@ -765,6 +794,7 @@ describe("runCodexPostToolUseHook", () => {
     const payload = JSON.stringify({
       hook_event_name: "PostToolUse",
       tool_name: "Bash",
+      exit_code: 0,
       tool_input: {
         command: "git status",
       },
@@ -785,20 +815,180 @@ describe("runCodexPostToolUseHook", () => {
     const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
       rewrote: boolean;
       matchedReducer?: string;
+      compaction?: {
+        authoritative?: boolean;
+        kinds?: string[];
+      };
     };
 
     const response = parseCodexReplacementOutput(stdout);
+    const observation = parseCodexObservation(response.hookSpecificOutput?.additionalContext);
 
     expect(code).toBe(0);
     expect(stderr).toBe("");
     expect(response.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("Changes not staged:");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
-    expect(response.hookSpecificOutput?.additionalContext).not.toContain("and have 8 and 642");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("tokenjuice wrap --raw -- <command>");
-    expect(response.hookSpecificOutput?.additionalContext).not.toContain("tokenjuice wrap --full -- <command>");
+    expect(observation.source).toBe("codex-post-tool-use");
+    expect(observation.exitCode).toBe(0);
+    expect(observation.authority).toBe("non-authoritative-rewrite");
+    expect(observation.compactedOutput).toContain("Changes not staged:");
+    expect(observation.compactedOutput).toContain("M: src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts");
+    expect(observation.compactedOutput).not.toContain("and have 8 and 642");
+    expect(observation).not.toHaveProperty("recoveryReference");
     expect(debug.rewrote).toBe(true);
     expect(debug.matchedReducer).toBe("git/status");
+    expect(debug.compaction?.authoritative).toBe(false);
+  });
+
+  it("does not suggest a raw rerun for a formatting-only rewrite", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "custom-tool --emit-json",
+      },
+      tool_response: JSON.stringify({
+        status: "ok",
+        files: Array.from({ length: 18 }, (_, index) => ({
+          path: `src/file-${index}.ts`,
+          changed: true,
+        })),
+      }, null, 2),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      compaction?: {
+        authoritative?: boolean;
+        kinds?: string[];
+      };
+    };
+    const response = parseCodexReplacementOutput(stdout);
+    const observation = parseCodexObservation(response.hookSpecificOutput?.additionalContext);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(debug.rewrote).toBe(true);
+    expect(debug.compaction?.authoritative).not.toBe(true);
+    expect(observation.exitCode).toBeNull();
+    expect(observation.authority).toBe("non-authoritative-rewrite");
+    expect(observation.compactedOutput).toContain('"status":"ok"');
+    expect(observation).not.toHaveProperty("recoveryReference");
+  });
+
+  it("includes a factual recovery reference for authoritative omissions", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      exit_code: 0,
+      tool_input: {
+        command: "git log --oneline",
+      },
+      tool_response: Array.from(
+        { length: 40 },
+        (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`,
+      ).join("\n"),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      compaction?: {
+        authoritative?: boolean;
+        kinds?: string[];
+      };
+    };
+    const response = parseCodexReplacementOutput(stdout);
+    const observation = parseCodexObservation(response.hookSpecificOutput?.additionalContext);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(debug.rewrote).toBe(true);
+    expect(debug.compaction?.authoritative).toBe(true);
+    expect(observation.source).toBe("codex-post-tool-use");
+    expect(observation.exitCode).toBe(0);
+    expect(observation.authority).toBe("authoritative-omission");
+    expect(observation.recoveryReference).toBe("tokenjuice wrap --raw -- <command>");
+    expect(response.hookSpecificOutput?.additionalContext).not.toContain("need raw?");
+  });
+
+  it("applies the Codex inline limit to the serialized observation", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+    process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS = "400";
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      exit_code: 0,
+      tool_input: {
+        command: "custom-tool --emit-json",
+      },
+      tool_response: JSON.stringify({
+        files: Array.from({ length: 80 }, (_, index) => ({
+          path: `src/file-${index}.ts`,
+          warning: "quoted value",
+        })),
+      }, null, 2),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const response = parseCodexReplacementOutput(stdout);
+    const context = response.hookSpecificOutput?.additionalContext;
+    const observation = parseCodexObservation(context);
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      feedbackTruncated?: boolean;
+      rewrote: boolean;
+    };
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(countTextChars(context!)).toBeLessThanOrEqual(400);
+    expect(observation.authority).toBe("authoritative-omission");
+    expect(observation.compactedOutput).toContain("compacted observation truncated");
+    expect(observation.recoveryReference).toBe("tokenjuice wrap --raw -- <command>");
+    expect(debug.rewrote).toBe(true);
+    expect(debug.feedbackTruncated).toBe(true);
+  });
+
+  it("preserves the original output when a no-omit observation cannot fit", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+    process.env.TOKENJUICE_CODEX_MAX_INLINE_CHARS = "400";
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      exit_code: 0,
+      tool_input: {
+        command: "custom-tool --emit-json",
+      },
+      tool_response: JSON.stringify({
+        files: Array.from({ length: 80 }, (_, index) => ({
+          path: `src/file-${index}.ts`,
+          warning: "quoted value",
+        })),
+      }, null, 2),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("observation-inline-limit");
   });
 
   it("keeps the original output when the installed hook explicitly enables no-omit", async () => {
@@ -993,22 +1183,30 @@ describe("runCodexPostToolUseHook", () => {
       reducedChars?: number;
       savedChars?: number;
       ratio?: number;
+      compaction?: {
+        authoritative?: boolean;
+        kinds?: string[];
+      };
     };
 
     const response = parseCodexReplacementOutput(stdout);
+    const observation = parseCodexObservation(response.hookSpecificOutput?.additionalContext);
 
     expect(code).toBe(0);
     expect(stderr).toBe("");
     expect(response.hookSpecificOutput?.hookEventName).toBe("PostToolUse");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("40 matches");
-    expect(response.hookSpecificOutput?.additionalContext).toContain("src/rules/example-1.json");
+    expect(observation.compactedOutput).toContain("40 matches");
+    expect(observation.compactedOutput).toContain("src/rules/example-1.json");
     expect(debug.rewrote).toBe(true);
     expect(debug.skipped).toBeUndefined();
     expect(debug.matchedReducer).toBe("filesystem/find");
+    expect(debug.compaction?.authoritative).toBe(true);
     expect(debug.rawChars).toBeGreaterThan(0);
     expect(debug.reducedChars).toBeLessThan(debug.rawChars!);
     expect(debug.savedChars).toBeGreaterThan(0);
     expect(debug.ratio).toBeLessThan(1);
+    expect(observation.authority).toBe("authoritative-omission");
+    expect(observation.recoveryReference).toBe("tokenjuice wrap --raw -- <command>");
   });
 
   it("skips auto-rewrite for file-content inspection commands", async () => {


### PR DESCRIPTION
## Summary

- emit Codex compaction feedback as a clearly delimited, inert observation
- include factual source, exit status, and authority metadata
- include a recovery reference only when the delivered observation has authoritative omissions
- preserve the original result when the configured no-omission policy prevents the complete observation from fitting

## Why

Codex currently delivers `PostToolUse` `additionalContext` as developer context. Tokenjuice cannot relabel that protocol role, so compacted tool output is presented as inert observation data rather than imperative text.

The old `need raw?` wording also advertised a rerun for normalized or formatting-only rewrites where Tokenjuice had not omitted authoritative content. This branch distinguishes those rewrites from actual omissions.

## Omission Policy

Rebased onto `aa3f98b56fe3d33f7a76cbb69ab4e69e472675f2`, which includes #218.

#218 remains the sole owner of:

- installed `--no-omit` policy
- runtime `noOmit` / `allowOmit` resolution
- Codex install, doctor, and CLI semantics

#214 consumes the resolved policy only when formatting the inert observation. It does not duplicate or override #218.

## Behavior

The observation contains:

- `source: codex-post-tool-use`
- the observed exit code, or `null` when unavailable
- `authority: non-authoritative-rewrite` or `authoritative-omission`
- compacted output
- a factual recovery reference only for authoritative omission

The complete serialized observation honors `TOKENJUICE_CODEX_MAX_INLINE_CHARS`. When no-omission mode is active and the envelope cannot fit, Tokenjuice emits no replacement context and Codex preserves the original tool result.

This adapter emits `hookSpecificOutput.additionalContext`; it does not claim role relabeling or command suppression.

## Verification

- focused overlap suite: 3 files, 72 tests passed
- `pnpm verify`: 132 files, 2,350 tests passed
- `pnpm build`
- local host E2E:
  - Codex CLI 0.153.2: passed
  - Claude Code 2.1.207: passed
  - CodeBuddy: passed
- autoreview against `aa3f98b56fe3d33f7a76cbb69ab4e69e472675f2`: clean, no accepted/actionable findings

Exact head: `7c569595b8d8073775fc8042fffad682e38e0335`
