### PR TITLE
chore(release): v0.8.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,15 @@ jobs:
           fetch-depth: 0
           ref: refs/tags/${{ steps.release.outputs.tag }}
 
+      - name: Verify release version
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).version)')"
+          if [ "${RELEASE_VERSION}" != "${PACKAGE_VERSION}" ]; then
+            echo "Release version ${RELEASE_VERSION} does not match package.json version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
       - name: Verify checked out release tag
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,29 @@
 
 ## Unreleased
 
+## 0.8.2 - 2026-09-04
+
 ### Fixes
 
-- Let Codex hooks fail open without adding context when tool responses or hook input exceed safety limits.
-- Pin Codex JavaScript launchers to a verified Node runtime and report duplicate, missing, non-executable, runtime-skewed, and package-skewed hook commands.
-- Clarify CodeBuddy hook activation after external settings changes and keep doctor claims limited to persisted configuration.
-- Rank per-source stats by observed cost and clarify missing source metadata.
-- Preserve quoted commands and Windows paths when wrapping POSIX shell payloads.
-- Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy.
-- Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites.
-- Keep raw and full command output available when optional telemetry storage is unavailable.
-- Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output.
-- Render successful generic error and warning counters as neutral mentions.
+- Let Codex hooks fail open without adding context when tool responses or hook input exceed safety limits. (#211)
+- Pin Codex JavaScript launchers to a verified Node runtime and report duplicate, missing, non-executable, runtime-skewed, and package-skewed hook commands. (#213)
+- Clarify CodeBuddy hook activation after external settings changes and keep doctor claims limited to persisted configuration. (#208)
+- Rank per-source stats by observed cost and clarify missing source metadata. (#223)
+- Preserve quoted commands and Windows paths when wrapping POSIX shell payloads. (#219)
+- Keep installed Codex hooks omission-policy neutral while honoring runtime environment policy. (#218)
+- Keep Codex compaction feedback inert and omit recovery references for non-authoritative rewrites. (#214)
+- Keep raw and full command output available when optional telemetry storage is unavailable. (#216)
+- Collapse oversized repeated-emoji banners in generic fallback summaries while preserving raw and no-omission output. (#220)
+- Render successful generic error and warning counters as neutral mentions. (#221)
+
+### Maintenance
+
+- Isolate the test suite from local environment state. (#217)
+
+## 0.8.1 - 2026-06-18
+
+### Fixes
+
 - Harden ownership detection, restoration, and malformed marker handling for beta host integrations.
 - Build release artifacts from explicit tags and validate Homebrew tap release-tag input.
 - Make `pnpm build` portable across supported Node platforms.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjuice",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Lean output compaction for terminal-heavy agent workflows.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- bump Tokenjuice from 0.8.1 to 0.8.2
- promote the accumulated Unreleased changes into the September 4, 2026 release notes
- fail the release workflow when the requested tag version differs from `package.json`

## Why

This prepares the verified v0.8.2 source commit and prevents publishing artifacts from a mismatched release tag.

## Test plan

- `pnpm release:local`
- `PATH="$HOME/.local/bin:$PATH" pnpm e2e:local`
- `node dist/cli/main.js --version`
- `(cd release && shasum -a 256 -c sha256sums.txt)`
- `ruby -c release/Formula/tokenjuice.rb`
- `actionlint .github/workflows/release.yml`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --codex-bin "$HOME/.local/bin/codex"`

## Release impact

Prepares v0.8.2 only. No tag or package publication is performed by this PR. Generated `dist/` and `release/` outputs are not committed. The blocked Grok Bot integration in #222 is excluded.
