### PR TITLE
fix(codex): honor configured omission policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
+- Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
 - Keep raw and full command output available when optional telemetry storage is unavailable.
 - Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output.
 - Render successful generic error and warning counters as neutral mentions.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -156,6 +156,7 @@ type ParsedArgs = {
   tee: boolean;
   raw: boolean;
   noOmit: boolean;
+  allowOmit: boolean;
   storeDir: string | undefined;
   maxInlineChars: number | undefined;
   maxCaptureBytes: number | undefined;
@@ -214,7 +215,7 @@ function printUsage(): void {
       "  tokenjuice install bob",
       "  tokenjuice install builder",
       "  tokenjuice install charlie",
-      "  tokenjuice install codex [--local]",
+      "  tokenjuice install codex [--local] [--no-omit]",
       "  tokenjuice install claude-code [--local]",
       "  tokenjuice install cline [--local]",
       "  tokenjuice install codeant",
@@ -390,6 +391,7 @@ function printUsage(): void {
       "  tokenjuice verify [--fixtures]",
       "  tokenjuice discover [file] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>] [--source <name>] [--by-source]",
       "  tokenjuice doctor [file|hooks|adal|aether|aictl|ai-memory-protocol|aider|agent-layer|agentinit|agentlink|agentloom|agents-cli|agents-md|agentsge|agentsmesh|amazon-q|amp|antigravity|anywhere-agents|augment|avante|baz|bito|blackbox|blocks|clawdbot|bob|builder|charlie|codex|claude-code|cline|codeant|codebuff|codegen|coder-agents|coderabbit|codebuddy|command-code|continue|copilot-agent|crush|cursor|deepagents|devin|dot-agents|docker-agent|droid|eca|elyra|firebase-studio|forgecode|gemini-cli|gitlab-duo|goose|greptile|grok-build|grok-cli|gptme|jean2|jetbrains-ai|junie|jules|leanctl|kimi|kiro|kilo|localcode|mcp-agent|mini-swe-agent|swe-agent|stagewise|mistral-vibe|mux|novakit|knowns|ona|openhands|open-interpreter|openwebui|pi|pi-go|opencode|plandex|qodo|qoder|qwen-code|replit|roo|rovo|ruler|tabby|tabnine|trae|uipath|vscode-copilot|warp|windsurf|zed|zencoder|copilot-cli] [--local] [--print-instructions] [--source-command <cmd>] [--tool-name <name>] [--exit-code <n>]",
+      "  tokenjuice doctor codex [--local] [--no-omit]",
       "  tokenjuice stats [--timezone local|utc|<iana-timezone>] [--source <name>] [--by-source]",
     ].join("\n"),
   );
@@ -411,6 +413,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let tee = false;
   let raw = false;
   let noOmit = false;
+  let allowOmit = false;
   let storeDir: string | undefined;
   let maxInlineChars: number | undefined;
   let maxCaptureBytes: number | undefined;
@@ -494,6 +497,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
         noOmit = true;
         index += 1;
         break;
+      case "--allow-omit":
+        allowOmit = true;
+        index += 1;
+        break;
       case "--tee":
         tee = true;
         index += 1;
@@ -564,6 +571,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
   }
 
+  if (noOmit && allowOmit) {
+    throw new Error("--no-omit and --allow-omit cannot be used together");
+  }
+  if (allowOmit && (command === "install" || command === "doctor")) {
+    throw new Error("--allow-omit is not supported for install or doctor; Codex hooks honor the configured omission policy");
+  }
+
   return {
     command,
     format,
@@ -577,6 +591,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     tee,
     raw,
     noOmit,
+    allowOmit,
     storeDir,
     maxInlineChars,
     maxCaptureBytes,
@@ -1298,7 +1313,10 @@ async function runInstall(args: ParsedArgs): Promise<number> {
   }
 
   if (target === "codex") {
-    const result = await installCodexHook(undefined, { local: args.local });
+    const result = await installCodexHook(undefined, {
+      local: args.local,
+      ...(args.noOmit ? { noOmit: true } : {}),
+    });
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
       return 0;
@@ -5056,7 +5074,10 @@ async function runDoctor(args: ParsedArgs): Promise<number> {
   }
 
   if (args.positionals[0] === "codex") {
-    const report = await doctorCodexHook(undefined, { local: args.local });
+    const report = await doctorCodexHook(undefined, {
+      local: args.local,
+      ...(args.noOmit ? { noOmit: true } : {}),
+    });
 
     if (args.format === "json") {
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
@@ -7372,7 +7393,10 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     case "stats":
       return await runStats(args);
     case "codex-post-tool-use":
-      return await runCodexPostToolUseHook(await readStdin(args.maxInputBytes));
+      return await runCodexPostToolUseHook(
+        await readStdin(args.maxInputBytes),
+        { noOmit: args.noOmit, allowOmit: args.allowOmit },
+      );
     case "claude-code-pre-tool-use":
       return await runClaudeCodePreToolUseHook(await readStdin(args.maxInputBytes), args.wrapLauncher);
     case "claude-code-post-tool-use":

--- a/src/core/integrations/compact-bash-result.ts
+++ b/src/core/integrations/compact-bash-result.ts
@@ -16,6 +16,7 @@ export type CompactBashResultInput = {
   exitCode?: number;
   maxInlineChars?: number;
   noOmit?: boolean;
+  allowOmit?: boolean;
   storeRaw?: boolean;
   metadata?: Record<string, unknown>;
   inspectionPolicy?: InspectionCommandPolicy;
@@ -116,7 +117,7 @@ export async function compactBashResult(input: CompactBashResultInput): Promise<
   const options: ReduceOptions = {
     ...(typeof input.cwd === "string" && input.cwd.trim() ? { cwd: input.cwd } : {}),
     ...(typeof input.maxInlineChars === "number" ? { maxInlineChars: input.maxInlineChars } : {}),
-    ...(readNoOmissionFromEnv() || input.noOmit ? { noOmit: true } : {}),
+    ...(input.noOmit || (!input.allowOmit && readNoOmissionFromEnv()) ? { noOmit: true } : {}),
     recordStats: true,
     ...(input.storeRaw ? { store: true } : {}),
   };

--- a/src/hosts/codex/index.ts
+++ b/src/hosts/codex/index.ts
@@ -6,6 +6,7 @@ import packageJson from "../../../package.json" with { type: "json" };
 
 import { stripLeadingCdPrefix } from "../../core/command.js";
 import { tryStoreArtifactMetadata } from "../../core/artifacts.js";
+import { readNoOmissionFromEnv } from "../../core/env.js";
 import { compactBashResult, getOutputAwareInspectionSkipReason } from "../../core/integrations/compact-bash-result.js";
 import { classifyOnly } from "../../core/reduce.js";
 import { countTextChars, stripAnsi } from "../../core/text.js";
@@ -100,6 +101,7 @@ export type CodexHookCommandOptions = {
   local?: boolean;
   binaryPath?: string;
   nodePath?: string;
+  noOmit?: boolean;
   /**
    * Override for the config.toml consulted when reporting the
    * `codex_hooks` feature-flag state. Defaults to `~/.codex/config.toml`.
@@ -108,6 +110,12 @@ export type CodexHookCommandOptions = {
    */
   featureFlagConfigPath?: string;
 };
+
+function validateCodexOmissionPolicy(options: { noOmit?: boolean; allowOmit?: boolean }): void {
+  if (options.noOmit && options.allowOmit) {
+    throw new Error("Codex noOmit and allowOmit policies cannot be enabled together");
+  }
+}
 
 export type CodexDoctorReport = {
   hooksPath: string;
@@ -370,22 +378,28 @@ async function buildCodexHookCommand(options: CodexHookCommandOptions = {}): Pro
     throw new Error("unable to resolve tokenjuice binary path for codex install");
   }
 
+  let command: string | undefined;
   if (!options.local) {
     const installedBinaryPath = await resolveInstalledTokenjuicePath();
     if (installedBinaryPath) {
-      return `${shellQuote(installedBinaryPath)} codex-post-tool-use`;
+      command = `${shellQuote(installedBinaryPath)} codex-post-tool-use`;
     }
   }
 
-  if (binaryPath.endsWith(".js")) {
-    return `${shellQuote(nodePath)} ${shellQuote(binaryPath)} codex-post-tool-use`;
+  if (!command) {
+    command = binaryPath.endsWith(".js")
+      ? `${shellQuote(nodePath)} ${shellQuote(binaryPath)} codex-post-tool-use`
+      : `${shellQuote(binaryPath)} codex-post-tool-use`;
   }
 
-  return `${shellQuote(binaryPath)} codex-post-tool-use`;
+  return options.noOmit ? `${command} --no-omit` : command;
 }
 
-function getCodexFixCommand(local = false): string {
-  return local ? "tokenjuice install codex --local" : TOKENJUICE_CODEX_FIX_COMMAND;
+function getCodexFixCommand(local = false, noOmit = false): string {
+  return [
+    local ? "tokenjuice install codex --local" : TOKENJUICE_CODEX_FIX_COMMAND,
+    ...(noOmit ? ["--no-omit"] : []),
+  ].join(" ");
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -831,8 +845,9 @@ export async function doctorCodexHook(
   hooksPath = getDefaultHooksPath(),
   options: CodexHookCommandOptions = {},
 ): Promise<CodexDoctorReport> {
+  const noOmit = options.noOmit === true;
   const expectedCommand = await buildCodexHookCommand(options);
-  const installFixCommand = getCodexFixCommand(options.local);
+  const installFixCommand = getCodexFixCommand(options.local, noOmit);
   let fixCommand = installFixCommand;
   const { config, exists } = await readHooksConfig(hooksPath);
   const detectedCommand = findTokenjuiceCodexHookCommand(config);
@@ -876,7 +891,8 @@ export async function doctorCodexHook(
   }
 
   const issues: string[] = [];
-  if (detectedCommand !== expectedCommand) {
+  const commandMismatch = detectedCommand !== expectedCommand;
+  if (commandMismatch) {
     if (detectedCommand.includes("/Cellar/")) {
       issues.push("configured Codex hook is pinned to a versioned Homebrew Cellar path");
     } else {
@@ -891,11 +907,13 @@ export async function doctorCodexHook(
     issues.push(
       `configured Codex hook launcher resolves to Homebrew tokenjuice ${resolvedVersionMismatch.resolvedVersion}, but this tokenjuice is ${packageJson.version}`,
     );
-    fixCommand = "brew upgrade tokenjuice";
+    fixCommand = commandMismatch
+      ? `brew upgrade tokenjuice && ${installFixCommand}`
+      : "brew upgrade tokenjuice";
   }
   if (options.local && await detectStaleLocalBuild(checkedPaths)) {
     issues.push("local Codex hook target is older than the source tree");
-    fixCommand = "pnpm build && tokenjuice install codex --local";
+    fixCommand = `pnpm build && ${getCodexFixCommand(true, noOmit)}`;
   }
   if (!featureFlag.enabled) {
     issues.push(
@@ -1078,7 +1096,11 @@ async function recordImmediateHookStats(
   );
 }
 
-export async function runCodexPostToolUseHook(rawText: string): Promise<number> {
+export async function runCodexPostToolUseHook(
+  rawText: string,
+  options: { noOmit?: boolean; allowOmit?: boolean } = {},
+): Promise<number> {
+  validateCodexOmissionPolicy(options);
   let payload: CodexPostToolUsePayload;
   try {
     payload = JSON.parse(rawText) as CodexPostToolUsePayload;
@@ -1087,10 +1109,12 @@ export async function runCodexPostToolUseHook(rawText: string): Promise<number> 
   }
 
   const command = payload.tool_input?.command;
+  const noOmit = !options.allowOmit && (options.noOmit || readNoOmissionFromEnv());
   const debug: Record<string, unknown> = {
     hookEvent: payload.hook_event_name,
     toolName: payload.tool_name,
     command,
+    noOmit,
     rewrote: false,
   };
 
@@ -1158,7 +1182,9 @@ export async function runCodexPostToolUseHook(rawText: string): Promise<number> 
       visibleText: combinedText,
       ...(typeof payload.cwd === "string" && payload.cwd.trim() ? { cwd: payload.cwd } : {}),
       ...(typeof exitCode === "number" ? { exitCode } : {}),
+      ...(options.allowOmit ? { allowOmit: true } : {}),
       ...(typeof maxInlineChars === "number" ? { maxInlineChars } : {}),
+      ...(noOmit ? { noOmit: true } : {}),
       storeRaw,
       metadata: {
         source: "codex-post-tool-use",

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -22,9 +22,25 @@ afterEach(async () => {
 });
 
 describe("parseArgs", () => {
-  it("parses --no-omit for reduce and wrap", () => {
+  it("parses --no-omit for direct commands and explicit Codex hook policy", () => {
     expect(parseArgs(["reduce", "--no-omit"]).noOmit).toBe(true);
     expect(parseArgs(["wrap", "--no-omit", "--", "echo", "hi"]).noOmit).toBe(true);
+    expect(parseArgs(["codex-post-tool-use", "--no-omit"]).noOmit).toBe(true);
+    expect(parseArgs(["install", "codex", "--no-omit"]).noOmit).toBe(true);
+    expect(parseArgs(["doctor", "codex", "--no-omit"]).noOmit).toBe(true);
+  });
+
+  it("limits the explicit omission override to the hook runtime", () => {
+    expect(parseArgs(["codex-post-tool-use", "--allow-omit"]).allowOmit).toBe(true);
+    expect(() => parseArgs(["install", "codex", "--allow-omit"]))
+      .toThrow("Codex hooks honor the configured omission policy");
+    expect(() => parseArgs(["doctor", "codex", "--allow-omit"]))
+      .toThrow("Codex hooks honor the configured omission policy");
+  });
+
+  it("rejects conflicting omission policies", () => {
+    expect(() => parseArgs(["codex-post-tool-use", "--no-omit", "--allow-omit"]))
+      .toThrow("--no-omit and --allow-omit cannot be used together");
   });
 });
 

--- a/test/core/integrations/compact-bash-result.test.ts
+++ b/test/core/integrations/compact-bash-result.test.ts
@@ -383,4 +383,49 @@ describe("compactBashResult", () => {
     expect(rewritten.result.compaction?.authoritative).toBe(false);
   });
 
+  it("allows a host-specific policy to override the no-omit environment", async () => {
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+
+    const outcome = await compactBashResult({
+      source: "codex",
+      command: "git log --oneline",
+      visibleText: Array.from(
+        { length: 40 },
+        (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`,
+      ).join("\n"),
+      allowOmit: true,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    const rewritten = expectRewrite(outcome);
+    expect(rewritten.result.inlineText).toContain("omitted");
+    expect(rewritten.result.compaction?.authoritative).toBe(true);
+  });
+
+  it("keeps explicit no-omit enabled when both input policies are set", async () => {
+    const outcome = await compactBashResult({
+      source: "codex",
+      command: "git status",
+      visibleText: [
+        "On branch main",
+        "Changes not staged for commit:",
+        ...Array.from({ length: 30 }, (_, index) => `  modified:   src/file-${index}.ts`),
+      ].join("\n"),
+      noOmit: true,
+      allowOmit: true,
+      maxInlineChars: 20_000,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    const rewritten = expectRewrite(outcome);
+    expect(rewritten.result.inlineText).toContain("M: src/file-29.ts");
+    expect(rewritten.result.inlineText).not.toContain("omitted");
+  });
+
 });

--- a/test/hosts/codex.test.ts
+++ b/test/hosts/codex.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:f
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { doctorCodexHook, installCodexHook, listArtifactMetadata, runCodexPostToolUseHook, uninstallCodexHook } from "../../src/index.js";
 
@@ -11,11 +11,21 @@ const tempDirs: string[] = [];
 const PACKAGE_VERSION = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).version as string;
 const originalHome = process.env.HOME;
 const originalPath = process.env.PATH;
+const originalNoOmission = process.env.TOKENJUICE_NO_OMISSION;
+
+beforeEach(() => {
+  delete process.env.TOKENJUICE_NO_OMISSION;
+});
 
 afterEach(async () => {
   delete process.env.CODEX_HOME;
   process.env.HOME = originalHome;
   process.env.PATH = originalPath;
+  if (originalNoOmission === undefined) {
+    delete process.env.TOKENJUICE_NO_OMISSION;
+  } else {
+    process.env.TOKENJUICE_NO_OMISSION = originalNoOmission;
+  }
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
@@ -169,6 +179,86 @@ describe("installCodexHook", () => {
     expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(`${launcherPath} codex-post-tool-use`);
   });
 
+  it("does not persist the no-omit environment in the installed hook command", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const result = await installCodexHook(hooksPath);
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.command).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(
+      `${launcherPath} codex-post-tool-use`,
+    );
+  });
+
+  it("persists no-omit only when explicitly requested", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    const result = await installCodexHook(hooksPath, { noOmit: true });
+    const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.command).toBe(`${launcherPath} codex-post-tool-use --no-omit`);
+    expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(
+      `${launcherPath} codex-post-tool-use --no-omit`,
+    );
+  });
+
+  it("removes legacy omission flags when reinstalling without explicit policy", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+
+    for (const legacyFlag of ["--allow-omit", "--no-omit"]) {
+      await writeFile(hooksPath, `${JSON.stringify({
+        hooks: {
+          PostToolUse: [{
+            matcher: "^Bash$",
+            hooks: [{
+              type: "command",
+              command: `${launcherPath} codex-post-tool-use ${legacyFlag}`,
+              statusMessage: "compacting bash output with tokenjuice",
+              timeout: 30,
+            }],
+          }],
+        },
+      }, null, 2)}\n`, "utf8");
+
+      const result = await installCodexHook(hooksPath);
+      const parsed = JSON.parse(await readFile(hooksPath, "utf8")) as {
+        hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      };
+
+      expect(result.command).toBe(`${launcherPath} codex-post-tool-use`);
+      expect(parsed.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe(
+        `${launcherPath} codex-post-tool-use`,
+      );
+    }
+  });
+
   it("can install a local codex hook without preferring PATH", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");
@@ -261,6 +351,75 @@ describe("doctorCodexHook", () => {
     expect(report.featureFlag.enabled).toBe(true);
   });
 
+  it("keeps a neutral hook healthy when the environment enables no omission", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await installCodexHook(hooksPath);
+
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+    const report = await doctorCodexHook(hooksPath);
+
+    expect(report.status).toBe("ok");
+    expect(report.expectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(report.fixCommand).toBe("tokenjuice install codex");
+    expect(report.issues).toEqual([]);
+  });
+
+  it("reports installed omission flags as stale unless explicitly requested", async () => {
+    const home = await createTempDir();
+    const hooksPath = join(home, "hooks.json");
+    const binDir = join(home, "bin");
+    const launcherPath = join(binDir, "tokenjuice");
+    const featureFlagConfigPath = join(home, "config.toml");
+
+    process.env.PATH = binDir;
+    await mkdir(binDir, { recursive: true });
+    await writeFile(launcherPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
+    await writeFile(featureFlagConfigPath, "[features]\ncodex_hooks = true\n", "utf8");
+
+    for (const staleFlag of ["--allow-omit", "--no-omit"]) {
+      await writeFile(hooksPath, `${JSON.stringify({
+        hooks: {
+          PostToolUse: [{
+            matcher: "^Bash$",
+            hooks: [{
+              type: "command",
+              command: `${launcherPath} codex-post-tool-use ${staleFlag}`,
+              statusMessage: "compacting bash output with tokenjuice",
+              timeout: 10,
+            }],
+          }],
+        },
+      }, null, 2)}\n`, "utf8");
+
+      const report = await doctorCodexHook(hooksPath, { featureFlagConfigPath });
+
+      expect(report.status).toBe("warn");
+      expect(report.expectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+      expect(report.detectedCommand).toBe(`${launcherPath} codex-post-tool-use ${staleFlag}`);
+      expect(report.fixCommand).toBe("tokenjuice install codex");
+      expect(report.issues).toContain(
+        "configured Codex hook command does not match the current recommended command",
+      );
+    }
+
+    const explicitReport = await doctorCodexHook(hooksPath, {
+      featureFlagConfigPath,
+      noOmit: true,
+    });
+    expect(explicitReport.status).toBe("ok");
+    expect(explicitReport.expectedCommand).toBe(`${launcherPath} codex-post-tool-use --no-omit`);
+    expect(explicitReport.fixCommand).toBe("tokenjuice install codex --no-omit");
+    expect(explicitReport.issues).toEqual([]);
+  });
+
   it("warns when the stable launcher resolves to an older Homebrew tokenjuice version", async () => {
     const home = await createTempDir();
     const hooksPath = join(home, "hooks.json");
@@ -287,6 +446,20 @@ describe("doctorCodexHook", () => {
       `configured Codex hook launcher resolves to Homebrew tokenjuice 0.0.1, but this tokenjuice is ${PACKAGE_VERSION}`,
     );
     expect(report.issues).not.toContain("configured Codex hook command does not match the current recommended command");
+
+    const policyReport = await doctorCodexHook(hooksPath, {
+      featureFlagConfigPath,
+      noOmit: true,
+    });
+    expect(policyReport.status).toBe("warn");
+    expect(policyReport.expectedCommand).toBe(`${launcherPath} codex-post-tool-use --no-omit`);
+    expect(policyReport.detectedCommand).toBe(`${launcherPath} codex-post-tool-use`);
+    expect(policyReport.fixCommand).toBe(
+      "brew upgrade tokenjuice && tokenjuice install codex --no-omit",
+    );
+    expect(policyReport.issues).toContain(
+      "configured Codex hook command does not match the current recommended command",
+    );
   });
 
   it("treats absent hooks feature flag as enabled for current Codex", async () => {
@@ -626,6 +799,76 @@ describe("runCodexPostToolUseHook", () => {
     expect(response.hookSpecificOutput?.additionalContext).not.toContain("tokenjuice wrap --full -- <command>");
     expect(debug.rewrote).toBe(true);
     expect(debug.matchedReducer).toBe("git/status");
+  });
+
+  it("keeps the original output when the installed hook explicitly enables no-omit", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: {
+        command: "git log --oneline",
+      },
+      tool_response: Array.from(
+        { length: 40 },
+        (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`,
+      ).join("\n"),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(
+      () => runCodexPostToolUseHook(payload, { noOmit: true }),
+    );
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      noOmit?: boolean;
+      rewrote: boolean;
+      skipped?: string;
+    };
+
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(debug.noOmit).toBe(true);
+    expect(debug.rewrote).toBe(false);
+    expect(debug.skipped).toBe("no-compaction");
+  });
+
+  it("compacts output when the explicit test policy overrides the no-omit environment", async () => {
+    const home = await createTempDir();
+    process.env.CODEX_HOME = home;
+    process.env.TOKENJUICE_NO_OMISSION = "1";
+
+    const payload = JSON.stringify({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "git log --oneline" },
+      tool_response: Array.from(
+        { length: 40 },
+        (_, index) => `${(index + 1).toString(16).padStart(7, "a")} feat: commit ${index}`,
+      ).join("\n"),
+    });
+
+    const { code, stdout, stderr } = await captureStdio(
+      () => runCodexPostToolUseHook(payload, { allowOmit: true }),
+    );
+    const debug = JSON.parse(await readFile(join(home, "tokenjuice-hook.last.json"), "utf8")) as {
+      noOmit?: boolean;
+      rewrote: boolean;
+    };
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("lines omitted");
+    expect(debug.noOmit).toBe(false);
+    expect(debug.rewrote).toBe(true);
+  });
+
+  it("rejects conflicting omission policies through the public runtime API", async () => {
+    await expect(runCodexPostToolUseHook("{}", {
+      noOmit: true,
+      allowOmit: true,
+    })).rejects.toThrow("noOmit and allowOmit policies cannot be enabled together");
   });
 
   it("skips rewriting generic fallback output for compound shell diagnostics", async () => {


### PR DESCRIPTION
## Summary

- keep installed Codex hook commands omission-policy neutral by default
- honor `TOKENJUICE_NO_OMISSION` at hook runtime instead of persisting environment state during installation
- preserve explicit `--no-omit` installation and doctor behavior when requested
- keep `--allow-omit` limited to direct hook-runtime testing
- replace stale managed `--allow-omit` and `--no-omit` commands on a default reinstall
- preserve policy-aware remediation when Homebrew and hook configuration are both stale

## Why

Omission policy belongs to the environment launching Codex. Persisting that environment into `hooks.json` creates stale overrides, while ignoring explicit operator flags removes a useful deterministic configuration path.

## Verification

- rebased onto `148b5d3d93201859255a629c924ab6ba0925c72a`
- preserved the landed #219, #220, and #221 behavior; the only conflict was their adjacent Unreleased changelog entries
- range-diff shows no #218 semantic patch changes
- `pnpm exec vitest run test/cli/main.test.ts test/core/integrations/compact-bash-result.test.ts test/hosts/codex.test.ts` - 68 tests passed
- `pnpm verify` - 132 test files and 2,346 tests passed
- built CLI hook probe with a temporary `CODEX_HOME`:
  - default install under `TOKENJUICE_NO_OMISSION=1` generated a hook with no omission flags
  - the installed runtime honored the environment with `noOmit=true` and `rewrote=false`
  - the same runtime compacted normally after the environment was unset
  - explicit `install codex --local --no-omit` and matching doctor completed successfully

This exact head remains intentionally unmerged for independent exact-head review.
