### PR TITLE
fix(core): neutralize success severity counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep raw and full command output available when optional telemetry storage is unavailable.
 - Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output.
+- Render successful generic error and warning counters as neutral mentions.
 - Harden ownership detection, restoration, and malformed marker handling for beta host integrations.
 - Build release artifacts from explicit tags and validate Homebrew tap release-tag input.
 - Make `pnpm build` portable across supported Node platforms.

--- a/src/core/reduce.ts
+++ b/src/core/reduce.ts
@@ -16,6 +16,7 @@ import type { CompactResult, CompiledRule, ReduceOptions, ToolExecutionInput } f
 const TINY_OUTPUT_MAX_CHARS = 240;
 const SMALL_OUTPUT_PASSTHROUGH_MIN_SAVED_CHARS = 120;
 const SMALL_OUTPUT_PASSTHROUGH_MAX_RATIO = 0.75;
+const FAILURE_SEVERITY_FACTS = new Set(["error", "warning"]);
 
 function buildRawText(input: ToolExecutionInput): string {
   if (input.combinedText) {
@@ -226,15 +227,20 @@ function isTerseDiscoveryCommand(classification: { family: string }, input: Tool
 }
 
 function formatInline(
-  classification: { family: string },
+  classification: { family: string; matchedReducer?: string },
   input: ToolExecutionInput,
   summary: string,
   facts: Record<string, number>,
   noOmit = false,
 ): string {
+  const neutralizeSeverityFacts = classification.matchedReducer === "generic/fallback"
+    && input.exitCode === 0;
   const factParts = Object.entries(facts)
     .filter(([, count]) => count > 0)
-    .map(([name, count]) => pluralize(count, name));
+    .map(([name, count]) => pluralize(
+      count,
+      neutralizeSeverityFacts && FAILURE_SEVERITY_FACTS.has(name) ? `${name} mention` : name,
+    ));
 
   const lines: string[] = [];
   if (input.exitCode && input.exitCode !== 0) {
@@ -594,7 +600,13 @@ export async function reduceExecutionWithRules(
   }
 
   const { summary, facts, compaction } = applyRule(matchedRule, reducerInput, rawText, opts.noOmit);
-  const compactText = formatInline(classification, reducerInput, summary || "(no output)", facts, opts.noOmit);
+  const compactText = formatInline(
+    classification,
+    reducerInput,
+    summary || "(no output)",
+    facts,
+    opts.noOmit,
+  );
   const selectedText = selectInlineText(classification, reducerInput, rawText, compactText, maxInlineChars, compaction, opts.noOmit);
   const clamp = classification.family === "help" || selectedText.text.includes("\n") ? clampTextMiddleWithMetadata : clampTextWithMetadata;
   const inlineText = clamp(selectedText.text, maxInlineChars, opts.noOmit);

--- a/test/core/reduce.test.ts
+++ b/test/core/reduce.test.ts
@@ -906,6 +906,137 @@ describe("reduceExecution", () => {
     });
   });
 
+  it("keeps match facts for successful direct rg searches", async () => {
+    const rawText = Array.from(
+      { length: 30 },
+      (_, index) => `src/file-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    ).join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n error src",
+      combinedText: rawText,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("search/rg");
+    expect(result.facts?.match).toBe(30);
+    expect(result.inlineText).toContain("30 matches");
+  });
+
+  it("labels successful framed search matches as neutral error mentions", async () => {
+    const rawText = Array.from(
+      { length: 30 },
+      (_, index) => `src/file-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    ).join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "bash -lc 'printf \"matches:\\n\"; rg -n error src'",
+      combinedText: rawText,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.facts?.error).toBe(30);
+    expect(result.inlineText).toMatch(/^30 error mentions$/mu);
+    expect(result.inlineText).toContain("lines omitted");
+  });
+
+  it("labels successful compound search facts as neutral mentions", async () => {
+    const errorMatches = Array.from(
+      { length: 24 },
+      (_, index) => `src/error-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    );
+    const warningMatches = Array.from(
+      { length: 8 },
+      (_, index) => `src/warning-${index + 1}.ts:${index + 1}:console.warn("warning")`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n error src; rg -n warning src",
+      combinedText: [...errorMatches, ...warningMatches].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.facts).toMatchObject({
+      error: 24,
+      warning: 8,
+    });
+    expect(result.inlineText).toMatch(/^24 error mentions, 8 warning mentions$/mu);
+    expect(result.inlineText).toContain("lines omitted");
+  });
+
+  it("keeps generic error and warning facts when a compound search fails", async () => {
+    const errorMatches = Array.from(
+      { length: 24 },
+      (_, index) => `src/error-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    );
+    const warningMatches = Array.from(
+      { length: 10 },
+      (_, index) => `src/warning-${index + 1}.ts:${index + 1}:console.warn("warning")`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n error src; rg -n warning src",
+      combinedText: [...errorMatches, ...warningMatches].join("\n"),
+      exitCode: 1,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toMatch(/^exit 1\n24 errors, 10 warnings$/mu);
+  });
+
+  it("labels successful non-search warning facts as neutral mentions", async () => {
+    const rawText = Array.from(
+      { length: 30 },
+      (_, index) => `plugin-${index + 1}: warning: deprecated option`,
+    ).join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "custom-linter inspect plugins",
+      combinedText: rawText,
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toMatch(/^30 warning mentions$/mu);
+  });
+
+  it("keeps mixed-chain severity facts as neutral mentions on success", async () => {
+    const errorMatches = Array.from(
+      { length: 24 },
+      (_, index) => `src/error-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    );
+    const warningLines = Array.from(
+      { length: 8 },
+      (_, index) => `plugin-${index + 1}: warning: deprecated option`,
+    );
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n error src; custom-linter inspect plugins",
+      combinedText: [...errorMatches, ...warningLines].join("\n"),
+      exitCode: 0,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toMatch(/^24 error mentions, 8 warning mentions$/mu);
+  });
+
+  it("keeps search severity facts when the exit status is unknown", async () => {
+    const rawText = Array.from(
+      { length: 30 },
+      (_, index) => `src/file-${index + 1}.ts:${index + 1}:throw new Error("boom")`,
+    ).join("\n");
+    const result = await reduceExecution({
+      toolName: "exec",
+      command: "rg -n error src; rg -n error test",
+      combinedText: rawText,
+    });
+
+    expect(result.classification.matchedReducer).toBe("generic/fallback");
+    expect(result.inlineText).toMatch(/^30 errors$/mu);
+  });
+
   it("does not summarize file inspection output from a multi-command sequence", async () => {
     const rawText = [
       "{",


### PR DESCRIPTION
## Summary

- keep generic fallback fact counters visible for successful commands
- render `error` and `warning` counters as neutral `error mention(s)` and `warning mention(s)` when `exitCode === 0`
- preserve existing `errors` and `warnings` wording when exit status is unknown or nonzero

## Fleet evidence

A recent multi-session fleet-log review found 189 exit-zero outputs where matched source text containing `error` was presented as a failure-severity counter. These were successful searches or framed command sequences, not command failures.

This change fixes the presentation without relying on command-provenance heuristics and without changing stored fact counts.

## Rebase evidence

- rebased exact head `e2a675b2725aad8b083a66e00ce40ecb6d432ff4` onto `acbcc0f3a66186586fe03c0c8b431305bb4e9f4e`
- rebase was conflict-free
- verified the repeated-emoji banner fix from #220 and POSIX shell payload quoting from #219 remain present
- prior independent review was clean for the feature patch; final exact-head review is requested for this rebased head

## Validation

- targeted reducer suite: 152 tests passed
- full `pnpm verify`: 132 test files and 2,334 tests passed
- lint, circular-dependency check, and typecheck passed
