### PR TITLE
test: isolate suite from local environment

### DIFF
--- a/test/core/wrap.test.ts
+++ b/test/core/wrap.test.ts
@@ -22,9 +22,9 @@ afterEach(async () => {
 describe("runWrappedCommand", () => {
   it("preserves the child exit code and produces a compact result", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "console.log('hello'); console.error('warning: noisy'); process.exit(3)",
+      "const fs = require('node:fs'); fs.writeSync(1, 'hello\\n'); fs.writeSync(2, 'warning: noisy\\n'); process.exit(3);",
     ]);
 
     expect(wrapped.exitCode).toBe(3);
@@ -36,9 +36,9 @@ describe("runWrappedCommand", () => {
     const storeDir = await createTempDir();
 
     await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "console.log('secret token value');",
+      "require('node:fs').writeSync(1, 'secret token value\\n');",
     ], {
       storeDir,
     });
@@ -49,9 +49,9 @@ describe("runWrappedCommand", () => {
 
   it("caps captured output to avoid unbounded memory growth", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write('a'.repeat(2000));",
+      "require('node:fs').writeSync(1, 'a'.repeat(2000));",
     ], {
       maxCaptureBytes: 128,
     });
@@ -65,9 +65,9 @@ describe("runWrappedCommand", () => {
     const storeDir = await createTempDir();
 
     await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write('a'.repeat(2000));",
+      "require('node:fs').writeSync(1, 'a'.repeat(2000));",
     ], {
       maxCaptureBytes: 128,
       store: true,
@@ -81,9 +81,9 @@ describe("runWrappedCommand", () => {
 
   it("supports a raw bypass for wrapped commands", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write('usage: cmd\\n\\nflag\\n');",
+      "require('node:fs').writeSync(1, 'usage: cmd\\n\\nflag\\n');",
     ], {
       raw: true,
       maxInlineChars: 4,
@@ -97,9 +97,9 @@ describe("runWrappedCommand", () => {
     const storeDir = await createTempDir();
 
     await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "console.log('source tagged output');",
+      "require('node:fs').writeSync(1, 'source tagged output\\n');",
     ], {
       source: "cursor",
       recordStats: true,
@@ -113,9 +113,9 @@ describe("runWrappedCommand", () => {
 
   it("does not flag lossless rewrites as authoritative compaction", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write('Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).\\n');",
+      "require('node:fs').writeSync(1, 'Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).\\n');",
     ]);
 
     expect(wrapped.result.inlineText).toBe("Deleted branch fix/cd-prefixed-raw-bypass-main (was 76b6858).");
@@ -125,9 +125,9 @@ describe("runWrappedCommand", () => {
 
   it("does not keep authoritative compaction when passthrough beats a lossy summary", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write(Array.from({ length: 13 }, (_, index) => `v${index}`).join('\\n') + '\\n');",
+      "require('node:fs').writeSync(1, Array.from({ length: 13 }, (_, index) => `v${index}`).join('\\n') + '\\n');",
     ]);
 
     expect(wrapped.result.inlineText).toBe(Array.from({ length: 13 }, (_, index) => `v${index}`).join("\n"));
@@ -137,9 +137,9 @@ describe("runWrappedCommand", () => {
 
   it("flags omitted summaries as authoritative compaction", async () => {
     const wrapped = await runWrappedCommand([
-      "node",
+      process.execPath,
       "-e",
-      "process.stdout.write(Array.from({ length: 40 }, (_, index) => `line ${index} ${'x'.repeat(80)}`).join('\\n'));",
+      "require('node:fs').writeSync(1, Array.from({ length: 40 }, (_, index) => `line ${index} ${'x'.repeat(80)}`).join('\\n'));",
     ]);
 
     expect(wrapped.result.inlineText).toContain("omitted");

--- a/test/hosts/claude-code.test.ts
+++ b/test/hosts/claude-code.test.ts
@@ -675,7 +675,7 @@ describe("doctorInstalledHooks", () => {
     await mkdir(binDir, { recursive: true });
     await writeFile(join(binDir, "tokenjuice"), "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
 
-    const report = await doctorInstalledHooks();
+    const report = await doctorInstalledHooks({ projectDir: home });
 
     expect(report.status).toBe("disabled");
     expect(report.integrations["claude-code"].status).toBe("disabled");
@@ -707,7 +707,7 @@ describe("doctorInstalledHooks", () => {
     await installCodeBuddyHook();
     await installPiExtension(undefined, { local: true });
 
-    const report = await doctorInstalledHooks();
+    const report = await doctorInstalledHooks({ projectDir: home });
 
     expect(report.status).toBe("ok");
     expect(report.integrations.codex.status).toBe("ok");
@@ -752,7 +752,7 @@ describe("doctorInstalledHooks", () => {
     await installCodeBuddyHook();
     await installPiExtension(undefined, { local: true });
 
-    const report = await doctorInstalledHooks();
+    const report = await doctorInstalledHooks({ projectDir: home });
 
     expect(report.status).toBe("ok");
     expect(report.integrations.codex.status).toBe("disabled");


### PR DESCRIPTION
## Summary
- run wrap fixtures with the active Node executable instead of a PATH lookup
- write child fixture output synchronously so immediate exits cannot drop buffered data
- point aggregate doctor tests at their temporary project instead of the developer working tree

## Root cause
Host tests mutate PATH and aggregate doctor scans project-scoped integrations. Concurrent tests could therefore execute a fake Node binary or detect a real local host configuration such as .kiro, making the suite depend on the machine running it.

## Tests
- `env -u TOKENJUICE_NO_OMISSION pnpm exec vitest run test/core/wrap.test.ts test/hosts/claude-code.test.ts`
- `pnpm lint`
- `pnpm typecheck`

## Impact
Test-only change; no runtime, documentation, packaging, or release impact.