### PR TITLE
fix(core): collapse repeated emoji banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Keep raw and full command output available when optional telemetry storage is unavailable.
+- Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output.
 - Harden ownership detection, restoration, and malformed marker handling for beta host integrations.
 - Build release artifacts from explicit tags and validate Homebrew tap release-tag input.
 - Make `pnpm build` portable across supported Node platforms.

--- a/src/core/compaction-metadata.ts
+++ b/src/core/compaction-metadata.ts
@@ -6,6 +6,7 @@ export type CompactionKind =
   | "git-diff-hunk-clip"
   | "inspection-package-lock-summary"
   | "inspection-large-document-summary"
+  | "repeated-emoji-banner-omission"
   | "github-actions-command-list-omission"
   | "github-actions-log-signal-filter"
   | "github-status-check-rollup-omission"

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -3,7 +3,7 @@ import { hasMultipleSubstantiveShellCommands } from "./command-match.js";
 import { classifyExecution, resolveRuleMatch } from "./classify.js";
 import { isFileContentInspectionCommand, isVerbatimConfigInspectionCommand } from "./command-identity.js";
 import { normalizeExecutionInput } from "./execution-input.js";
-import { clampTextMiddleWithMetadata, clampTextWithMetadata, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
+import { clampTextMiddleWithMetadata, clampTextWithMetadata, collapseRepeatedEmojiBanner, countTextChars, dedupeAdjacent, headTail, normalizeLines, pluralize, stripAnsi, trimEmptyEdges } from "./text.js";
 import { storeArtifact, tryStoreArtifactMetadata } from "./artifacts.js";
 import { NO_COMPACTION_METADATA, mergeCompactionMetadata, type CompactionMetadata } from "./compaction-metadata.js";
 import { buildGithubActionsFailureSummary } from "./github-actions-summary.js";
@@ -68,6 +68,13 @@ function applyRule(
     lines = normalizeLines(stripAnsi(lines.join("\n")));
   }
 
+  let rewriteCompaction: CompactionMetadata | undefined;
+  if (!noOmit && rule.id === "generic/fallback") {
+    const collapsed = collapseRepeatedEmojiBanner(lines);
+    lines = collapsed.lines;
+    rewriteCompaction = mergeCompactionMetadata(rewriteCompaction, collapsed.compaction);
+  }
+
   const outputMatchText = trimEmptyEdges(lines).join("\n");
   const matchedOutput = compiledRule.compiled.outputMatches.find((entry) => entry.pattern.test(outputMatchText));
   if (!noOmit && matchedOutput) {
@@ -106,7 +113,6 @@ function applyRule(
     lines = rewriteGitStatusLines(lines);
   }
   const preRewriteLines = [...lines];
-  let rewriteCompaction: CompactionMetadata | undefined;
   if (rule.id === "cloud/gh") {
     counterLines = rewriteGhLines(counterLines, input, noOmit).lines;
     const rewritten = rewriteGhLines(lines, input, noOmit);

--- a/src/core/text.ts
+++ b/src/core/text.ts
@@ -9,6 +9,9 @@ const TRUNCATION_SUFFIX = "\n... truncated ...";
 const MIDDLE_TRUNCATION_MARKER = "\n... omitted ...\n";
 const COMBINING_MARK_PATTERN = /\p{Mark}/u;
 const EMOJI_PATTERN = /\p{Extended_Pictographic}/u;
+const FLAG_EMOJI_PATTERN = /^\p{Regional_Indicator}{2}$/u;
+const KEYCAP_EMOJI_PATTERN = /^[#*0-9]\uFE0F?\u20E3$/u;
+const REPEATED_EMOJI_BANNER_MIN_REPETITIONS = 24;
 const graphemeSegmenter = typeof Intl !== "undefined" && "Segmenter" in Intl
   ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
   : null;
@@ -137,6 +140,42 @@ export function dedupeAdjacent(lines: string[]): string[] {
     }
   }
   return next;
+}
+
+function formatCodePoints(text: string): string {
+  return Array.from(text, (character) => `U+${character.codePointAt(0)?.toString(16).toUpperCase().padStart(4, "0")}`).join("+");
+}
+
+function isEmojiGrapheme(text: string): boolean {
+  return EMOJI_PATTERN.test(text)
+    || FLAG_EMOJI_PATTERN.test(text)
+    || KEYCAP_EMOJI_PATTERN.test(text);
+}
+
+export function collapseRepeatedEmojiBanner(lines: string[]): { lines: string[]; compaction?: CompactionMetadata } {
+  let collapsed = false;
+  const nextLines = lines.map((line) => {
+    const visibleSegments = graphemes(line).filter((segment) => !/^\s+$/u.test(segment));
+    const repeatedEmoji = visibleSegments[0];
+    if (
+      visibleSegments.length < REPEATED_EMOJI_BANNER_MIN_REPETITIONS
+      || !repeatedEmoji
+      || !isEmojiGrapheme(repeatedEmoji)
+      || visibleSegments.some((segment) => segment !== repeatedEmoji)
+    ) {
+      return line;
+    }
+
+    collapsed = true;
+    return `[repeated emoji banner omitted: ${formatCodePoints(repeatedEmoji)} x${visibleSegments.length}]`;
+  });
+
+  return collapsed
+    ? {
+        lines: nextLines,
+        compaction: createCompactionMetadata("repeated-emoji-banner-omission"),
+      }
+    : { lines: nextLines };
 }
 
 export function headTail(lines: string[], head: number, tail: number, noOmit = false): { lines: string[]; compaction?: CompactionMetadata } {

--- a/test/core/integrations/compact-bash-result.test.ts
+++ b/test/core/integrations/compact-bash-result.test.ts
@@ -265,6 +265,29 @@ describe("compactBashResult", () => {
     expect(kept.result?.classification.matchedReducer).toBe("generic/fallback");
   });
 
+  it("removes repeated emoji banners from Crabbox-like generic output", async () => {
+    const outcome = await compactBashResult({
+      source: "codex",
+      command: "crabbox run inspect-model",
+      visibleText: [
+        "generated modeling_modernbert.py",
+        "🚨".repeat(1_935),
+        "inspection complete",
+      ].join("\n"),
+      maxInlineChars: 1_200,
+      minSavedCharsAny: 8,
+      genericFallbackMinSavedChars: 120,
+      genericFallbackMaxRatio: 0.75,
+      skipGenericFallbackForCompoundCommands: true,
+    });
+
+    const rewritten = expectRewrite(outcome);
+    expect(rewritten.result.classification.matchedReducer).toBe("generic/fallback");
+    expect(rewritten.result.inlineText).toContain("[repeated emoji banner omitted: U+1F6A8 x1935]");
+    expect(rewritten.result.inlineText).not.toContain("🚨");
+    expect(rewritten.result.compaction?.kinds).toContain("repeated-emoji-banner-omission");
+  });
+
   it("compacts generic/fallback output when the command is only a cd-prefixed chain", async () => {
     // Regression: a leading `cd <dir> && <cmd>` is classified as compound by
     // `isCompoundShellCommand`, which trips `skipGenericFallbackForCompoundCommands`

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -300,6 +300,86 @@ describe("reduceExecution", () => {
     expect(result.inlineText).toContain("lines omitted");
   });
 
+  it("collapses repeated emoji banners in generic fallback output", async () => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-tool check",
+      combinedText: [
+        "generated source follows",
+        Array.from({ length: 1_935 }, () => "🚨").join(" "),
+        "done",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toContain("[repeated emoji banner omitted: U+1F6A8 x1935]");
+    expect(result.inlineText).not.toContain("🚨");
+    expect(result.compaction).toEqual({
+      authoritative: true,
+      kinds: ["repeated-emoji-banner-omission"],
+    });
+  });
+
+  it.each([
+    {
+      label: "flag",
+      emoji: "🇫🇷",
+      codePoints: "U+1F1EB+U+1F1F7",
+    },
+    {
+      label: "keycap",
+      emoji: "1️⃣",
+      codePoints: "U+0031+U+FE0F+U+20E3",
+    },
+  ])("collapses repeated $label emoji graphemes", async ({ emoji, codePoints }) => {
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-tool check",
+      combinedText: Array.from({ length: 48 }, () => emoji).join(" "),
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toBe(`[repeated emoji banner omitted: ${codePoints} x48]`);
+    expect(result.compaction?.kinds).toContain("repeated-emoji-banner-omission");
+  });
+
+  it("preserves normal emoji, CJK, and mixed-content lines", async () => {
+    const rawText = [
+      "状态正常 🚨",
+      "🚨".repeat(23),
+      `${"🚨".repeat(24)} warning`,
+      Array.from({ length: 24 }, () => "🇫").join(" "),
+      "1".repeat(24),
+      Array.from({ length: 24 }, (_, index) => index % 2 === 0 ? "🇫🇷" : "🇺🇸").join(" "),
+    ].join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-tool check",
+      combinedText: rawText,
+      exitCode: 0,
+    });
+
+    expect(result.inlineText).toBe(rawText);
+    expect(result.compaction?.authoritative).toBe(false);
+  });
+
+  it("preserves repeated emoji banners when noOmit is enabled", async () => {
+    const rawText = "🚨".repeat(48);
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-tool check",
+      combinedText: rawText,
+      exitCode: 0,
+    }, {
+      noOmit: true,
+      maxInlineChars: 20_000,
+    });
+
+    expect(result.inlineText).toBe(rawText);
+    expect(result.compaction?.kinds).not.toContain("repeated-emoji-banner-omission");
+  });
+
   it("minifies whole JSON object output before generic fallback", async () => {
     const rawText = prettyJson({
       runtimeVersion: "2026.5.7",


### PR DESCRIPTION
## Summary

- collapse decorative repeated-emoji banners retained by generic fallback summaries
- preserve meaningful mixed content while replacing a single repeated emoji grapheme with compact ASCII metadata
- keep `noOmit` and raw artifact behavior unchanged

## Cause

Generic fallback retained very large decorative emoji-only lines from generated tool output. Those lines could then appear in compacted Codex session summaries even though they carried no useful diagnostic content.

## Verification

- `pnpm verify`
- 132 test files passed
- 2,301 tests passed
- independent exact-head review completed with no remaining findings
