### PR TITLE
fix(artifacts): fail open when optional stats cannot be written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Keep raw and full command output available when optional telemetry storage is unavailable.
 - Harden ownership detection, restoration, and malformed marker handling for beta host integrations.
 - Build release artifacts from explicit tags and validate Homebrew tap release-tag input.
 - Make `pnpm build` portable across supported Node platforms.

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -153,6 +153,19 @@ export async function storeArtifactMetadata(input: StoredArtifactInput, storeDir
   };
 }
 
+export async function tryStoreArtifactMetadata(
+  input: StoredArtifactInput,
+  storeDir?: string,
+): Promise<ArtifactMetadataRef | undefined> {
+  try {
+    return await storeArtifactMetadata(input, storeDir);
+  } catch {
+    // Stats are ancillary: a read-only or unavailable artifact directory must not discard the
+    // command result. Explicit artifact storage remains strict through storeArtifact().
+    return undefined;
+  }
+}
+
 export async function getArtifact(id: string, storeDir?: string): Promise<StoredArtifact | null> {
   if (!isValidArtifactId(id)) {
     return null;

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -10,6 +10,23 @@ import type { ArtifactMetadataRef, StoredArtifact, StoredArtifactInput, StoredAr
 
 const ARTIFACT_ID_PATTERN = /^tj_[0-9a-f-]{12}$/iu;
 export const ARTIFACT_DIR_ENV = "TOKENJUICE_ARTIFACT_DIR";
+const OPTIONAL_METADATA_STORAGE_ERROR_CODES = new Set([
+  "EACCES",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "EPERM",
+  "EROFS",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -159,9 +176,12 @@ export async function tryStoreArtifactMetadata(
 ): Promise<ArtifactMetadataRef | undefined> {
   try {
     return await storeArtifactMetadata(input, storeDir);
-  } catch {
-    // Stats are ancillary: a read-only or unavailable artifact directory must not discard the
-    // command result. Explicit artifact storage remains strict through storeArtifact().
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (typeof code !== "string" || !OPTIONAL_METADATA_STORAGE_ERROR_CODES.has(code)) {
+      throw error;
+    }
+
     return undefined;
   }
 }

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -4,7 +4,7 @@ import { classifyExecution, resolveRuleMatch } from "./classify.js";
 import { isFileContentInspectionCommand, isVerbatimConfigInspectionCommand } from "./command-identity.js";
 import { normalizeExecutionInput } from "./execution-input.js";
 import { clampTextMiddleWithMetadata, clampTextWithMetadata, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
-import { storeArtifact, storeArtifactMetadata } from "./artifacts.js";
+import { storeArtifact, tryStoreArtifactMetadata } from "./artifacts.js";
 import { NO_COMPACTION_METADATA, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { buildGithubActionsFailureSummary } from "./github-actions-summary.js";
 import { rewriteGhLines, rewriteGitDiffLines, rewriteGitStatusLines, rewriteSearchLines } from "./reduce-formatters.js";
@@ -373,7 +373,7 @@ export async function reduceExecutionWithRules(
         )
       : undefined;
     if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
+      await tryStoreArtifactMetadata(
         {
           input: normalizedInput,
           rawText,
@@ -432,7 +432,7 @@ export async function reduceExecutionWithRules(
       : undefined;
 
     if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
+      await tryStoreArtifactMetadata(
         {
           input: normalizedInput,
           rawText,
@@ -456,7 +456,7 @@ export async function reduceExecutionWithRules(
 
   if (classification.matchedReducer === "generic/fallback" && isFileContentInspectionCommand(normalizedInput)) {
     if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
+      await tryStoreArtifactMetadata(
         {
           input: normalizedInput,
           rawText,
@@ -515,7 +515,7 @@ export async function reduceExecutionWithRules(
       : undefined;
 
     if (!opts.store && opts.recordStats) {
-      await storeArtifactMetadata(
+      await tryStoreArtifactMetadata(
         {
           input: normalizedInput,
           rawText,
@@ -565,7 +565,7 @@ export async function reduceExecutionWithRules(
         : undefined;
 
       if (!opts.store && opts.recordStats) {
-        await storeArtifactMetadata(
+        await tryStoreArtifactMetadata(
           {
             input: normalizedInput,
             rawText,
@@ -611,7 +611,7 @@ export async function reduceExecutionWithRules(
     : undefined;
 
   if (!opts.store && opts.recordStats) {
-    await storeArtifactMetadata(
+    await tryStoreArtifactMetadata(
       {
         input: normalizedInput,
         rawText,

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import packageJson from "../../../package.json" with { type: "json" };
 
 import { stripLeadingCdPrefix } from "../../core/command.js";
-import { storeArtifactMetadata } from "../../core/artifacts.js";
+import { tryStoreArtifactMetadata } from "../../core/artifacts.js";
 import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
 import { countTextChars, stripAnsi } from "../../core/text.js";
@@ -1064,7 +1064,7 @@ async function recordImmediateHookStats(
 
   const stats = buildImmediateSkipStats(rawText);
   const classification = await classifyOnly(input);
-  await storeArtifactMetadata(
+  await tryStoreArtifactMetadata(
     {
       input,
       rawText,

--- a/test/core/artifacts-fail-open.test.ts
+++ b/test/core/artifacts-fail-open.test.ts
@@ -1,0 +1,46 @@
+import { mkdir } from "node:fs/promises";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    mkdir: vi.fn<typeof actual.mkdir>(actual.mkdir),
+  };
+});
+
+import { tryStoreArtifactMetadata } from "../../src/core/artifacts.js";
+
+const input = {
+  input: { toolName: "exec", command: "tokenjuice wrap --raw -- cat AGENTS.md", exitCode: 0 },
+  rawText: "raw output\n",
+  classification: { family: "generic", confidence: 1, matchedReducer: "generic/fallback" },
+  stats: { rawChars: 11, reducedChars: 11, ratio: 1 },
+};
+
+function storageError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`storage failed: ${code}`), { code });
+}
+
+beforeEach(() => {
+  vi.mocked(mkdir).mockReset();
+});
+
+describe("tryStoreArtifactMetadata", () => {
+  it.each(["EPERM", "EROFS", "ENOTDIR", "ENAMETOOLONG", "ELOOP"])(
+    "fails open for %s metadata storage errors",
+    async (code) => {
+      vi.mocked(mkdir).mockRejectedValueOnce(storageError(code));
+
+      await expect(tryStoreArtifactMetadata(input)).resolves.toBeUndefined();
+    },
+  );
+
+  it("does not hide programmer exceptions", async () => {
+    const error = new TypeError("metadata construction failed");
+    vi.mocked(mkdir).mockRejectedValueOnce(error);
+
+    await expect(tryStoreArtifactMetadata(input)).rejects.toBe(error);
+  });
+});

--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -91,6 +91,43 @@ describe("runWrappedCommand", () => {
 
     expect(wrapped.result.inlineText).toBe("usage: cmd\n\nflag\n");
     expect(wrapped.result.stats.ratio).toBe(1);
+  });
+
+  it("preserves raw output when optional stats cannot be written", async () => {
+    const tempDir = await createTempDir();
+    const blockedStoreDir = join(tempDir, "artifact-dir-is-a-file");
+    await writeFile(blockedStoreDir, "not a directory", "utf8");
+
+    const wrapped = await runWrappedCommand([
+      process.execPath,
+      "-e",
+      "require('node:fs').writeSync(1, 'raw marker\\n'); process.exit(7);",
+    ], {
+      raw: true,
+      recordStats: true,
+      storeDir: blockedStoreDir,
+    });
+
+    expect(wrapped.exitCode).toBe(7);
+    expect(wrapped.stdout).toBe("raw marker\n");
+    expect(wrapped.result.inlineText).toBe("raw marker\n");
+    expect(wrapped.result.stats.ratio).toBe(1);
+  });
+
+  it("keeps explicit artifact storage failures strict", async () => {
+    const tempDir = await createTempDir();
+    const blockedStoreDir = join(tempDir, "artifact-dir-is-a-file");
+    await writeFile(blockedStoreDir, "not a directory", "utf8");
+
+    await expect(runWrappedCommand([
+      process.execPath,
+      "-e",
+      "require('node:fs').writeSync(1, 'raw marker\\n');",
+    ], {
+      raw: true,
+      store: true,
+      storeDir: blockedStoreDir,
+    })).rejects.toThrow(/EEXIST|ENOTDIR/u);
   });
 
   it("records the requested source for wrapper stats", async () => {

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -944,6 +944,44 @@ describe("runCodexPostToolUseHook", () => {
     expect(debug.ratio).toBe(1);
   });
 
+  it("keeps raw bypasses fail-open when optional stats cannot be written", async () => {
+    const home = await createTempDir();
+    const blockedArtifactDir = join(home, "artifact-dir-is-a-file");
+    const originalArtifactDir = process.env.TOKENJUICE_ARTIFACT_DIR;
+    process.env.CODEX_HOME = home;
+    process.env.TOKENJUICE_ARTIFACT_DIR = blockedArtifactDir;
+    await writeFile(blockedArtifactDir, "not a directory", "utf8");
+
+    try {
+      const payload = JSON.stringify({
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_input: {
+          command: "tokenjuice wrap --raw -- bash -lc 'git show HEAD --stat'",
+        },
+        tool_response: "commit abcdef\n README.md | 1 +\n",
+      });
+
+      const { code, stdout, stderr } = await captureStdio(() => runCodexPostToolUseHook(payload));
+      const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+        rewrote: boolean;
+        skipped?: string;
+      };
+
+      expect(code).toBe(0);
+      expect(stdout).toBe("");
+      expect(stderr).toBe("");
+      expect(debug.rewrote).toBe(false);
+      expect(debug.skipped).toBe("explicit-raw-bypass");
+    } finally {
+      if (originalArtifactDir === undefined) {
+        delete process.env.TOKENJUICE_ARTIFACT_DIR;
+      } else {
+        process.env.TOKENJUICE_ARTIFACT_DIR = originalArtifactDir;
+      }
+    }
+  });
+
   it("honors absolute tokenjuice raw bypass commands without re-compacting them", async () => {
     const home = await createTempDir();
     process.env.CODEX_HOME = home;


### PR DESCRIPTION
## Summary

- make optional `recordStats` metadata writes best effort
- preserve byte-exact raw/full output and child exit codes when telemetry storage is unavailable
- keep explicit `--store` failures strict
- apply the same fail-open behavior to Codex immediate skip stats
- rethrow non-storage and programmer exceptions

## Root cause

Optional telemetry used the same strict metadata writer as explicit artifact storage. Expected filesystem failures such as `EPERM`, `EROFS`, or `ENOTDIR` could therefore replace an already completed command result.

## Remediation

- rebased onto current `main` after https://github.com/vincentkoc/tokenjuice/pull/217
- limited fail-open behavior to a bounded filesystem/storage errno allowlist
- added direct `EPERM`, `EROFS`, `ENOTDIR`, `ENAMETOOLONG`, and `ELOOP` coverage
- added a regression proving ordinary programmer exceptions still propagate

## Tests

- `pnpm exec vitest run test/core/artifacts-fail-open.test.ts test/core/artifacts.test.ts test/core/wrap.test.ts test/hosts/codex.test.ts`
- `pnpm verify`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Full verification passed with 132 test files and 2,295 tests. Independent autoreview reported no accepted or actionable findings.

## Impact

Raw/full bypasses no longer lose stdout or child exit status solely because optional telemetry cannot be written. Explicit artifact storage remains strict. The user-visible fix is recorded under `Unreleased`.
