### PR TITLE
chore(release): v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
+## 0.8.3 - 2026-09-04
+
 ### Features
 
-- Add a beta Grok Bot project-guidance integration through a Cursor-format `.cursor/rules/tokenjuice.mdc` rule with `alwaysApply: true` metadata.
+- Add a beta Grok Bot project-guidance integration through a Cursor-format `.cursor/rules/tokenjuice.mdc` rule with `alwaysApply: true` metadata. (#222)
 
 ### Fixes
 
-- Generate strict-audit-compatible Homebrew formulas with verified local checksums, support explicit published-tarball recovery, and leave tap publication to the target repository workflow.
+- Sync the canonical Homebrew tap from the published Tokenjuice release. (#225)
+- Generate strict-audit-compatible Homebrew formulas with verified local checksums, support explicit published-tarball recovery, and leave tap publication to the target repository workflow. (#226)
 
 ## 0.8.2 - 2026-09-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenjuice",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Lean output compaction for terminal-heavy agent workflows.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

- bump Tokenjuice from 0.8.2 to 0.8.3
- promote the three post-v0.8.2 changes into the September 4, 2026 release notes
- include Grok Bot beta guidance and the Homebrew publication corrections

## Test plan

- `pnpm release:local`
- `PATH="$HOME/.local/bin:$PATH" pnpm e2e:local`
- `node dist/cli/main.js --version`
- `(cd release && shasum -a 256 -c sha256sums.txt)`
- `ruby -c release/Formula/tokenjuice.rb`
- `actionlint .github/workflows/release.yml`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Release impact

Prepares v0.8.3 only. No tag or package publication is performed by this PR.
Generated `dist/` and `release/` outputs are not committed.
