### PR TITLE
fix(release): sync canonical Homebrew tap

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout tap repository
         uses: actions/checkout@v5
         with:
-          repository: vincentkoc/tap
+          repository: vincentkoc/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Update formula

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Releases are tag-driven and should stay aligned with `package.json`.
 3. Commit the version bump and any required workflow fixes to `main`, then push `main`.
 4. Create and push an annotated tag: `git tag -a v0.6.0 -m "v0.6.0"` and `git push origin v0.6.0`.
 5. Watch the `Release` GitHub Actions workflow and confirm the GitHub release is published with the `.tar.gz`, `.deb`, `.rpm`, `sha256sums.txt`, and `tokenjuice.rb` assets.
-6. Confirm the `homebrew-tap.yml` sync workflow succeeds and that `vincentkoc/tap` points at the new tarball and SHA.
+6. Confirm the `homebrew-tap.yml` sync workflow succeeds and that the canonical `vincentkoc/homebrew-tap` repository points at the new tarball and SHA.
 
 If a release tag was pushed against a broken workflow, fix `main`, delete and recreate the tag, then rerun the release from the corrected commit.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npm install -g tokenjuice
 pnpm add -g tokenjuice
 # or
 yarn global add tokenjuice
-# or
+# or (the vincentkoc/tap alias maps to github.com/vincentkoc/homebrew-tap)
 brew tap vincentkoc/tap
 brew install tokenjuice
 ```

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,10 +67,13 @@ brew tap vincentkoc/tap
 brew install tokenjuice
 ```
 
+Homebrew maps the `vincentkoc/tap` alias to the canonical
+`vincentkoc/homebrew-tap` GitHub repository.
+
 the release flow now mirrors `autosecure`:
 
 - GitHub release uploads `sha256sums.txt`
-- the tap sync workflow updates `vincentkoc/tap`
+- the tap sync workflow updates `vincentkoc/homebrew-tap`
 - the tap formula points at the GitHub release tarball
 
 ## apt / dnf / yum


### PR DESCRIPTION
## Summary

- sync release formulas to the canonical `vincentkoc/homebrew-tap` repository
- keep the valid `brew tap vincentkoc/tap` alias and document its GitHub mapping
- align release guidance across `AGENTS.md`, `README.md`, and distribution docs

## Why

Tokenjuice v0.8.2 published successfully, but Homebrew child run
https://github.com/vincentkoc/tokenjuice/actions/runs/33871912377 failed while
pushing the generated formula because the workflow checked out archived,
read-only `vincentkoc/tap`. That repository identifies
`vincentkoc/homebrew-tap` as canonical. The canonical repository is active and
the maintainer token owner has push/admin access.

The v0.8.2 tag and release remain unchanged. After independent review and merge,
only the failed Homebrew sync should be dispatched again for `v0.8.2`.

## Test plan

- `actionlint .github/workflows/homebrew-tap.yml`
- `pnpm verify` (135 files, 2,373 tests)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `brew tap-info vincentkoc/tap --json` confirms the alias remote is `https://github.com/vincentkoc/homebrew-tap`
