### PR TITLE
fix(windows): quote the `-lc` payload for the shell that parses it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep raw and full command output available when optional telemetry storage is unavailable.
 - Harden ownership detection, restoration, and malformed marker handling for beta host integrations.
 - Build release artifacts from explicit tags and validate Homebrew tap release-tag input.

--- a/src/hosts/shared/hook-command.ts
+++ b/src/hosts/shared/hook-command.ts
@@ -34,6 +34,32 @@ export function shellQuote(value: string, platform = process.platform): string {
     return `"${value}"`;
   }
 
+  return posixShellQuote(value);
+}
+
+/**
+ * Quote a value for a POSIX shell, regardless of the host platform.
+ *
+ * `shellQuote` picks its quoting style from `process.platform`, which is the
+ * right question for a *path* going into a host config file: on win32 it wraps
+ * in double quotes without escaping, and that is safe because a Windows path
+ * cannot contain `"` in the first place.
+ *
+ * It is the wrong question for a *command* that we are about to hand to a
+ * POSIX shell via `-lc`. There the parser is the shell we resolved, not the
+ * platform we happen to be running on, and user commands routinely contain
+ * quotes. Wrapping `git commit -m "fix: thing"` in bare double quotes on
+ * Windows yields `-lc "git commit -m "fix: thing""`, which bash re-splits into
+ * `git commit -m fix: thing` -- a different command, silently.
+ *
+ * Callers building a command line that a POSIX shell will parse must use this
+ * for every argv item, including Windows paths and the `-lc` payload.
+ */
+export function posixShellQuote(value: string): string {
+  if (POSIX_SAFE_SHELL_WORD.test(value)) {
+    return value;
+  }
+
   return `'${value.replace(/'/gu, `'\\''`)}'`;
 }
 
@@ -43,20 +69,45 @@ export function parseShellWords(command: string, platform = process.platform): s
   let quote: "'" | "\"" | null = null;
   let escaping = false;
 
-  for (const char of command) {
+  const chars = [...command];
+  for (let index = 0; index < chars.length; index += 1) {
+    const char = chars[index] as string;
+
+    if (quote === "'") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
     if (escaping) {
       current += char;
       escaping = false;
       continue;
     }
 
-    if (platform !== "win32" && char === "\\") {
-      escaping = true;
+    if (char === "\\") {
+      if (platform === "win32") {
+        current += char;
+      } else if (chars[index + 1] === "\n") {
+        index += 1;
+      } else if (quote === "\"") {
+        const next = chars[index + 1];
+        if (next === "$" || next === "`" || next === "\"" || next === "\\") {
+          escaping = true;
+        } else {
+          current += char;
+        }
+      } else {
+        escaping = true;
+      }
       continue;
     }
 
-    if (quote) {
-      if (char === quote) {
+    if (quote === "\"") {
+      if (char === "\"") {
         quote = null;
       } else {
         current += char;

--- a/src/hosts/shared/pre-tool-wrap.ts
+++ b/src/hosts/shared/pre-tool-wrap.ts
@@ -17,9 +17,15 @@ import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 
-import { stripLeadingCdPrefix, tokenizeCommand } from "../../core/command.js";
+import { stripLeadingCdPrefix } from "../../core/command.js";
 
-import { isNodeExecutablePath, isTokenjuiceExecutablePath, shellQuote } from "./hook-command.js";
+import {
+  isNodeExecutablePath,
+  isTokenjuiceExecutablePath,
+  parseShellWords,
+  posixShellQuote,
+  shellQuote,
+} from "./hook-command.js";
 
 export type WrapLauncherOptions = {
   /** When true, bypass the `PATH` lookup for an installed tokenjuice binary and route through the caller's build. */
@@ -190,10 +196,10 @@ export function buildWrappedCommand(params: {
 }): string {
   const nodePath = params.nodePath ?? process.execPath;
   const launcherCommand = params.wrapLauncher.endsWith(".js")
-    ? `${shellQuote(nodePath)} ${shellQuote(params.wrapLauncher)}`
-    : shellQuote(params.wrapLauncher);
-  const sourceArgs = params.source ? ` --source ${shellQuote(params.source)}` : "";
-  return `${launcherCommand} wrap${sourceArgs} -- ${shellQuote(params.shellPath)} -lc ${shellQuote(params.command)}`;
+    ? `${posixShellQuote(nodePath)} ${posixShellQuote(params.wrapLauncher)}`
+    : posixShellQuote(params.wrapLauncher);
+  const sourceArgs = params.source ? ` --source ${posixShellQuote(params.source)}` : "";
+  return `${launcherCommand} wrap${sourceArgs} -- ${posixShellQuote(params.shellPath)} -lc ${posixShellQuote(params.command)}`;
 }
 
 /**
@@ -209,7 +215,9 @@ export function buildWrappedCommand(params: {
  * (e.g. the user invoked `tokenjuice wrap --raw -- <cmd>` explicitly).
  */
 export function commandAlreadyWrapped(command: string): boolean {
-  const argv = tokenizeCommand(stripLeadingCdPrefix(command));
+  // PreToolUse hosts execute this command through a POSIX shell, including
+  // Bash-compatible shells on Windows.
+  const argv = parseShellWords(stripLeadingCdPrefix(command), "linux");
   if (argv.length < 2) {
     return false;
   }

--- a/test/hosts/shared/hook-command.test.ts
+++ b/test/hosts/shared/hook-command.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { extractHookCommandPaths, parseShellWords, shellQuote } from "../../../src/hosts/shared/hook-command.js";
+import {
+  extractHookCommandPaths,
+  parseShellWords,
+  posixShellQuote,
+  shellQuote,
+} from "../../../src/hosts/shared/hook-command.js";
 
 describe("shellQuote", () => {
   it("leaves unspaced Windows paths unquoted", () => {
@@ -17,6 +22,18 @@ describe("shellQuote", () => {
 });
 
 describe("parseShellWords", () => {
+  it("preserves backslashes inside POSIX single quotes", () => {
+    const path = String.raw`C:\Users\me\bin\tokenjuice.cmd`;
+
+    expect(parseShellWords(`${posixShellQuote(path)} wrap`, "linux")).toEqual([path, "wrap"]);
+  });
+
+  it("preserves ordinary backslashes inside POSIX double quotes", () => {
+    const path = String.raw`C:\Program Files\tokenjuice.cmd`;
+
+    expect(parseShellWords(`"${path}" wrap`, "linux")).toEqual([path, "wrap"]);
+  });
+
   it("preserves backslashes in unquoted Windows launcher commands", () => {
     expect(parseShellWords(String.raw`C:\Users\andre\bin\tokenjuice.exe codex-post-tool-use`, "win32")).toEqual([
       String.raw`C:\Users\andre\bin\tokenjuice.exe`,

--- a/test/hosts/shared/pre-tool-wrap.test.ts
+++ b/test/hosts/shared/pre-tool-wrap.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildWrapLauncherHookCommand,
@@ -15,6 +15,7 @@ import {
   resolveInstalledTokenjuicePath,
   resolveShellPath,
 } from "../../../src/hosts/shared/pre-tool-wrap.js";
+import { parseWrappedCommand } from "./wrap-command.js";
 
 const tempDirs: string[] = [];
 const originalPath = process.env.PATH;
@@ -250,6 +251,81 @@ describe("buildWrappedCommand", () => {
     expect(wrapped).toBe("/usr/local/bin/tokenjuice wrap --source cursor -- /bin/bash -lc 'git status --short'");
   });
 
+  // Regression: buildWrappedCommand used to quote the `-lc` payload with
+  // shellQuote(), which picks its style from process.platform. On win32 that
+  // wraps the command in bare double quotes with no escaping, so any command
+  // containing a quote of its own was re-split by bash into a DIFFERENT
+  // command -- silently, whenever the mangled form still parsed.
+  //
+  // The payload is parsed by the shell at shellPath, so its quoting must not
+  // depend on the host platform at all. These cases run identically on both.
+  describe.each(["linux", "win32"] as const)("payload quoting on %s", (platform) => {
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: platform });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    });
+
+    it.each([
+      ["git commit -m \"fix: thing\""],
+      ["echo \"a b\""],
+      ["grep -rn \"TODO\" src | head -3"],
+      ["echo it's raining"],
+      ["printf \"[%s]\n\" -m \"fix: thing\""],
+      [String.raw`printf '%s\n' '\"'`],
+      [String.raw`printf "%s\n" "a\\\"b"`],
+      ["git log --format=\"%H %s\" -5"],
+      ["git status --short"],
+    ])("round-trips %j through the shell payload", (command) => {
+      const parsed = parseWrappedCommand(
+        buildWrappedCommand({
+          wrapLauncher: "/usr/local/bin/tokenjuice",
+          shellPath: "/bin/bash",
+          command,
+        }),
+      );
+
+      expect(parsed.shellFlag).toBe("-lc");
+      // What actually runs must be byte-identical to what the user asked for.
+      expect(parsed.inner).toBe(command);
+      expect(parsed.wrapDepth).toBe(1);
+    });
+
+    it("keeps a quoted argument as one word instead of re-splitting it", () => {
+      const parsed = parseWrappedCommand(
+        buildWrappedCommand({
+          wrapLauncher: "/usr/local/bin/tokenjuice",
+          shellPath: "/bin/bash",
+          command: 'git commit -m "fix: thing"',
+        }),
+      );
+
+      // Pre-fix on win32 this was ["git","commit","-m","fix:","thing"] --
+      // a truncated message plus a stray pathspec.
+      expect(parsed.innerArgv).toEqual(["git", "commit", "-m", "fix: thing"]);
+    });
+
+    it("preserves Windows launcher and shell paths for Bash", () => {
+      const wrapLauncher = String.raw`C:\Users\me\bin\tokenjuice.cmd`;
+      const shellPath = String.raw`C:\Program Files\Git\bin\bash.exe`;
+      const parsed = parseWrappedCommand(
+        buildWrappedCommand({
+          wrapLauncher,
+          shellPath,
+          command: "git status --short",
+        }),
+      );
+
+      expect(parsed.launcher).toEqual([wrapLauncher]);
+      expect(parsed.shellPath).toBe(shellPath);
+      expect(parsed.inner).toBe("git status --short");
+    });
+  });
+
   it("escapes commands containing single quotes through POSIX shellQuote", () => {
     const wrapped = buildWrappedCommand({
       wrapLauncher: "/usr/local/bin/tokenjuice",
@@ -279,5 +355,23 @@ describe("commandAlreadyWrapped", () => {
     ["tokenjuice", false, "launcher without subcommand"],
   ])("returns %s for %j (%s)", (input, expected) => {
     expect(commandAlreadyWrapped(input)).toBe(expected);
+  });
+
+  it("recognizes a generated wrapper with Windows paths", () => {
+    const wrapped = buildWrappedCommand({
+      wrapLauncher: String.raw`C:\Users\me\bin\tokenjuice.cmd`,
+      shellPath: String.raw`C:\Program Files\Git\bin\bash.exe`,
+      command: "git status --short",
+    });
+
+    expect(commandAlreadyWrapped(wrapped)).toBe(true);
+  });
+
+  it("recognizes a manually double-quoted Windows launcher path", () => {
+    expect(
+      commandAlreadyWrapped(
+        String.raw`"C:\Program Files\tokenjuice.cmd" wrap -- "C:\Program Files\Git\bin\bash.exe" -lc 'git status'`,
+      ),
+    ).toBe(true);
   });
 });

--- a/test/hosts/shared/wrap-command.ts
+++ b/test/hosts/shared/wrap-command.ts
@@ -63,7 +63,7 @@ function countWrapInvocations(argv: string[]): number {
  * rather than at a downstream structural assertion.
  */
 export function parseWrappedCommand(raw: string): WrappedCommand {
-  const argv = parseShellWords(raw);
+  const argv = parseShellWords(raw, "linux");
   if (argv.length === 0) {
     throw new Error(`parseWrappedCommand: empty argv from ${JSON.stringify(raw)}`);
   }
@@ -109,7 +109,7 @@ export function parseWrappedCommand(raw: string): WrappedCommand {
   }
 
   const inner = innerTokens[0] ?? "";
-  const innerArgv = parseShellWords(inner);
+  const innerArgv = parseShellWords(inner, "linux");
 
   // A correctly wrapped command has wrapDepth === 1: the outer invocation
   // counts, and nothing inside the shell payload should recursively re-wrap.


### PR DESCRIPTION
## The bug

On Windows, shared PreToolUse wrappers quoted commands according to `process.platform` even though the resulting command line is parsed by a POSIX shell through `-lc`. Quote-bearing commands could be silently changed, and unspaced Windows paths such as `C:\Users\me\bin\tokenjuice.cmd` could lose their backslashes.

## Remediated fix

- Add `posixShellQuote()` for command lines parsed by POSIX shells.
- Quote the launcher, optional Node entrypoint, source, shell path, and `-lc` payload with POSIX rules.
- Preserve backslashes inside POSIX single quotes and preserve ordinary backslashes inside POSIX double quotes.
- Parse shared PreToolUse wrapper detection with POSIX semantics so Windows paths do not trigger recursive wrapping.
- Leave VS Code Copilot's separate PowerShell branch unchanged; this PR does not claim to solve PowerShell command quoting.
- Add an Unreleased changelog entry.

## Verification

Exact head: `d9db9228171b82149b45c0f4b4ce34a371118ecf`

- Focused host/platform suite: 8 files, 210 tests passed.
- `pnpm verify`: 132 files, 2,321 tests passed.
- `pnpm build`: passed.
- Real Bash argv probe: exact Windows-style shell path and quote/backslash-heavy payload preserved.
- Independent repository autoreview: clean after remediation.
- Commit signature: valid.

The tests exercise both `linux` and `win32` platform stubs, Windows launcher/shell paths, single and double quotes, literal backslashes, and already-wrapped detection. A broad Windows CI job was not added because the repository still has unrelated Windows-only suite failures.

## Authorship

Original report, Windows 11 reproduction, and fix direction by @mrsonord2240. Maintainer remediation preserves the contributor as commit author.
