### PR TITLE
fix(stats): rank sources by observed cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Let Codex hooks fail open without adding context when tool responses or hook input exceed safety limits.
 - Pin Codex JavaScript launchers to a verified Node runtime and report duplicate, missing, non-executable, runtime-skewed, and package-skewed hook commands.
 - Clarify CodeBuddy hook activation after external settings changes and keep doctor claims limited to persisted configuration.
+- Rank per-source stats by observed cost and clarify missing source metadata.
 - Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
 - Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
 - Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,12 +8,14 @@ import packageJson from "../../package.json" with { type: "json" };
 
 import { getArtifact, listArtifactMetadata, listArtifacts } from "../core/artifacts.js";
 import { buildAnalysisEntry, discoverCandidates, doctorArtifacts, statsArtifacts } from "../core/analysis.js";
+import type { StatsSourceReport } from "../core/analysis.js";
 import { verifyBuiltinFixtures } from "../core/fixtures.js";
 import { readNoOmissionFromEnv } from "../core/env.js";
 import { parseReduceJsonRequest } from "../core/json-protocol.js";
 import { WRAP_AUTHORITATIVE_FOOTER } from "../core/compaction-metadata.js";
 import { reduceExecution } from "../core/reduce.js";
 import { verifyRules } from "../core/rules.js";
+import { UNKNOWN_ARTIFACT_SOURCE } from "../core/source.js";
 import { runWrappedCommand } from "../core/wrap.js";
 import type { WrapResult } from "../types.js";
 import { doctorAdalInstructions, installAdalInstructions, uninstallAdalInstructions } from "../hosts/adal/index.js";
@@ -4273,6 +4275,43 @@ function formatMetric(value: number): string {
     .replace(/([KMBT])$/u, (suffix) => suffix.toLowerCase());
 }
 
+export function formatStatsSources(sources: StatsSourceReport[]): string {
+  if (sources.length === 0) {
+    return "";
+  }
+
+  const orderedSources = [...sources].sort((left, right) =>
+    right.totals.observedRawChars - left.totals.observedRawChars
+    || left.source.localeCompare(right.source)
+  );
+  const lines = ["sources:"];
+
+  for (const source of orderedSources) {
+    const observedRaw = source.totals.captureTruncatedEntries > 0
+      ? ` observedRaw=${formatMetric(source.totals.observedRawChars)}`
+      : "";
+    lines.push(
+      `source ${source.source}: entries=${formatMetric(source.totals.entries)} raw=${formatMetric(source.totals.rawChars)}${observedRaw} reduced=${formatMetric(source.totals.reducedChars)} saved=${formatMetric(source.totals.savedChars)} avgRatio=${formatRatio(source.totals.avgRatio)}`,
+    );
+    if (source.reducers.length > 0) {
+      lines.push(
+        `  reducers: ${source.reducers.slice(0, 3).map((reducer) => `${reducer.reducer}(${formatMetric(reducer.count)})`).join(", ")}`,
+      );
+    }
+    if (source.commands.length > 0) {
+      lines.push(
+        `  commands: ${source.commands.slice(0, 3).map((command) => `${command.signature}(${formatMetric(command.count)})`).join(", ")}`,
+      );
+    }
+  }
+
+  if (orderedSources.some((source) => source.source === UNKNOWN_ARTIFACT_SOURCE)) {
+    lines.push("note: source unknown means stored artifacts have missing or invalid source metadata.");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 async function runDiscover(args: ParsedArgs): Promise<number> {
   const direct = await loadDirectAnalysisEntry(args);
   const entries = direct ? [direct.entry] : await listArtifactMetadata(args.storeDir);
@@ -7357,22 +7396,7 @@ async function runStats(args: ParsedArgs): Promise<number> {
   }
 
   if (report.sources && report.sources.length > 0) {
-    process.stdout.write("sources:\n");
-    for (const source of report.sources) {
-      process.stdout.write(
-        `source ${source.source}: entries=${formatMetric(source.totals.entries)} saved=${formatMetric(source.totals.savedChars)} avgRatio=${formatRatio(source.totals.avgRatio)}\n`,
-      );
-      if (source.reducers.length > 0) {
-        process.stdout.write(
-          `  reducers: ${source.reducers.slice(0, 3).map((reducer) => `${reducer.reducer}(${formatMetric(reducer.count)})`).join(", ")}\n`,
-        );
-      }
-      if (source.commands.length > 0) {
-        process.stdout.write(
-          `  commands: ${source.commands.slice(0, 3).map((command) => `${command.signature}(${formatMetric(command.count)})`).join(", ")}\n`,
-        );
-      }
-    }
+    process.stdout.write(formatStatsSources(report.sources));
   }
 
   return 0;

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -6,7 +6,9 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { WRAP_AUTHORITATIVE_FOOTER } from "../../src/core/compaction-metadata.js";
-import { decorateWrapInlineText, isDirectModuleEntrypoint, parseArgs, resolveNoOmit } from "../../src/cli/main.js";
+import { decorateWrapInlineText, formatStatsSources, isDirectModuleEntrypoint, parseArgs, resolveNoOmit } from "../../src/cli/main.js";
+import { statsArtifacts } from "../../src/core/analysis.js";
+import type { StatsSourceReport } from "../../src/core/analysis.js";
 import type { CompactResult } from "../../src/types.js";
 
 const tempDirs: string[] = [];
@@ -20,6 +22,34 @@ async function createTempDir(): Promise<string> {
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
+
+function statsSource(
+  source: string,
+  observed: { entries: number; rawChars: number; reducedChars: number },
+): StatsSourceReport {
+  const observedSavedChars = Math.max(observed.rawChars - observed.reducedChars, 0);
+  return {
+    source,
+    totals: {
+      observedEntries: observed.entries,
+      captureTruncatedEntries: 0,
+      observedRawChars: observed.rawChars,
+      observedReducedChars: observed.reducedChars,
+      observedSavedChars,
+      observedAvgRatio: observed.rawChars > 0 ? observed.reducedChars / observed.rawChars : null,
+      observedSavingsPercent: observed.rawChars > 0 ? observedSavedChars / observed.rawChars : null,
+      entries: 1,
+      rawChars: 10,
+      reducedChars: 5,
+      savedChars: 5,
+      avgRatio: 0.5,
+      savingsPercent: 0.5,
+    },
+    reducers: [],
+    commands: [],
+    daily: [],
+  };
+}
 
 describe("parseArgs", () => {
   it("parses --no-omit for direct commands and explicit Codex hook policy", () => {
@@ -41,6 +71,125 @@ describe("parseArgs", () => {
   it("rejects conflicting omission policies", () => {
     expect(() => parseArgs(["codex-post-tool-use", "--no-omit", "--allow-omit"]))
       .toThrow("--no-omit and --allow-omit cannot be used together");
+  });
+});
+
+describe("formatStatsSources", () => {
+  it("ranks sources by observed cost with a stable source-name tie break", () => {
+    const sources = [
+      statsSource("unknown", { entries: 1, rawChars: 500, reducedChars: 250 }),
+      statsSource("cursor", { entries: 2, rawChars: 2_000, reducedChars: 600 }),
+      statsSource("codex", { entries: 3, rawChars: 2_000, reducedChars: 500 }),
+    ];
+
+    const output = formatStatsSources(sources);
+
+    expect(output.indexOf("source codex:")).toBeLessThan(output.indexOf("source cursor:"));
+    expect(output.indexOf("source cursor:")).toBeLessThan(output.indexOf("source unknown:"));
+    expect(sources.map((source) => source.source)).toEqual(["unknown", "cursor", "codex"]);
+  });
+
+  it("sorts capture-truncated sources by observed cost while displaying exact totals", () => {
+    const report = statsArtifacts([
+      {
+        metadata: {
+          createdAt: "2026-09-04T00:00:00.000Z",
+          source: "cursor",
+          command: "large-tool",
+          classification: {
+            family: "generic",
+            confidence: 1,
+            matchedReducer: "generic/fallback",
+          },
+          rawChars: 5_000,
+          reducedChars: 100,
+          ratio: 0.02,
+          captureTruncated: true,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-09-04T00:01:00.000Z",
+          source: "cursor",
+          command: "rg TODO",
+          classification: {
+            family: "search",
+            confidence: 1,
+            matchedReducer: "search/rg",
+          },
+          rawChars: 100,
+          reducedChars: 40,
+          ratio: 0.4,
+        },
+      },
+      {
+        metadata: {
+          createdAt: "2026-09-04T00:02:00.000Z",
+          source: "codex",
+          command: "pnpm test",
+          classification: {
+            family: "tests",
+            confidence: 1,
+            matchedReducer: "tests/pnpm-test",
+          },
+          rawChars: 500,
+          reducedChars: 100,
+          ratio: 0.2,
+        },
+      },
+    ], { bySource: true });
+    const sources = report.sources ?? [];
+
+    expect(sources.map((source) => source.source)).toEqual(["codex", "cursor"]);
+    expect(sources.find((source) => source.source === "cursor")?.totals).toMatchObject({
+      observedRawChars: 5_100,
+      rawChars: 100,
+    });
+    expect(sources.find((source) => source.source === "codex")?.totals).toMatchObject({
+      observedRawChars: 500,
+      rawChars: 500,
+    });
+
+    const output = formatStatsSources(sources);
+    expect(output.indexOf("source cursor:")).toBeLessThan(output.indexOf("source codex:"));
+    expect(output).toContain("source cursor: entries=1 raw=100 observedRaw=5.1k reduced=40 saved=60 avgRatio=40%");
+    expect(output).toContain("source codex: entries=1 raw=500 reduced=100 saved=400 avgRatio=20%");
+    expect(output).not.toContain("source codex: entries=1 raw=500 observedRaw=");
+
+    const sourceTotals = sources.reduce(
+      (totals, source) => ({
+        entries: totals.entries + source.totals.entries,
+        rawChars: totals.rawChars + source.totals.rawChars,
+        reducedChars: totals.reducedChars + source.totals.reducedChars,
+        savedChars: totals.savedChars + source.totals.savedChars,
+      }),
+      { entries: 0, rawChars: 0, reducedChars: 0, savedChars: 0 },
+    );
+    expect(sourceTotals).toEqual({
+      entries: report.totals.entries,
+      rawChars: report.totals.rawChars,
+      reducedChars: report.totals.reducedChars,
+      savedChars: report.totals.savedChars,
+    });
+  });
+
+  it("does not substitute observed values into exact display metrics", () => {
+    const output = formatStatsSources([
+      statsSource("codex", { entries: 4, rawChars: 2_500, reducedChars: 1_000 }),
+    ]);
+
+    expect(output).toContain("source codex: entries=1 raw=10 reduced=5 saved=5 avgRatio=50%");
+    expect(output).not.toContain("raw=2.5k");
+    expect(output).not.toContain("observedRaw=");
+  });
+
+  it("describes unknown source metadata without guessing its origin", () => {
+    const output = formatStatsSources([
+      statsSource("unknown", { entries: 1, rawChars: 100, reducedChars: 50 }),
+    ]);
+
+    expect(output).toContain("source unknown means stored artifacts have missing or invalid source metadata.");
+    expect(output).not.toContain("older");
   });
 });
 


### PR DESCRIPTION
## Summary

- rank `stats --by-source` rows by observed raw character cost from the fleet audit
- show `observedRaw` when capture truncation makes the ordering differ from exact totals
- preserve exact raw, reduced, and saved metrics in source rows
- describe unknown sources neutrally as missing or invalid source metadata
- leave JSON output and `--source` filtering unchanged

## Motivation

The fleet audit found that capture-truncated observations could dominate actual source cost while remaining invisible in the previous per-source ordering. This made the text report rank lower-cost sources first and obscured why.

## Verification

- rebased onto `47fcece5d7f1b3b46ac06874cea8b80447571969`
- `pnpm exec vitest run test/cli/main.test.ts test/core/analysis.test.ts` - 25 tests passed
- `pnpm verify` - 135 test files, 2,373 tests passed
- pre-rebase independent review clean; rebased exact-head review pending
